### PR TITLE
Ensure CLI handles empty string argument

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,9 @@ function parseArgs(argv: string[]) {
 
 async function main() {
   const args = parseArgs(process.argv);
-  const key = args._ as string | undefined;
+  const key = Object.prototype.hasOwnProperty.call(args, "_")
+    ? ((args as { _: string })._)
+    : undefined;
   const salt = (args.salt as string) ?? "";
   const namespace = (args.namespace as string) ?? "";
   const norm = (args.normalize as string) ?? "nfkc";
@@ -34,7 +36,7 @@ async function main() {
     process.exit(1);
   }
 
-  const input = key !== undefined ? key : await readStdin();
+  const input = key ?? (await readStdin());
   const res = cat.assign(input);
   process.stdout.write(JSON.stringify(res) + "\n");
 }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -268,3 +268,27 @@ test("CLI handles empty string key from argv", async () => {
   const expected = new Cat32().assign("");
   assert.equal(result.hash, expected.hash);
 });
+
+test("CLI command cat32 \"\" exits successfully", async () => {
+  const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
+  const child = spawn(process.argv[0], [CLI_PATH, ""], {
+    stdio: ["pipe", "pipe", "inherit"],
+  });
+
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+
+  const exitCode: number | null = await new Promise((resolve) => {
+    child.on("close", (code: number | null) => resolve(code));
+  });
+  assert.equal(exitCode, 0);
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.key, "");
+
+  const expected = new Cat32().assign("");
+  assert.equal(result.hash, expected.hash);
+});


### PR DESCRIPTION
## Summary
- add a CLI regression test that runs the cat32 command with an empty string argument
- adjust cli argument parsing to distinguish between an undefined key and an empty string key and fall back to stdin only when no key is provided

## Testing
- npm test (fails: NaN serialized distinctly from null)
- node --test --test-name-pattern "CLI" dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68ee65840c488321901227c1884c3cc3