### PR TITLE
Normalize override canonical keys

### DIFF
--- a/src/categorizer.ts
+++ b/src/categorizer.ts
@@ -47,7 +47,7 @@ export class Cat32 {
 
     if (opts.overrides) {
       for (const [rawKey, v] of Object.entries(opts.overrides)) {
-        const k = this.canonicalKey(rawKey);
+        const k = this.normalizeCanonicalKey(rawKey);
         if (typeof v === "number") {
           this.overrides.set(k, this.normalizeIndex(v));
         } else {
@@ -86,13 +86,17 @@ export class Cat32 {
 
   private canonicalKey(input: unknown): string {
     const serialized = stableStringify(input);
+    return this.normalizeCanonicalKey(serialized);
+  }
+
+  private normalizeCanonicalKey(key: string): string {
     switch (this.normalize) {
       case "nfc":
-        return serialized.normalize("NFC");
+        return key.normalize("NFC");
       case "nfkc":
-        return serialized.normalize("NFKC");
+        return key.normalize("NFKC");
       default:
-        return serialized;
+        return key;
     }
   }
 


### PR DESCRIPTION
## Summary
- update Cat32 override initialization to only normalize already-canonical keys
- expand tests to cover canonical override keys for primitives and adjust existing override expectations

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ef6cfdc0a883218197b44a851f9c5f