### PR TITLE
Fix top-level undefined canonical key

### DIFF
--- a/src/categorizer.ts
+++ b/src/categorizer.ts
@@ -113,7 +113,7 @@ export class Cat32 {
         s = stableStringify(input);
         break;
       case "undefined":
-        s = "__undefined__";
+        s = stableStringify(input);
         break;
       default:
         s = String(input);

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -286,6 +286,12 @@ test("undefined sentinel string differs from undefined value", () => {
   assert.ok(undefinedAssignment.hash !== stringAssignment.hash);
 });
 
+test("top-level undefined serializes with sentinel string", () => {
+  const assignment = new Cat32().assign(undefined);
+
+  assert.equal(assignment.key, JSON.stringify("__undefined__"));
+});
+
 test("undefined object property serializes with sentinel", () => {
   const c = new Cat32();
   const assignment = c.assign({ value: undefined });


### PR DESCRIPTION
## Summary
- add a regression test that exercises the canonical key for a top-level undefined input
- change Cat32 canonicalization to reuse stableStringify for undefined values so the JSON sentinel is preserved

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68ef3bb02b1c832198799bc110ec3032