### PR TITLE
Align set serialization with arrays

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -105,10 +105,7 @@ function _stringify(v: unknown, stack: Set<any>): string {
       _stringify(value, stack),
     );
     serializedValues.sort();
-    const out =
-      "[\"__set__\"" +
-      (serializedValues.length > 0 ? "," + serializedValues.join(",") : "") +
-      "]";
+    const out = "[" + serializedValues.join(",") + "]";
     stack.delete(v);
     return out;
   }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -396,13 +396,20 @@ test("map payload matches plain object with same entries", () => {
   assert.equal(mapAssignment.hash, objectAssignment.hash);
 });
 
-test("set differs from array with same entries", () => {
+test("set serialization matches array entries regardless of insertion order", () => {
   const c = new Cat32();
-  const setAssignment = c.assign(new Set([1, 2]));
-  const arrayAssignment = c.assign([1, 2]);
+  const values = [1, 2, 3];
 
-  assert.ok(setAssignment.key !== arrayAssignment.key);
-  assert.ok(setAssignment.hash !== arrayAssignment.hash);
+  const setAssignment = c.assign(new Set(values));
+  const arrayAssignment = c.assign([...values]);
+
+  assert.equal(setAssignment.key, arrayAssignment.key);
+  assert.equal(setAssignment.hash, arrayAssignment.hash);
+
+  const reorderedSetAssignment = c.assign(new Set([...values].reverse()));
+
+  assert.equal(reorderedSetAssignment.key, setAssignment.key);
+  assert.equal(reorderedSetAssignment.hash, setAssignment.hash);
 });
 
 test("CLI preserves leading whitespace from stdin", async () => {


### PR DESCRIPTION
## Summary
- ensure Cat32 set assignments share keys and hashes with equivalent arrays regardless of set insertion order
- adjust stable serialization of Set values to omit the __set__ sentinel and emit sorted array-like output

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68eeea9923748321bbbe86cbf4926d4e