### PR TITLE
Improve CLI specification violation detection

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,17 +58,19 @@ function readStdin(): Promise<string> {
   });
 }
 
+const SPEC_VIOLATION_MESSAGE_FRAGMENTS = [
+  "cyclic object",
+  "override label",
+  "index out of range",
+] as const;
+
 function isSpecificationViolation(error: unknown): boolean {
   if (error instanceof RangeError) {
     return true;
   }
   if (error instanceof Error) {
     const message = String(error.message ?? "").toLowerCase();
-    if (
-      message.includes("cyclic object") ||
-      message.includes("override label") ||
-      message.includes("index out of range")
-    ) {
+    if (SPEC_VIOLATION_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment))) {
       return true;
     }
   }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -520,6 +520,42 @@ test("CLI exits with code 2 for invalid normalize option", async () => {
   assert.equal(exitCode, 2);
 });
 
+test("CLI exits with code 2 when override label error is thrown", async () => {
+  const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
+  const script = [
+    "(async () => {",
+    "  const cliPath = process.argv.at(-1);",
+    "  const { pathToFileURL } = await import('node:url');",
+    "  const { Cat32 } = await import(new URL('../src/categorizer.js', pathToFileURL(cliPath)));",
+    "  const originalAssign = Cat32.prototype.assign;",
+    "  Cat32.prototype.assign = function assign() {",
+    '    Cat32.prototype.assign = originalAssign;',
+    '    throw new Error(\'override label "VIP" not in labels\');',
+    "  };",
+    "  process.stdin.isTTY = true;",
+    "  process.argv = [process.argv[0], cliPath, 'payload'];",
+    "  try {",
+    "    await import(cliPath);",
+    "  } catch (error) {",
+    "    console.error(error);",
+    "    process.exit(1);",
+    "  }",
+    "})();",
+  ].join("\n");
+
+  const child = spawn(process.argv[0], ["-e", script, CLI_PATH], {
+    stdio: ["pipe", "ignore", "pipe"],
+  });
+
+  child.stdin.end();
+
+  const exitCode: number | null = await new Promise((resolve) => {
+    child.on("close", (code: number | null) => resolve(code));
+  });
+
+  assert.equal(exitCode, 2);
+});
+
 test("CLI exits with code 2 when override label is missing", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
   const script = [


### PR DESCRIPTION
## Summary
- add a CLI spawn test that temporarily overrides `Cat32.prototype.assign` to throw an override-label error and expects exit code 2
- factor CLI specification-violation message fragments to recognize override-label and index-range errors thrown as generic `Error`

## Testing
- npm run build
- node --test dist/tests
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68eee6097908832188fcdd20282039ba