### PR TITLE
Ensure string canonical keys stay literal

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -12,7 +12,6 @@ const UNDEFINED_SENTINEL = "__undefined__";
 const DATE_SENTINEL_PREFIX = "__date__:";
 const BIGINT_SENTINEL_PREFIX = "__bigint__:";
 const NUMBER_SENTINEL_PREFIX = "__number__:";
-const STRING_SENTINEL_PREFIX = `${SENTINEL_PREFIX}string:`;
 
 export function typeSentinel(type: string, payload = ""): string {
   return `${SENTINEL_PREFIX}${type}:${payload}${SENTINEL_SUFFIX}`;
@@ -25,15 +24,7 @@ const SENTINEL_STRING_PREFIXES = [
 ];
 
 export function escapeSentinelString(value: string): string {
-  if (value === UNDEFINED_SENTINEL) {
-    return value;
-  }
-  for (const prefix of SENTINEL_STRING_PREFIXES) {
-    if (value.startsWith(prefix)) {
-      return value;
-    }
-  }
-  return JSON.stringify(value);
+  return value;
 }
 
 export function stableStringify(v: unknown): string {


### PR DESCRIPTION
## Summary
- return raw string values from the release bundle so canonical keys for strings stay literal
- tighten distribution tests to cover sentinel-like literals and CLI output while sharing a UTF-8 helper
- regenerate the dist artifacts via the TypeScript build to keep bundles in sync

## Testing
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68ef66e36cb08321ab3f50953d9eaac1