### PR TITLE
Add canonical key override test and normalize override keys

### DIFF
--- a/dist/categorizer.js
+++ b/dist/categorizer.js
@@ -25,7 +25,7 @@ export class Cat32 {
         this.overrides = new Map();
         if (opts.overrides) {
             for (const [rawKey, v] of Object.entries(opts.overrides)) {
-                const k = this.canonicalKey(rawKey);
+                const k = this.normalizeCanonicalKey(rawKey);
                 if (typeof v === "number") {
                     this.overrides.set(k, this.normalizeIndex(v));
                 }
@@ -62,13 +62,16 @@ export class Cat32 {
     }
     canonicalKey(input) {
         const serialized = stableStringify(input);
+        return this.normalizeCanonicalKey(serialized);
+    }
+    normalizeCanonicalKey(key) {
         switch (this.normalize) {
             case "nfc":
-                return serialized.normalize("NFC");
+                return key.normalize("NFC");
             case "nfkc":
-                return serialized.normalize("NFKC");
+                return key.normalize("NFKC");
             default:
-                return serialized;
+                return key;
         }
     }
     normalizeIndex(i) {

--- a/dist/src/categorizer.js
+++ b/dist/src/categorizer.js
@@ -25,7 +25,7 @@ export class Cat32 {
         this.overrides = new Map();
         if (opts.overrides) {
             for (const [rawKey, v] of Object.entries(opts.overrides)) {
-                const k = this.canonicalKey(rawKey);
+                const k = this.normalizeCanonicalKey(rawKey);
                 if (typeof v === "number") {
                     this.overrides.set(k, this.normalizeIndex(v));
                 }
@@ -62,13 +62,16 @@ export class Cat32 {
     }
     canonicalKey(input) {
         const serialized = stableStringify(input);
+        return this.normalizeCanonicalKey(serialized);
+    }
+    normalizeCanonicalKey(key) {
         switch (this.normalize) {
             case "nfc":
-                return serialized.normalize("NFC");
+                return key.normalize("NFC");
             case "nfkc":
-                return serialized.normalize("NFKC");
+                return key.normalize("NFKC");
             default:
-                return serialized;
+                return key;
         }
     }
     normalizeIndex(i) {

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -162,6 +162,17 @@ test("override by label", () => {
     assert.equal(a.index, 31);
     assert.equal(a.label, "L31");
 });
+test("override accepts canonical key strings", () => {
+    const overrides = {
+        [stableStringify(123)]: 5,
+        [stableStringify(undefined)]: 6,
+        [stableStringify(true)]: 7,
+    };
+    const c = new Cat32({ overrides });
+    assert.equal(c.assign(123).index, 5);
+    assert.equal(c.assign(undefined).index, 6);
+    assert.equal(c.assign(true).index, 7);
+});
 test("override rejects NaN with explicit error", () => {
     assert.throws(() => new Cat32({ overrides: { foo: Number.NaN } }), (error) => error instanceof Error && error.message === "index out of range: NaN");
 });


### PR DESCRIPTION
## Summary
- normalize override map lookups in the dist Cat32 build via the existing canonical key normalization helper
- add a regression test in the distribution test suite to ensure overrides work when keyed by stableStringify outputs

## Testing
- node --test dist/tests *(fails: known assertions around sentinel string handling remain failing in the baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68ef7a0e22808321837c72a49abd99b9