### PR TITLE
Handle Cat32 string sentinel escaping

### DIFF
--- a/dist/categorizer.js
+++ b/dist/categorizer.js
@@ -1,5 +1,5 @@
 import { fnv1a32, toHex32 } from "./hash.js";
-import { escapeSentinelString, stableStringify } from "./serialize.js";
+import { stableStringify } from "./serialize.js";
 const DEFAULT_LABELS = [
     ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ",
     ..."012345"
@@ -61,28 +61,15 @@ export class Cat32 {
         return this.salt ? `${s}|salt:${this.salt}` : s;
     }
     canonicalKey(input) {
-        let serialized;
-        switch (typeof input) {
-            case "string":
-                serialized = escapeSentinelString(input);
-                break;
-            case "bigint":
-            case "number":
-            case "boolean":
-            case "undefined":
-                serialized = stableStringify(input);
-                break;
-            case "object":
-                serialized = stableStringify(input);
-                break;
+        const serialized = stableStringify(input);
+        switch (this.normalize) {
+            case "nfc":
+                return serialized.normalize("NFC");
+            case "nfkc":
+                return serialized.normalize("NFKC");
             default:
-                serialized = stableStringify(input);
+                return serialized;
         }
-        if (this.normalize === "nfc")
-            return serialized.normalize("NFC");
-        if (this.normalize === "nfkc")
-            return serialized.normalize("NFKC");
-        return serialized;
     }
     normalizeIndex(i) {
         if (!Number.isFinite(i) || !Number.isInteger(i)) {

--- a/dist/src/categorizer.js
+++ b/dist/src/categorizer.js
@@ -1,5 +1,5 @@
 import { fnv1a32, toHex32 } from "./hash.js";
-import { escapeSentinelString, stableStringify } from "./serialize.js";
+import { stableStringify } from "./serialize.js";
 const DEFAULT_LABELS = [
     ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ",
     ..."012345"
@@ -61,28 +61,15 @@ export class Cat32 {
         return this.salt ? `${s}|salt:${this.salt}` : s;
     }
     canonicalKey(input) {
-        let serialized;
-        switch (typeof input) {
-            case "string":
-                serialized = escapeSentinelString(input);
-                break;
-            case "bigint":
-            case "number":
-            case "boolean":
-            case "undefined":
-                serialized = stableStringify(input);
-                break;
-            case "object":
-                serialized = stableStringify(input);
-                break;
+        const serialized = stableStringify(input);
+        switch (this.normalize) {
+            case "nfc":
+                return serialized.normalize("NFC");
+            case "nfkc":
+                return serialized.normalize("NFKC");
             default:
-                serialized = stableStringify(input);
+                return serialized;
         }
-        if (this.normalize === "nfc")
-            return serialized.normalize("NFC");
-        if (this.normalize === "nfkc")
-            return serialized.normalize("NFKC");
-        return serialized;
     }
     normalizeIndex(i) {
         if (!Number.isFinite(i) || !Number.isInteger(i)) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -18,7 +18,9 @@ export function typeSentinel(type: string, payload = ""): string {
 }
 
 export function escapeSentinelString(value: string): string {
-  return JSON.stringify(value);
+  const needsEscaping = value.startsWith(SENTINEL_PREFIX) && !value.startsWith(STRING_SENTINEL_PREFIX);
+  const escaped = needsEscaping ? typeSentinel("string", value) : value;
+  return JSON.stringify(escaped);
 }
 
 export function stableStringify(v: unknown): string {
@@ -30,7 +32,7 @@ function _stringify(v: unknown, stack: Set<any>): string {
   if (v === null) return "null";
   const t = typeof v;
 
-  if (t === "string") return JSON.stringify(v);
+  if (t === "string") return escapeSentinelString(v as string);
   if (t === "number") {
     const value = v as number;
     if (Number.isNaN(value) || !Number.isFinite(value)) {
@@ -114,8 +116,19 @@ function _stringify(v: unknown, stack: Set<any>): string {
 
 function reviveFromSerialized(serialized: string): unknown {
   try {
-    return JSON.parse(serialized);
+    const parsed = JSON.parse(serialized);
+    if (
+      typeof parsed === "string" &&
+      parsed.startsWith(STRING_SENTINEL_PREFIX) &&
+      parsed.endsWith(SENTINEL_SUFFIX)
+    ) {
+      return parsed.slice(STRING_SENTINEL_PREFIX.length, -SENTINEL_SUFFIX.length);
+    }
+    return parsed;
   } catch {
+    if (serialized.startsWith(STRING_SENTINEL_PREFIX) && serialized.endsWith(SENTINEL_SUFFIX)) {
+      return serialized.slice(STRING_SENTINEL_PREFIX.length, -SENTINEL_SUFFIX.length);
+    }
     return serialized;
   }
 }
@@ -128,6 +141,13 @@ function toPropertyKeyString(value: unknown, fallback: string): string {
   }
   if (type === "symbol") {
     return (value as symbol).toString();
+  }
+  if (
+    type === "string" &&
+    (value as string).startsWith(STRING_SENTINEL_PREFIX) &&
+    (value as string).endsWith(SENTINEL_SUFFIX)
+  ) {
+    return (value as string).slice(STRING_SENTINEL_PREFIX.length, -SENTINEL_SUFFIX.length);
   }
   return String(value);
 }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -197,6 +197,12 @@ test("canonical key encodes date sentinel", () => {
 test("canonical key matches stableStringify for basic primitives", () => {
   const c = new Cat32({ normalize: "none" });
 
+  assert.equal(c.assign("foo").key, stableStringify("foo"));
+  assert.equal(c.assign(1n).key, stableStringify(1n));
+  assert.equal(c.assign(Number.NaN).key, stableStringify(Number.NaN));
+  assert.equal(c.assign(Symbol("x")).key, stableStringify(Symbol("x")));
+});
+
 test("functions and symbols serialize to bare strings", () => {
   const fn = function foo() {};
   const sym = Symbol("x");
@@ -385,6 +391,15 @@ test("Infinity serialized distinctly from string sentinel", () => {
 
   assert.equal(infinityAssignment.key === sentinelAssignment.key, false);
   assert.equal(infinityAssignment.hash === sentinelAssignment.hash, false);
+});
+
+test("raw number sentinel string differs from Infinity value", () => {
+  const c = new Cat32();
+  const sentinelAssignment = c.assign("\u0000cat32:number:Infinity\u0000");
+  const infinityAssignment = c.assign(Infinity);
+
+  assert.ok(sentinelAssignment.key !== infinityAssignment.key);
+  assert.ok(sentinelAssignment.hash !== infinityAssignment.hash);
 });
 
 test("top-level bigint differs from number", () => {


### PR DESCRIPTION
## Summary
- escape user-provided Cat32 sentinel strings via string sentinels and decode them during map revival
- ensure property key normalization unwraps Cat32 string sentinels
- cover raw number sentinel string collisions and restore primitive canonical-key assertions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ef6cfe22f4832185f092e00592f56c