### PR TITLE
Fix Map numeric sentinel normalization

### DIFF
--- a/dist/serialize.js
+++ b/dist/serialize.js
@@ -140,20 +140,44 @@ function stringifySentinelLiteral(value) {
 }
 function reviveFromSerialized(serialized) {
     try {
-        const parsed = JSON.parse(serialized);
-        if (typeof parsed === "string" &&
-            parsed.startsWith(STRING_SENTINEL_PREFIX) &&
-            parsed.endsWith(SENTINEL_SUFFIX)) {
-            return parsed.slice(STRING_SENTINEL_PREFIX.length, -SENTINEL_SUFFIX.length);
-        }
-        return parsed;
+        return reviveSentinelValue(JSON.parse(serialized));
     }
     catch {
-        if (serialized.startsWith(STRING_SENTINEL_PREFIX) && serialized.endsWith(SENTINEL_SUFFIX)) {
-            return serialized.slice(STRING_SENTINEL_PREFIX.length, -SENTINEL_SUFFIX.length);
-        }
-        return serialized;
+        return reviveSentinelValue(serialized);
     }
+}
+function reviveSentinelValue(value) {
+    if (typeof value === "string" &&
+        value.startsWith(SENTINEL_PREFIX) &&
+        value.endsWith(SENTINEL_SUFFIX)) {
+        const inner = value.slice(SENTINEL_PREFIX.length, -SENTINEL_SUFFIX.length);
+        const separatorIndex = inner.indexOf(":");
+        if (separatorIndex !== -1) {
+            const type = inner.slice(0, separatorIndex);
+            const payload = inner.slice(separatorIndex + 1);
+            if (type === "string") {
+                return payload;
+            }
+            if (type === "number") {
+                if (payload === "Infinity")
+                    return Number.POSITIVE_INFINITY;
+                if (payload === "-Infinity")
+                    return Number.NEGATIVE_INFINITY;
+                if (payload === "NaN")
+                    return Number.NaN;
+                return Number(payload);
+            }
+            if (type === "bigint") {
+                try {
+                    return BigInt(payload);
+                }
+                catch {
+                    return value;
+                }
+            }
+        }
+    }
+    return value;
 }
 function toPropertyKeyString(value, fallback) {
     if (value === null)

--- a/dist/src/serialize.js
+++ b/dist/src/serialize.js
@@ -140,20 +140,44 @@ function stringifySentinelLiteral(value) {
 }
 function reviveFromSerialized(serialized) {
     try {
-        const parsed = JSON.parse(serialized);
-        if (typeof parsed === "string" &&
-            parsed.startsWith(STRING_SENTINEL_PREFIX) &&
-            parsed.endsWith(SENTINEL_SUFFIX)) {
-            return parsed.slice(STRING_SENTINEL_PREFIX.length, -SENTINEL_SUFFIX.length);
-        }
-        return parsed;
+        return reviveSentinelValue(JSON.parse(serialized));
     }
     catch {
-        if (serialized.startsWith(STRING_SENTINEL_PREFIX) && serialized.endsWith(SENTINEL_SUFFIX)) {
-            return serialized.slice(STRING_SENTINEL_PREFIX.length, -SENTINEL_SUFFIX.length);
-        }
-        return serialized;
+        return reviveSentinelValue(serialized);
     }
+}
+function reviveSentinelValue(value) {
+    if (typeof value === "string" &&
+        value.startsWith(SENTINEL_PREFIX) &&
+        value.endsWith(SENTINEL_SUFFIX)) {
+        const inner = value.slice(SENTINEL_PREFIX.length, -SENTINEL_SUFFIX.length);
+        const separatorIndex = inner.indexOf(":");
+        if (separatorIndex !== -1) {
+            const type = inner.slice(0, separatorIndex);
+            const payload = inner.slice(separatorIndex + 1);
+            if (type === "string") {
+                return payload;
+            }
+            if (type === "number") {
+                if (payload === "Infinity")
+                    return Number.POSITIVE_INFINITY;
+                if (payload === "-Infinity")
+                    return Number.NEGATIVE_INFINITY;
+                if (payload === "NaN")
+                    return Number.NaN;
+                return Number(payload);
+            }
+            if (type === "bigint") {
+                try {
+                    return BigInt(payload);
+                }
+                catch {
+                    return value;
+                }
+            }
+        }
+    }
+    return value;
 }
 function toPropertyKeyString(value, fallback) {
     if (value === null)

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -69,6 +69,17 @@ test("Cat32 assigns distinct keys for sets with mixed primitive types", () => {
     assert.ok(mixedSet.key !== numericSet.key);
     assert.ok(mixedSet.hash !== numericSet.hash);
 });
+test("Cat32 normalizes Map keys with special numeric values", () => {
+    const cat = new Cat32();
+    const mapNaN = cat.assign(new Map([[Number.NaN, "v"]]));
+    const objectNaN = cat.assign({ NaN: "v" });
+    assert.equal(mapNaN.key, objectNaN.key);
+    assert.equal(mapNaN.hash, objectNaN.hash);
+    const mapInfinity = cat.assign(new Map([[Infinity, "v"]]));
+    const objectInfinity = cat.assign({ Infinity: "v" });
+    assert.equal(mapInfinity.key, objectInfinity.key);
+    assert.equal(mapInfinity.hash, objectInfinity.hash);
+});
 test("dist entry point exports Cat32", async () => {
     const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
         ? new URL("../../tests/categorizer.test.ts", import.meta.url)

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -153,6 +153,20 @@ test("Cat32 assigns distinct keys for sets with mixed primitive types", () => {
   assert.ok(mixedSet.hash !== numericSet.hash);
 });
 
+test("Cat32 normalizes Map keys with special numeric values", () => {
+  const cat = new Cat32();
+
+  const mapNaN = cat.assign(new Map([[Number.NaN, "v"]]));
+  const objectNaN = cat.assign({ NaN: "v" });
+  assert.equal(mapNaN.key, objectNaN.key);
+  assert.equal(mapNaN.hash, objectNaN.hash);
+
+  const mapInfinity = cat.assign(new Map([[Infinity, "v"]]));
+  const objectInfinity = cat.assign({ Infinity: "v" });
+  assert.equal(mapInfinity.key, objectInfinity.key);
+  assert.equal(mapInfinity.hash, objectInfinity.hash);
+});
+
 test("dist entry point exports Cat32", async () => {
   const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
     ? new URL("../../tests/categorizer.test.ts", import.meta.url)


### PR DESCRIPTION
## Summary
- add regression coverage asserting Map keys with NaN/Infinity normalize to the same identifiers as plain objects
- convert number/bigint sentinel strings back to their primitive values before building Map property key strings
- rebuild the distributed bundles to include the updated serializer logic and tests

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68efcf3b189c8321b74230abcae07756