### PR TITLE
Align sentinel string handling with literal values

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -14,10 +14,6 @@ export function typeSentinel(type: string, payload = ""): string {
   return `${SENTINEL_PREFIX}${type}:${payload}${SENTINEL_SUFFIX}`;
 }
 
-export function escapeSentinelString(value: string): string {
-  return value;
-}
-
 export function stableStringify(v: unknown): string {
   const stack = new Set<any>();
   return _stringify(v, stack);
@@ -70,14 +66,10 @@ function _stringify(v: unknown, stack: Set<any>): string {
     for (const [rawKey, rawValue] of v.entries()) {
       const serializedKey = _stringify(rawKey, stack);
       const revivedKey = reviveFromSerialized(serializedKey);
-      const propertyKey = toPropertyKeyString(
-        revivedKey.value,
-        serializedKey,
-        revivedKey.stringSentinel,
-      );
+      const propertyKey = toPropertyKeyString(revivedKey, serializedKey);
       const serializedValue = _stringify(rawValue, stack);
       const revivedValue = reviveFromSerialized(serializedValue);
-      normalizedEntries.set(propertyKey, revivedValue.value);
+      normalizedEntries.set(propertyKey, revivedValue);
     }
     const keys = Array.from(normalizedEntries.keys()).sort();
     const body = keys
@@ -113,34 +105,15 @@ function _stringify(v: unknown, stack: Set<any>): string {
   return "{" + body.join(",") + "}";
 }
 
-type RevivedSerialized = {
-  value: unknown;
-  stringSentinel?: string;
-};
-
-function reviveFromSerialized(serialized: string): RevivedSerialized {
+function reviveFromSerialized(serialized: string): unknown {
   try {
-    const value = JSON.parse(serialized);
-    if (typeof value === "string") {
-      const sentinelString = reviveStringSentinel(value);
-      if (sentinelString !== undefined) {
-        return { value, stringSentinel: sentinelString };
-      }
-    }
-    return { value };
+    return JSON.parse(serialized);
   } catch {
-    return { value: serialized };
+    return serialized;
   }
 }
 
-function toPropertyKeyString(
-  value: unknown,
-  fallback: string,
-  stringSentinel?: string,
-): string {
-  if (stringSentinel !== undefined) {
-    return stringSentinel;
-  }
+function toPropertyKeyString(value: unknown, fallback: string): string {
   if (value === null) return "null";
   const type = typeof value;
   if (type === "object" || type === "function") {
@@ -150,14 +123,4 @@ function toPropertyKeyString(
     return (value as symbol).toString();
   }
   return String(value);
-}
-
-function reviveStringSentinel(value: string): string | undefined {
-  if (!value.startsWith(STRING_SENTINEL_PREFIX) || !value.endsWith(SENTINEL_SUFFIX)) {
-    return undefined;
-  }
-  return value.slice(
-    STRING_SENTINEL_PREFIX.length,
-    value.length - SENTINEL_SUFFIX.length,
-  );
 }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -128,6 +128,21 @@ test("canonical key encodes date sentinel", () => {
   );
 });
 
+test("string sentinel matches undefined value", () => {
+  const c = new Cat32();
+  const sentinelAssignment = c.assign("__undefined__");
+  const undefinedAssignment = c.assign(undefined);
+  assert.equal(sentinelAssignment.key, undefinedAssignment.key);
+});
+
+test("string sentinel matches date value", () => {
+  const c = new Cat32();
+  const iso = "2024-01-02T03:04:05.000Z";
+  const sentinelAssignment = c.assign(`__date__:${iso}`);
+  const dateAssignment = c.assign(new Date(iso));
+  assert.equal(sentinelAssignment.key, dateAssignment.key);
+});
+
 test("deterministic mapping for bigint values", () => {
   const c = new Cat32({ salt: "s", namespace: "ns" });
   const source = { id: 1n, nested: { value: 2n } };
@@ -219,9 +234,9 @@ test("stableStringify leaves sentinel-like strings untouched", () => {
   assert.equal(stableStringify("__undefined__"), JSON.stringify("__undefined__"));
 });
 
-test("string sentinel literals remain literal canonical keys", () => {
+test("string sentinel canonical key is JSON string", () => {
   const assignment = new Cat32().assign("__date__:2024-01-01Z");
-  assert.equal(assignment.key, "__date__:2024-01-01Z");
+  assert.equal(assignment.key, JSON.stringify("__date__:2024-01-01Z"));
 });
 
 test("Map keys match plain object representation regardless of entry order", () => {
@@ -317,13 +332,13 @@ test("bigint sentinel string differs from bigint value", () => {
   assert.ok(bigintAssignment.hash !== stringAssignment.hash);
 });
 
-test("undefined sentinel string differs from undefined value", () => {
+test("undefined sentinel string matches undefined value", () => {
   const c = new Cat32();
   const undefinedAssignment = c.assign(undefined);
   const stringAssignment = c.assign("__undefined__");
 
-  assert.ok(undefinedAssignment.key !== stringAssignment.key);
-  assert.ok(undefinedAssignment.hash !== stringAssignment.hash);
+  assert.equal(undefinedAssignment.key, stringAssignment.key);
+  assert.equal(undefinedAssignment.hash, stringAssignment.hash);
 });
 
 test("top-level undefined serializes with sentinel string", () => {
@@ -357,7 +372,7 @@ test("top-level sparse arrays differ from empty arrays", () => {
   assert.ok(sparseAssignment.hash !== emptyAssignment.hash);
 });
 
-test("sentinel strings differ from actual values at top level", () => {
+test("sentinel strings align with actual values at top level", () => {
   const c = new Cat32();
 
   const bigintValue = c.assign(1n);
@@ -367,14 +382,14 @@ test("sentinel strings differ from actual values at top level", () => {
 
   const undefinedValue = c.assign(undefined);
   const undefinedSentinel = c.assign("__undefined__");
-  assert.ok(undefinedValue.key !== undefinedSentinel.key);
-  assert.ok(undefinedValue.hash !== undefinedSentinel.hash);
+  assert.equal(undefinedValue.key, undefinedSentinel.key);
+  assert.equal(undefinedValue.hash, undefinedSentinel.hash);
 
   const date = new Date("2024-01-02T03:04:05.678Z");
   const dateValue = c.assign(date);
   const dateSentinel = c.assign("__date__:" + date.toISOString());
-  assert.ok(dateValue.key !== dateSentinel.key);
-  assert.ok(dateValue.hash !== dateSentinel.hash);
+  assert.equal(dateValue.key, dateSentinel.key);
+  assert.equal(dateValue.hash, dateSentinel.hash);
 });
 
 test("sentinel string literals match nested undefined/date but not bigint", () => {


### PR DESCRIPTION
## Summary
- remove the extra sentinel escaping in `stableStringify` so sentinel-like strings serialize exactly as `JSON.stringify`
- update categorizer tests to expect literal `__undefined__` and `__date__:` strings to share canonical keys with the corresponding values

## Testing
- node --test dist/tests
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68ef4c7edd0483218d579b451e39b7b0