### PR TITLE
Fix Map serialization normalization

### DIFF
--- a/dist/serialize.js
+++ b/dist/serialize.js
@@ -77,14 +77,13 @@ function _stringify(v, stack) {
             const revivedKey = reviveFromSerialized(serializedKey);
             const propertyKey = toPropertyKeyString(revivedKey, serializedKey);
             const serializedValue = _stringify(rawValue, stack);
-            const revivedValue = reviveFromSerialized(serializedValue);
-            normalizedEntries.set(propertyKey, revivedValue);
+            normalizedEntries.set(propertyKey, serializedValue);
         }
         const keys = Array.from(normalizedEntries.keys()).sort();
         const body = keys
             .map((key) => {
-            const revivedValue = normalizedEntries.get(key);
-            return JSON.stringify(key) + ":" + JSON.stringify(revivedValue);
+            const serializedValue = normalizedEntries.get(key);
+            return JSON.stringify(key) + ":" + serializedValue;
         })
             .join(",");
         stack.delete(v);

--- a/dist/src/serialize.js
+++ b/dist/src/serialize.js
@@ -77,14 +77,13 @@ function _stringify(v, stack) {
             const revivedKey = reviveFromSerialized(serializedKey);
             const propertyKey = toPropertyKeyString(revivedKey, serializedKey);
             const serializedValue = _stringify(rawValue, stack);
-            const revivedValue = reviveFromSerialized(serializedValue);
-            normalizedEntries.set(propertyKey, revivedValue);
+            normalizedEntries.set(propertyKey, serializedValue);
         }
         const keys = Array.from(normalizedEntries.keys()).sort();
         const body = keys
             .map((key) => {
-            const revivedValue = normalizedEntries.get(key);
-            return JSON.stringify(key) + ":" + JSON.stringify(revivedValue);
+            const serializedValue = normalizedEntries.get(key);
+            return JSON.stringify(key) + ":" + serializedValue;
         })
             .join(",");
         stack.delete(v);

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -265,6 +265,18 @@ test("Map keys match plain object representation regardless of entry order", () 
     assert.equal(duplicateKeyMapAssignment.key, duplicateKeyObjectAssignment.key);
     assert.equal(duplicateKeyMapAssignment.hash, duplicateKeyObjectAssignment.hash);
 });
+test("Map values serialize identically to plain object values", () => {
+    const c = new Cat32();
+    const fn = function foo() { };
+    const sym = Symbol("x");
+    const mapAssignment = c.assign(new Map([
+        ["fn", fn],
+        ["sym", sym],
+    ]));
+    const objectAssignment = c.assign({ fn, sym });
+    assert.equal(mapAssignment.key, objectAssignment.key);
+    assert.equal(mapAssignment.hash, objectAssignment.hash);
+});
 test("Map string sentinel key matches object property", () => {
     const c = new Cat32();
     const mapAssignment = c.assign(new Map([["__undefined__", 1]]));

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -7,6 +7,7 @@
 const SENTINEL_PREFIX = "\u0000cat32:";
 const SENTINEL_SUFFIX = "\u0000";
 const HOLE_SENTINEL = JSON.stringify(typeSentinel("hole"));
+const STRING_SENTINEL_PREFIX = `${SENTINEL_PREFIX}string:`;
 const UNDEFINED_SENTINEL = "__undefined__";
 const DATE_SENTINEL_PREFIX = "__date__:";
 const BIGINT_SENTINEL_PREFIX = "__bigint__:";
@@ -74,20 +75,19 @@ function _stringify(v: unknown, stack: Set<any>): string {
   if (v instanceof Map) {
     if (stack.has(v)) throw new TypeError("Cyclic object");
     stack.add(v);
-    const normalizedEntries = new Map<string, unknown>();
+    const normalizedEntries = new Map<string, string>();
     for (const [rawKey, rawValue] of v.entries()) {
       const serializedKey = _stringify(rawKey, stack);
       const revivedKey = reviveFromSerialized(serializedKey);
       const propertyKey = toPropertyKeyString(revivedKey, serializedKey);
       const serializedValue = _stringify(rawValue, stack);
-      const revivedValue = reviveFromSerialized(serializedValue);
-      normalizedEntries.set(propertyKey, revivedValue);
+      normalizedEntries.set(propertyKey, serializedValue);
     }
     const keys = Array.from(normalizedEntries.keys()).sort();
     const body = keys
       .map((key) => {
-        const revivedValue = normalizedEntries.get(key)!;
-        return JSON.stringify(key) + ":" + JSON.stringify(revivedValue);
+        const serializedValue = normalizedEntries.get(key)!;
+        return JSON.stringify(key) + ":" + serializedValue;
       })
       .join(",");
     stack.delete(v);

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -482,6 +482,23 @@ test("Map keys match plain object representation regardless of entry order", () 
   assert.equal(duplicateKeyMapAssignment.hash, duplicateKeyObjectAssignment.hash);
 });
 
+test("Map values serialize identically to plain object values", () => {
+  const c = new Cat32();
+  const fn = function foo() {};
+  const sym = Symbol("x");
+
+  const mapAssignment = c.assign(
+    new Map<string, unknown>([
+      ["fn", fn],
+      ["sym", sym],
+    ]),
+  );
+  const objectAssignment = c.assign({ fn, sym });
+
+  assert.equal(mapAssignment.key, objectAssignment.key);
+  assert.equal(mapAssignment.hash, objectAssignment.hash);
+});
+
 test("Map string sentinel key matches object property", () => {
   const c = new Cat32();
   const mapAssignment = c.assign(new Map([["__undefined__", 1]]));


### PR DESCRIPTION
## Summary
- add regression coverage to ensure Map values with functions and symbols match plain object serialization
- refactor Map serialization to reuse pre-stringified values when building normalized entries
- mirror the updated logic in the distributed bundles

## Testing
- npm run build
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68ef75785cb08321ab1ea3da73aa0a21