### PR TITLE
Fix map serialization collisions with plain objects

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -38,7 +38,7 @@ function _stringify(v: unknown, stack: Set<any>): string {
     stack.add(v);
     const entries = Array.from(v.entries()).map(([k, val], idx) => ({
       key: _stringify(k, stack),
-      value: val,
+      value: _stringify(val, stack),
       order: idx,
     }));
     entries.sort((a, b) => {
@@ -46,9 +46,11 @@ function _stringify(v: unknown, stack: Set<any>): string {
       if (a.key > b.key) return 1;
       return a.order - b.order;
     });
-    const body = entries.map(({ key, value }) => JSON.stringify(key) + ":" + _stringify(value, stack));
+    const body = entries
+      .map(({ key, value }) => "[" + key + "," + value + "]")
+      .join(",");
     stack.delete(v);
-    return "{" + body.join(",") + "}";
+    return "[\"__map__\"" + (body.length ? "," + body : "") + "]";
   }
 
   // Set

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -145,6 +145,28 @@ test("map object key differs from same-name string key", () => {
   assert.ok(a.key !== b.key);
 });
 
+test("map differs from plain object with same entries", () => {
+  const c = new Cat32();
+  const mapInput = {
+    payload: new Map<unknown, unknown>([
+      [1, "one"],
+      [2, "two"],
+    ]),
+  };
+  const objectInput = {
+    payload: {
+      1: "one",
+      2: "two",
+    },
+  };
+
+  const mapAssignment = c.assign(mapInput);
+  const objectAssignment = c.assign(objectInput);
+
+  assert.ok(mapAssignment.key !== objectAssignment.key);
+  assert.ok(mapAssignment.hash !== objectAssignment.hash);
+});
+
 test("CLI preserves leading whitespace from stdin", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
   const child = spawn(process.argv[0], [CLI_PATH], {


### PR DESCRIPTION
## Summary
- add a regression test ensuring map assignments differ from plain-object equivalents
- serialize Map instances as ["__map__", ...] tuples to avoid collisions with plain objects

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee51d313a88321bf3a45dcc82eab6c