### PR TITLE
Add Set serialization sentinel

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -21,7 +21,13 @@ function _stringify(v: unknown, stack: Set<any>): string {
   const t = typeof v;
 
   if (t === "string") return JSON.stringify(v);
-  if (t === "number" || t === "boolean") return JSON.stringify(v);
+  if (t === "number") {
+    if (Number.isNaN(v)) {
+      return JSON.stringify(typeSentinel("number", "NaN"));
+    }
+    return JSON.stringify(v);
+  }
+  if (t === "boolean") return JSON.stringify(v);
   if (t === "bigint") return JSON.stringify(typeSentinel("bigint", (v as bigint).toString()));
   if (t === "undefined") return JSON.stringify(typeSentinel("undefined"));
   if (t === "function" || t === "symbol") return JSON.stringify(String(v));
@@ -65,7 +71,8 @@ function _stringify(v: unknown, stack: Set<any>): string {
     if (stack.has(v)) throw new TypeError("Cyclic object");
     stack.add(v);
     const arr = Array.from(v.values()).map((x) => _stringify(x, stack));
-    const out = "[" + arr.join(",") + "]";
+    const out =
+      "[\"__set__\"" + (arr.length > 0 ? "," + arr.join(",") : "") + "]";
     stack.delete(v);
     return out;
   }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -210,6 +210,15 @@ test("map differs from plain object with same entries", () => {
   assert.ok(mapAssignment.hash !== objectAssignment.hash);
 });
 
+test("set differs from array with same entries", () => {
+  const c = new Cat32();
+  const setAssignment = c.assign(new Set([1, 2]));
+  const arrayAssignment = c.assign([1, 2]);
+
+  assert.ok(setAssignment.key !== arrayAssignment.key);
+  assert.ok(setAssignment.hash !== arrayAssignment.hash);
+});
+
 test("CLI preserves leading whitespace from stdin", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
   const child = spawn(process.argv[0], [CLI_PATH], {


### PR DESCRIPTION
## Summary
- add a regression test ensuring assigning a Set differs from an equivalent array
- serialize Sets with a dedicated "__set__" prefix and emit a numeric sentinel for NaN values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee65864da083219795a6e9d0a188c8