### PR TITLE
Add tests for dist module imports

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -6,6 +6,7 @@
 
 const SENTINEL_PREFIX = "\u0000cat32:";
 const SENTINEL_SUFFIX = "\u0000";
+const STRING_SENTINEL_PREFIX = `${SENTINEL_PREFIX}string:`;
 const HOLE_SENTINEL = JSON.stringify(typeSentinel("hole"));
 const UNDEFINED_SENTINEL = "__undefined__";
 const DATE_SENTINEL_PREFIX = "__date__:";

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -46,6 +46,50 @@ test("dist entry point exports Cat32", async () => {
   assert.equal(typeof distModule.Cat32, "function");
 });
 
+test("dist index and cli modules are importable", async () => {
+  const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
+    ? new URL("../../tests/categorizer.test.ts", import.meta.url)
+    : import.meta.url;
+
+  await import(
+    new URL("../dist/index.js", sourceImportMetaUrl) as unknown as string,
+  ).catch((error) => {
+    throw new Error(`Failed to import dist/index.js: ${String(error)}`);
+  });
+
+  const originalArgv = process.argv.slice();
+  const originalExit = process.exit;
+  const originalStdoutWrite = process.stdout.write;
+  const stdin = process.stdin as unknown as { isTTY?: boolean };
+  const originalIsTTY = stdin.isTTY;
+  const captured: string[] = [];
+
+  try {
+    const distCliPath = new URL("../dist/cli.js", sourceImportMetaUrl).pathname;
+    process.argv = [originalArgv[0], distCliPath, "__cat32_test_key__"];
+    stdin.isTTY = true;
+    process.exit = (() => undefined) as typeof process.exit;
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+      captured.push(text);
+      return true;
+    }) as typeof process.stdout.write;
+
+    await import(
+      new URL("../dist/cli.js", sourceImportMetaUrl) as unknown as string,
+    );
+  } catch (error) {
+    throw new Error(`Failed to import dist/cli.js: ${String(error)}`);
+  } finally {
+    process.argv = originalArgv;
+    stdin.isTTY = originalIsTTY;
+    process.exit = originalExit;
+    process.stdout.write = originalStdoutWrite;
+  }
+
+  assert.ok(captured.some((chunk) => chunk.includes("index")));
+});
+
 const CLI_SET_ASSIGN_SCRIPT = [
   "(async () => {",
   "  const cliPath = process.argv.at(-1);",


### PR DESCRIPTION
## Summary
- add a node:test case to confirm the built index and CLI entry points can be imported without module resolution errors
- define the missing `STRING_SENTINEL_PREFIX` constant so the TypeScript build succeeds and emits dist artifacts

## Testing
- npm run build
- time node --test dist/tests/categorizer.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ef4c824bc88321b17bca0ad786edc1