### PR TITLE
Validate normalization option

### DIFF
--- a/src/categorizer.ts
+++ b/src/categorizer.ts
@@ -37,7 +37,12 @@ export class Cat32 {
     const baseSalt = opts.salt ?? "";
     const ns = opts.namespace ? `|ns:${opts.namespace}` : "";
     this.salt = `${baseSalt}${ns}`;
-    this.normalize = opts.normalize ?? "nfkc";
+
+    const normalize = opts.normalize ?? "nfkc";
+    if (normalize !== "none" && normalize !== "nfc" && normalize !== "nfkc") {
+      throw new RangeError("normalize must be one of \"none\", \"nfc\", or \"nfkc\"");
+    }
+    this.normalize = normalize;
     this.overrides = new Map();
 
     if (opts.overrides) {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -80,6 +80,13 @@ test("normalization NFKC merges fullwidth", () => {
   assert.equal(x.index, y.index);
 });
 
+test("unsupported normalization option throws", () => {
+  assert.throws(
+    () => new Cat32({ normalize: "nfkd" as any }),
+    (error) => error instanceof RangeError,
+  );
+});
+
 test("bigint values serialize deterministically", () => {
   const c = new Cat32({ salt: "s", namespace: "ns" });
   const input = {


### PR DESCRIPTION
## Summary
- add a regression test covering unsupported normalization settings
- validate Cat32 normalize option and reject unsupported values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee51d544948321971e49c2d7e5471c