### PR TITLE
Handle NaN and Infinity serialization

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -14,7 +14,16 @@ function _stringify(v: unknown, stack: Set<any>): string {
   const t = typeof v;
 
   if (t === "string") return JSON.stringify(v);
-  if (t === "number" || t === "boolean") return JSON.stringify(v);
+  if (t === "number") {
+    const num = v as number;
+    if (Number.isNaN(num)) return '"__nan__"';
+    if (!Number.isFinite(num)) {
+      const sign = num > 0 ? "+" : "-";
+      return JSON.stringify(`__inf__:${sign}`);
+    }
+    return JSON.stringify(num);
+  }
+  if (t === "boolean") return JSON.stringify(v);
   if (t === "bigint") return `"__bigint__:${(v as bigint).toString()}"`;
   if (t === "undefined") return '"__undefined__"';
   if (t === "function" || t === "symbol") return JSON.stringify(String(v));

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -98,6 +98,24 @@ test("bigint values serialize deterministically", () => {
   assert.equal(first.hash, second.hash);
 });
 
+test("NaN serialized distinctly from null", () => {
+  const c = new Cat32({ salt: "s", namespace: "ns" });
+  const nanAssignment = c.assign({ value: NaN });
+  const nullAssignment = c.assign({ value: null });
+
+  assert.ok(nanAssignment.key !== nullAssignment.key);
+  assert.ok(nanAssignment.hash !== nullAssignment.hash);
+});
+
+test("Infinity serialized distinctly from string sentinel", () => {
+  const c = new Cat32({ salt: "s", namespace: "ns" });
+  const infinityAssignment = c.assign({ value: Infinity });
+  const sentinelAssignment = c.assign({ value: "__number__:Infinity" });
+
+  assert.ok(infinityAssignment.key !== sentinelAssignment.key);
+  assert.ok(infinityAssignment.hash !== sentinelAssignment.hash);
+});
+
 test("top-level bigint differs from number", () => {
   const c = new Cat32();
   const bigintAssignment = c.assign(1n);


### PR DESCRIPTION
## Summary
- add coverage to ensure NaN and Infinity inputs yield distinct categorizer hashes
- encode NaN and Infinity with dedicated sentinels during stable serialization

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee51d442cc83219bc26c344b63c28b