### PR TITLE
Ensure dist build outputs root entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cat32": "dist/cli.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node -e \"const fs=require('node:fs');const path=require('node:path');const dist=path.resolve('dist');const src=path.join(dist,'src');for (const entry of fs.readdirSync(src,{withFileTypes:true})){if(entry.isFile()&&(/\\.(js|d.ts)$/.test(entry.name))){fs.copyFileSync(path.join(src,entry.name),path.join(dist,entry.name));}}\"",
     "test": "npm run build && node --test dist/tests",
     "prepare": "npm run build"
   },

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -33,6 +33,18 @@ const dynamicImport = new Function(
 
 const CLI_PATH = new URL("../src/cli.js", import.meta.url).pathname;
 
+test("dist entry point exports Cat32", async () => {
+  const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
+    ? new URL("../../tests/categorizer.test.ts", import.meta.url)
+    : import.meta.url;
+
+  const distModule = (await import(
+    new URL("../dist/index.js", sourceImportMetaUrl) as unknown as string
+  )) as { Cat32?: unknown };
+
+  assert.equal(typeof distModule.Cat32, "function");
+});
+
 const CLI_SET_ASSIGN_SCRIPT = [
   "(async () => {",
   "  const cliPath = process.argv.at(-1);",


### PR DESCRIPTION
## Summary
- add a node:test case to assert that the built dist/index.js entry point can be imported
- update the build script to copy compiled artifacts from dist/src into the package root so the distribution files exist where expected

## Testing
- npm run build
- node --test


------
https://chatgpt.com/codex/tasks/task_e_68ef458fe7e083219b374af940d31f83