### PR TITLE
Add canonical key assertions for primitives

### DIFF
--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -308,10 +308,16 @@ test("top-level bigint canonical key uses bigint prefix", () => {
 });
 test("canonical key for primitives uses stable stringify", () => {
     const c = new Cat32();
-    assert.equal(c.assign("foo").key, stableStringify("foo"));
-    assert.equal(c.assign(1n).key, stableStringify(1n));
-    assert.equal(c.assign(Number.NaN).key, stableStringify(Number.NaN));
-    assert.equal(c.assign(Symbol("x")).key, stableStringify(Symbol("x")));
+    const stringValue = "foo";
+    const numberValue = 123;
+    const bigintValue = 1n;
+    const nanValue = Number.NaN;
+    const symbolValue = Symbol("x");
+    assert.equal(c.assign(stringValue).key, stableStringify(stringValue));
+    assert.equal(c.assign(numberValue).key, stableStringify(numberValue));
+    assert.equal(c.assign(bigintValue).key, stableStringify(bigintValue));
+    assert.equal(c.assign(nanValue).key, stableStringify(nanValue));
+    assert.equal(c.assign(symbolValue).key, stableStringify(symbolValue));
 });
 test("bigint sentinel string differs from bigint value", () => {
     const c = new Cat32();

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -287,6 +287,18 @@ test("canonical key encodes date sentinel", () => {
 
 test("canonical key matches stableStringify for basic primitives", () => {
   const c = new Cat32({ normalize: "none" });
+
+  const stringValue = "foo";
+  const numberValue = 123;
+  const bigintValue = 1n;
+  const nanValue = Number.NaN;
+  const symbolValue = Symbol("x");
+
+  assert.equal(c.assign(stringValue).key, stableStringify(stringValue));
+  assert.equal(c.assign(numberValue).key, stableStringify(numberValue));
+  assert.equal(c.assign(bigintValue).key, stableStringify(bigintValue));
+  assert.equal(c.assign(nanValue).key, stableStringify(nanValue));
+  assert.equal(c.assign(symbolValue).key, stableStringify(symbolValue));
 });
 
 test("functions and symbols serialize to bare strings", () => {


### PR DESCRIPTION
## Summary
- extend the primitive canonical key test to assert Cat32 keys match stableStringify for string, number, bigint, NaN, and symbol inputs
- mirror the strengthened primitive key test in the distributed test suite

## Testing
- node --test --test-name-pattern "canonical key matches stableStringify for basic primitives"

------
https://chatgpt.com/codex/tasks/task_e_68ef7a0f0d008321802b7ccbd51130e1