### PR TITLE
Fix stable map key serialization

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -35,9 +35,17 @@ function _stringify(v: unknown, stack: Set<any>): string {
   if (v instanceof Map) {
     if (stack.has(v)) throw new TypeError("Cyclic object");
     stack.add(v);
-    const entries = Array.from(v.entries()).map(([k, val]) => [String(k), val] as const);
-    entries.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
-    const body = entries.map(([k, val]) => JSON.stringify(k) + ":" + _stringify(val, stack));
+    const entries = Array.from(v.entries()).map(([k, val], idx) => ({
+      key: _stringify(k, stack),
+      value: val,
+      order: idx,
+    }));
+    entries.sort((a, b) => {
+      if (a.key < b.key) return -1;
+      if (a.key > b.key) return 1;
+      return a.order - b.order;
+    });
+    const body = entries.map(({ key, value }) => JSON.stringify(key) + ":" + _stringify(value, stack));
     stack.delete(v);
     return "{" + body.join(",") + "}";
   }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -47,3 +47,24 @@ test("cyclic object throws", () => {
   const c = new Cat32();
   assert.throws(() => c.assign(a), /Cyclic object/);
 });
+
+test("map object key differs from same-name string key", () => {
+  const c = new Cat32();
+  const objectKey = { foo: 1 };
+  const stringKey = String(objectKey);
+  const inputWithObjectKey = {
+    payload: new Map<unknown, string>([
+      [objectKey, "object"],
+      [stringKey, "string"],
+    ]),
+  };
+  const inputWithStringKey = {
+    payload: new Map<unknown, string>([
+      [stringKey, "object"],
+      [objectKey, "string"],
+    ]),
+  };
+  const a = c.assign(inputWithObjectKey);
+  const b = c.assign(inputWithStringKey);
+  assert.notEqual(a.key, b.key);
+});


### PR DESCRIPTION
## Summary
- serialize Map keys using the same stable stringify logic as values to avoid key collisions
- add a regression test covering Maps that mix object keys with identical string keys

## Testing
- npm test *(fails: TypeScript build is missing Node type definitions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee26bd42308321bc812ce0141e988d