### PR TITLE
Ensure Cat32 uses literal sentinels for undefined and dates

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -14,6 +14,12 @@ export function typeSentinel(type: string, payload = ""): string {
 }
 
 export function escapeSentinelString(value: string): string {
+  if (
+    value.startsWith("__undefined__") ||
+    value.startsWith("__date__:")
+  ) {
+    return typeSentinel("string", value);
+  }
   if (!value.startsWith(SENTINEL_PREFIX)) {
     return value;
   }
@@ -42,7 +48,7 @@ function _stringify(v: unknown, stack: Set<any>): string {
   }
   if (t === "boolean") return JSON.stringify(v);
   if (t === "bigint") return JSON.stringify(typeSentinel("bigint", (v as bigint).toString()));
-  if (t === "undefined") return JSON.stringify(typeSentinel("undefined"));
+  if (t === "undefined") return JSON.stringify("__undefined__");
   if (t === "function" || t === "symbol") return JSON.stringify(String(v));
 
   if (Array.isArray(v)) {
@@ -64,7 +70,7 @@ function _stringify(v: unknown, stack: Set<any>): string {
 
   // Date
   if (v instanceof Date) {
-    return JSON.stringify(typeSentinel("date", v.toISOString()));
+    return JSON.stringify(`__date__:${v.toISOString()}`);
   }
 
   // Map

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -270,6 +270,13 @@ test("undefined sentinel string differs from undefined value", () => {
   assert.ok(undefinedAssignment.hash !== stringAssignment.hash);
 });
 
+test("undefined object property serializes with sentinel", () => {
+  const c = new Cat32();
+  const assignment = c.assign({ value: undefined });
+
+  assert.equal(assignment.key, '{"value":"__undefined__"}');
+});
+
 test("sparse arrays differ from empty arrays", () => {
   const c = new Cat32({ salt: "s", namespace: "ns" });
   const sparseAssignment = c.assign({ value: new Array(1) });
@@ -326,6 +333,17 @@ test("sentinel strings differ from actual values when nested", () => {
   const dateSentinel = c.assign({ value: "__date__:" + date.toISOString() });
   assert.ok(dateValue.key !== dateSentinel.key);
   assert.ok(dateValue.hash !== dateSentinel.hash);
+});
+
+test("date object property serializes with sentinel", () => {
+  const c = new Cat32();
+  const date = new Date("2024-01-02T03:04:05.678Z");
+  const assignment = c.assign({ value: date });
+
+  assert.equal(
+    assignment.key,
+    '{"value":"__date__:2024-01-02T03:04:05.678Z"}',
+  );
 });
 
 test("cyclic object throws", () => {


### PR DESCRIPTION
## Summary
- add regression coverage asserting object keys encode undefined and Date values using literal sentinel strings
- serialize undefined and Date inputs to the documented __undefined__/__date__ sentinel forms while escaping colliding string literals

## Testing
- `npm run build`
- `node --test dist/tests`


------
https://chatgpt.com/codex/tasks/task_e_68eee60a7bf48321a9ffcd308e294775