### PR TITLE
Add NaN override validation

### DIFF
--- a/src/categorizer.ts
+++ b/src/categorizer.ts
@@ -124,8 +124,9 @@ export class Cat32 {
   }
 
   private normalizeIndex(i: number): number {
-    const n = Math.trunc(i);
-    if (n < 0 || n > 31) throw new Error(`index out of range: ${i}`);
-    return n;
+    if (!Number.isFinite(i) || !Number.isInteger(i) || i < 0 || i > 31) {
+      throw new Error(`index out of range: ${i}`);
+    }
+    return i;
   }
 }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -66,6 +66,13 @@ test("override by label", () => {
   assert.equal(a.label, "L31");
 });
 
+test("override rejects NaN", () => {
+  assert.throws(
+    () => new Cat32({ overrides: { foo: Number.NaN as any } }),
+    (error) => error instanceof Error,
+  );
+});
+
 test("range 0..31 and various types", () => {
   const c = new Cat32();
   for (const k of ["a", "b", "c", "日本語", "ＡＢＣ", 123, true, null]) {


### PR DESCRIPTION
## Summary
- add a regression test ensuring NaN overrides raise an error
- tighten normalizeIndex validation to reject NaN and non-integer indices

## Testing
- node --test


------
https://chatgpt.com/codex/tasks/task_e_68ee8e0b61008321afdf54369e19e457