### PR TITLE
Add tests for sentinel serialization and guard helper

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -141,6 +141,9 @@ function stringifyStringLiteral(value: string): string {
 }
 
 function stringifySentinelLiteral(value: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError("Sentinel literal must be a string");
+  }
   return JSON.stringify(value);
 }
 

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -453,6 +453,23 @@ test("stableStringify leaves sentinel-like strings untouched", () => {
   assert.equal(stableStringify("__undefined__"), JSON.stringify("__undefined__"));
 });
 
+test("stableStringify serializes undefined and Date sentinels", () => {
+  const iso = "2024-01-02T03:04:05.678Z";
+
+  assert.equal(stableStringify(undefined), JSON.stringify("__undefined__"));
+  assert.equal(stableStringify(new Date(iso)), JSON.stringify(`__date__:${iso}`));
+});
+
+test("Cat32 assign handles undefined and Date literals", () => {
+  const cat = new Cat32();
+  const iso = "2024-01-02T03:04:05.678Z";
+
+  assert.doesNotThrow(() => {
+    cat.assign(undefined);
+    cat.assign(new Date(iso));
+  });
+});
+
 test("stableStringify uses String() for functions and symbols", () => {
   const fn = function foo() {};
   const sym = Symbol("x");


### PR DESCRIPTION
## Summary
- add coverage for undefined/date sentinel serialization and Cat32.assign usage
- enforce string inputs for stringifySentinelLiteral before JSON encoding

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68efc982ff8c8321b51f2e8ab8988b7f