### PR TITLE
Use github-script for CODEOWNERS approval check

### DIFF
--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -7,8 +7,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check CODEOWNERS approval
-        uses: mheap/github-action-required-reviewers@v2
-        with: { reviewers: 'CODEOWNERS', failOnMissing: true }
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+            const number = context.issue.number;
+            const query = `
+              query ($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    reviewDecision
+                  }
+                }
+              }
+            `;
+            const result = await github.graphql(query, { owner, repo, number });
+            const decision = result.repository.pullRequest?.reviewDecision;
+            core.info(`Review decision: ${decision ?? 'UNKNOWN'}`);
+            if (decision !== 'APPROVED') {
+              core.setFailed('CODEOWNERS approval missing (review decision is not APPROVED).');
+            }
       - name: Block auto-merge
         run: |
           echo "Auto merge is disabled by policy"


### PR DESCRIPTION
## Summary
- replace the unavailable required reviewer action with a github-script step that checks the pull request review decision for CODEOWNERS approval

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68ee69e616908321aaa004b12ad16975