### PR TITLE
Ensure undefined and date keys use sentinel literals

### DIFF
--- a/src/categorizer.ts
+++ b/src/categorizer.ts
@@ -113,7 +113,7 @@ export class Cat32 {
         s = stableStringify(input);
         break;
       case "undefined":
-        s = typeSentinel("undefined");
+        s = "__undefined__";
         break;
       default:
         s = String(input);

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -8,6 +8,8 @@ const SENTINEL_PREFIX = "\u0000cat32:";
 const SENTINEL_SUFFIX = "\u0000";
 const STRING_SENTINEL_PREFIX = `${SENTINEL_PREFIX}string:`;
 const HOLE_SENTINEL = JSON.stringify(typeSentinel("hole"));
+const UNDEFINED_SENTINEL = "__undefined__";
+const DATE_SENTINEL_PREFIX = "__date__:";
 
 export function typeSentinel(type: string, payload = ""): string {
   return `${SENTINEL_PREFIX}${type}:${payload}${SENTINEL_SUFFIX}`;
@@ -15,8 +17,8 @@ export function typeSentinel(type: string, payload = ""): string {
 
 export function escapeSentinelString(value: string): string {
   if (
-    value.startsWith("__undefined__") ||
-    value.startsWith("__date__:")
+    value.startsWith(UNDEFINED_SENTINEL) ||
+    value.startsWith(DATE_SENTINEL_PREFIX)
   ) {
     return typeSentinel("string", value);
   }
@@ -48,7 +50,7 @@ function _stringify(v: unknown, stack: Set<any>): string {
   }
   if (t === "boolean") return JSON.stringify(v);
   if (t === "bigint") return JSON.stringify(typeSentinel("bigint", (v as bigint).toString()));
-  if (t === "undefined") return JSON.stringify("__undefined__");
+  if (t === "undefined") return JSON.stringify(UNDEFINED_SENTINEL);
   if (t === "function" || t === "symbol") return JSON.stringify(String(v));
 
   if (Array.isArray(v)) {
@@ -70,7 +72,7 @@ function _stringify(v: unknown, stack: Set<any>): string {
 
   // Date
   if (v instanceof Date) {
-    return JSON.stringify(`__date__:${v.toISOString()}`);
+    return JSON.stringify(`${DATE_SENTINEL_PREFIX}${v.toISOString()}`);
   }
 
   // Map

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -99,6 +99,22 @@ test("deterministic mapping for object key order", () => {
   assert.equal(a1.hash, a2.hash);
 });
 
+test("canonical key encodes undefined sentinel", () => {
+  const c = new Cat32();
+  const assignment = c.assign({ value: undefined });
+  assert.equal(assignment.key, "{\"value\":\"__undefined__\"}");
+});
+
+test("canonical key encodes date sentinel", () => {
+  const c = new Cat32();
+  const date = new Date("2024-01-02T03:04:05.000Z");
+  const assignment = c.assign({ value: date });
+  assert.equal(
+    assignment.key,
+    `{"value":"__date__:${date.toISOString()}"}`,
+  );
+});
+
 test("deterministic mapping for bigint values", () => {
   const c = new Cat32({ salt: "s", namespace: "ns" });
   const source = { id: 1n, nested: { value: 2n } };


### PR DESCRIPTION
## Summary
- add unit tests covering canonical key serialization for undefined and Date inputs
- normalize undefined canonical keys to the __undefined__ literal format
- centralize sentinel constants to keep Date and undefined escape handling consistent

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68eeea98eb888321a80df8f68b914a5d