### PR TITLE
Add tsc duplicate identifier regression test and remove unused sentinel constant

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -7,7 +7,6 @@
 const SENTINEL_PREFIX = "\u0000cat32:";
 const SENTINEL_SUFFIX = "\u0000";
 const HOLE_SENTINEL = JSON.stringify(typeSentinel("hole"));
-const STRING_SENTINEL_PREFIX = `${SENTINEL_PREFIX}string:`;
 const UNDEFINED_SENTINEL = "__undefined__";
 const DATE_SENTINEL_PREFIX = "__date__:";
 const BIGINT_SENTINEL_PREFIX = "__bigint__:";


### PR DESCRIPTION
## Summary
- add a regression test that spawns `tsc` to ensure duplicate identifier errors do not reappear
- extend the test utilities to cover fs/path helpers and close the existing canonical key primitive test
- remove the unused `STRING_SENTINEL_PREFIX` constant from the serializer implementation

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ef6cfcde6083219aca45825fe30240