### PR TITLE
Handle CLI spec violations with exit code 2

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,23 @@ function readStdin(): Promise<string> {
   });
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+function isSpecificationViolation(error: unknown): boolean {
+  if (error instanceof RangeError) {
+    return true;
+  }
+  if (error instanceof TypeError) {
+    const message = String(error.message ?? "").toLowerCase();
+    if (message.includes("cyclic object")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error);
+  const exitCode = isSpecificationViolation(error) ? 2 : 1;
+  process.exit(exitCode);
+}

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -359,3 +359,18 @@ test("CLI command cat32 \"\" exits successfully", async () => {
   const expected = new Cat32().assign("");
   assert.equal(result.hash, expected.hash);
 });
+
+test("CLI exits with code 2 for invalid normalize option", async () => {
+  const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
+  const child = spawn(process.argv[0], [CLI_PATH, "foo", "--normalize=invalid"], {
+    stdio: ["pipe", "pipe", "inherit"],
+  });
+
+  child.stdin.end();
+
+  const exitCode: number | null = await new Promise((resolve) => {
+    child.on("close", (code: number | null) => resolve(code));
+  });
+
+  assert.equal(exitCode, 2);
+});


### PR DESCRIPTION
## Summary
- add a CLI test that covers invalid normalization options
- classify CLI errors so spec violations exit with code 2 while other failures use code 1

## Testing
- npm run build
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68ee87381f2c832186367779f2cc9c9f