### PR TITLE
Handle sparse array serialization holes

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -7,6 +7,7 @@
 const SENTINEL_PREFIX = "\u0000cat32:";
 const SENTINEL_SUFFIX = "\u0000";
 const STRING_SENTINEL_PREFIX = `${SENTINEL_PREFIX}string:`;
+const HOLE_SENTINEL = JSON.stringify(typeSentinel("hole"));
 
 export function typeSentinel(type: string, payload = ""): string {
   return `${SENTINEL_PREFIX}${type}:${payload}${SENTINEL_SUFFIX}`;
@@ -47,12 +48,13 @@ function _stringify(v: unknown, stack: Set<any>): string {
   if (Array.isArray(v)) {
     if (stack.has(v)) throw new TypeError("Cyclic object");
     stack.add(v);
-    const parts: string[] = [];
-    for (let i = 0; i < v.length; i += 1) {
-      if (Object.prototype.hasOwnProperty.call(v, i)) {
-        parts.push(_stringify(v[i], stack));
+    const length = v.length;
+    const parts: string[] = new Array(length);
+    for (let i = 0; i < length; i += 1) {
+      if (Object.hasOwn(v, i)) {
+        parts[i] = _stringify(v[i], stack);
       } else {
-        parts.push(JSON.stringify(typeSentinel("hole")));
+        parts[i] = HOLE_SENTINEL;
       }
     }
     const out = "[" + parts.join(",") + "]";

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -169,6 +169,15 @@ test("sparse arrays differ from empty arrays", () => {
   assert.ok(sparseAssignment.hash !== emptyAssignment.hash);
 });
 
+test("top-level sparse arrays differ from empty arrays", () => {
+  const c = new Cat32({ salt: "s", namespace: "ns" });
+  const sparseAssignment = c.assign(new Array(1));
+  const emptyAssignment = c.assign([]);
+
+  assert.ok(sparseAssignment.key !== emptyAssignment.key);
+  assert.ok(sparseAssignment.hash !== emptyAssignment.hash);
+});
+
 test("sentinel strings differ from actual values at top level", () => {
   const c = new Cat32();
 


### PR DESCRIPTION
## Summary
- add regression coverage ensuring top-level sparse arrays receive distinct keys and hashes
- reuse a shared hole sentinel and indexed loop when serializing arrays to preserve sparse metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee75bbd8d48321a8babe746c546a3d