### PR TITLE
Fix bigint canonical keys

### DIFF
--- a/src/categorizer.ts
+++ b/src/categorizer.ts
@@ -85,8 +85,10 @@ export class Cat32 {
       case "string":
         s = input;
         break;
-      case "number":
       case "bigint":
+        s = stableStringify(input);
+        break;
+      case "number":
       case "boolean":
         s = String(input);
         break;

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -98,6 +98,14 @@ test("bigint values serialize deterministically", () => {
   assert.equal(first.hash, second.hash);
 });
 
+test("top-level bigint differs from number", () => {
+  const c = new Cat32();
+  const bigintAssignment = c.assign(1n);
+  const numberAssignment = c.assign(1);
+  assert.ok(bigintAssignment.key !== numberAssignment.key);
+  assert.ok(bigintAssignment.hash !== numberAssignment.hash);
+});
+
 test("cyclic object throws", () => {
   const a: any = { x: 1 };
   a.self = a;


### PR DESCRIPTION
## Summary
- add a regression test to ensure Cat32 assigns different keys and hashes for top-level bigint and number inputs
- update canonicalKey to stringify bigints with stableStringify so their keys remain distinct from numbers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee32930a6083218943d874fd27b6c6