### PR TITLE
Ensure sentinel strings serialize identically to literal values

### DIFF
--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -468,6 +468,25 @@ test("values containing __string__ escape exactly once", () => {
   assert.equal(stableStringify(escaped), escaped);
 });
 
+test("undefined sentinel string matches literal undefined in arrays", () => {
+  const c = new Cat32();
+  const sentinelAssignment = c.assign({ list: ["__undefined__"] });
+  const literalAssignment = c.assign({ list: [undefined] });
+
+  assert.equal(sentinelAssignment.key, literalAssignment.key);
+  assert.equal(sentinelAssignment.hash, literalAssignment.hash);
+});
+
+test("date sentinel string matches Date instance in arrays", () => {
+  const c = new Cat32();
+  const iso = "2024-04-01T12:34:56.789Z";
+  const sentinelAssignment = c.assign({ list: [`__date__:${iso}`] });
+  const literalAssignment = c.assign({ list: [new Date(iso)] });
+
+  assert.equal(sentinelAssignment.key, literalAssignment.key);
+  assert.equal(sentinelAssignment.hash, literalAssignment.hash);
+});
+
 test("Map keys match plain object representation regardless of entry order", () => {
   const c = new Cat32();
   const map = new Map<string, number>([


### PR DESCRIPTION
## Summary
- add coverage to confirm sentinel literals in arrays hash the same as their literal counterparts
- centralize string serialization helpers so generated sentinel strings are JSON stringified consistently

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68ef7f2e43088321976dbefae645d642