### PR TITLE
Handle sparse array serialization

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -47,7 +47,15 @@ function _stringify(v: unknown, stack: Set<any>): string {
   if (Array.isArray(v)) {
     if (stack.has(v)) throw new TypeError("Cyclic object");
     stack.add(v);
-    const out = "[" + v.map((x) => _stringify(x, stack)).join(",") + "]";
+    const parts: string[] = [];
+    for (let i = 0; i < v.length; i += 1) {
+      if (Object.prototype.hasOwnProperty.call(v, i)) {
+        parts.push(_stringify(v[i], stack));
+      } else {
+        parts.push(JSON.stringify(typeSentinel("hole")));
+      }
+    }
+    const out = "[" + parts.join(",") + "]";
     stack.delete(v);
     return out;
   }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -160,6 +160,15 @@ test("undefined sentinel string differs from undefined value", () => {
   assert.ok(undefinedAssignment.hash !== stringAssignment.hash);
 });
 
+test("sparse arrays differ from empty arrays", () => {
+  const c = new Cat32({ salt: "s", namespace: "ns" });
+  const sparseAssignment = c.assign({ value: new Array(1) });
+  const emptyAssignment = c.assign({ value: [] });
+
+  assert.ok(sparseAssignment.key !== emptyAssignment.key);
+  assert.ok(sparseAssignment.hash !== emptyAssignment.hash);
+});
+
 test("sentinel strings differ from actual values at top level", () => {
   const c = new Cat32();
 


### PR DESCRIPTION
## Summary
- add a regression test covering sparse arrays to ensure they hash differently than empty arrays
- update array serialization to record holes via a dedicated sentinel token

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee6febf4f483219fa617829cea5a27