### PR TITLE
Distinguish top-level bigint canonical keys from numbers

### DIFF
--- a/src/categorizer.ts
+++ b/src/categorizer.ts
@@ -86,7 +86,7 @@ export class Cat32 {
         s = input;
         break;
       case "bigint":
-        s = stableStringify(input);
+        s = `__bigint__:${String(input)}`;
         break;
       case "number":
       case "boolean":

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -106,6 +106,16 @@ test("top-level bigint differs from number", () => {
   assert.ok(bigintAssignment.hash !== numberAssignment.hash);
 });
 
+test("top-level bigint canonical key uses bigint prefix", () => {
+  const c = new Cat32();
+  const bigintAssignment = c.assign(1n);
+  const numberAssignment = c.assign(1);
+
+  assert.equal(bigintAssignment.key, "__bigint__:1");
+  assert.ok(bigintAssignment.key !== numberAssignment.key);
+  assert.ok(bigintAssignment.hash !== numberAssignment.hash);
+});
+
 test("cyclic object throws", () => {
   const a: any = { x: 1 };
   a.self = a;


### PR DESCRIPTION
## Summary
- add coverage ensuring top-level bigint assignments differ from numbers and expose the bigint prefix
- update Cat32 canonicalKey to emit __bigint__ prefixed strings for bigint inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee49d29408832199d6398c42642116