### PR TITLE
Fix CLI handling of empty string arguments

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,18 +23,18 @@ function parseArgs(argv: string[]) {
 
 async function main() {
   const args = parseArgs(process.argv);
-  const key = (args._ as string) ?? "";
+  const key = args._ as string | undefined;
   const salt = (args.salt as string) ?? "";
   const namespace = (args.namespace as string) ?? "";
   const norm = (args.normalize as string) ?? "nfkc";
 
   const cat = new Cat32({ salt, namespace, normalize: norm as any });
-  if (!key && process.stdin.isTTY) {
+  if (key === undefined && process.stdin.isTTY) {
     console.error("Usage: cat32 <key> [--salt=... --namespace=... --normalize=nfkc|nfc|none]");
     process.exit(1);
   }
 
-  const input = key || (await readStdin());
+  const input = key !== undefined ? key : await readStdin();
   const res = cat.assign(input);
   process.stdout.write(JSON.stringify(res) + "\n");
 }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -171,3 +171,35 @@ test("CLI preserves leading whitespace from stdin", async () => {
   const expected = new Cat32().assign("  spaced");
   assert.equal(result.hash, expected.hash);
 });
+
+test("CLI handles empty string key from argv", async () => {
+  const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
+  const script = [
+    "const path = process.argv.at(-1);",
+    "process.stdin.isTTY = true;",
+    'process.argv = [process.argv[0], path, ""];',
+    "import(path).catch((err) => { console.error(err); process.exit(1); });",
+  ].join(" ");
+  const child = spawn(process.argv[0], ["-e", script, CLI_PATH], {
+    stdio: ["pipe", "pipe", "inherit"],
+  });
+
+  child.stdin.end();
+
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+
+  const exitCode: number | null = await new Promise((resolve) => {
+    child.on("close", (code: number | null) => resolve(code));
+  });
+  assert.equal(exitCode, 0);
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.key, "");
+
+  const expected = new Cat32().assign("");
+  assert.equal(result.hash, expected.hash);
+});


### PR DESCRIPTION
## Summary
- add a regression test covering `cat32 ""` with a simulated TTY stdin
- ensure the CLI distinguishes between missing and empty keys so empty strings are processed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee51d439388321b81730ab4bba8ca8