### PR TITLE
Handle override label errors as specification violations

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,9 +62,13 @@ function isSpecificationViolation(error: unknown): boolean {
   if (error instanceof RangeError) {
     return true;
   }
-  if (error instanceof TypeError) {
+  if (error instanceof Error) {
     const message = String(error.message ?? "").toLowerCase();
-    if (message.includes("cyclic object")) {
+    if (
+      message.includes("cyclic object") ||
+      message.includes("override label") ||
+      message.includes("index out of range")
+    ) {
       return true;
     }
   }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -496,3 +496,37 @@ test("CLI exits with code 2 for invalid normalize option", async () => {
 
   assert.equal(exitCode, 2);
 });
+
+test("CLI exits with code 2 when override label is missing", async () => {
+  const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
+  const script = [
+    "(async () => {",
+    "  const cliPath = process.argv.at(-1);",
+    "  const { pathToFileURL } = await import('node:url');",
+    "  const { Cat32 } = await import(new URL('../src/categorizer.js', pathToFileURL(cliPath)));",
+    "  Cat32.prototype.assign = function assign() {",
+    '    throw new Error(\'override label "X" not in labels\');',
+    "  };",
+    "  process.stdin.isTTY = true;",
+    "  process.argv = [process.argv[0], cliPath, 'payload'];",
+    "  try {",
+    "    await import(cliPath);",
+    "  } catch (error) {",
+    "    console.error(error);",
+    "    process.exit(1);",
+    "  }",
+    "})();",
+  ].join("\n");
+
+  const child = spawn(process.argv[0], ["-e", script, CLI_PATH], {
+    stdio: ["pipe", "ignore", "pipe"],
+  });
+
+  child.stdin.end();
+
+  const exitCode: number | null = await new Promise((resolve) => {
+    child.on("close", (code: number | null) => resolve(code));
+  });
+
+  assert.equal(exitCode, 2);
+});


### PR DESCRIPTION
## Summary
- add a CLI regression test that overrides Cat32.assign to emit an override-label error and expect exit code 2
- extend cli specification-violation detection to look for override label and index out of range keywords in error messages

## Testing
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68eee21b473c8321855d165e9ffd5baf