### PR TITLE
Handle BigInt serialization in stable stringify

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -14,7 +14,8 @@ function _stringify(v: unknown, stack: Set<any>): string {
   const t = typeof v;
 
   if (t === "string") return JSON.stringify(v);
-  if (t === "number" || t === "boolean" || t === "bigint") return JSON.stringify(v);
+  if (t === "number" || t === "boolean") return JSON.stringify(v);
+  if (t === "bigint") return JSON.stringify(`__bigint__:${(v as bigint).toString()}`);
   if (t === "undefined") return '"__undefined__"';
   if (t === "function" || t === "symbol") return JSON.stringify(String(v));
 

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -12,6 +12,16 @@ test("deterministic mapping for object key order", () => {
   assert.equal(a1.hash, a2.hash);
 });
 
+test("deterministic mapping for bigint values", () => {
+  const c = new Cat32({ salt: "s", namespace: "ns" });
+  const source = { id: 1n, nested: { value: 2n } };
+  const a1 = c.assign(source);
+  const a2 = c.assign({ nested: { value: 2n }, id: 1n });
+  assert.equal(a1.index, a2.index);
+  assert.equal(a1.label, a2.label);
+  assert.equal(a1.hash, a2.hash);
+});
+
 test("override by index", () => {
   const c = new Cat32({ overrides: { "hello": 7 } });
   const a = c.assign("hello");


### PR DESCRIPTION
## Summary
- encode bigint values using a __bigint__ prefix during stable serialization
- add a regression test ensuring Cat32 handles objects containing bigint members deterministically

## Testing
- npm test *(fails: TypeScript build missing Node types in src/cli.ts and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ee26bd98288321ab1c81a5173be5b4