### PR TITLE
Update README overrides example to use canonical keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,22 @@ npm i deterministic-32
 ## Usage (Library)
 ```ts
 import { Cat32 } from "deterministic-32";
+import { stableStringify } from "deterministic-32/dist/serialize.js";
 
 const cat = new Cat32({
   salt: "projectX",
   namespace: "v1",
-  // labels: Array(32).fill(0).map((_,i)=>`B${i}`),  // optional
-  // overrides: { "vip-user": 0, "audited": "A" },   // pin by index or label
+  // labels: Array(32).fill(0).map((_, i) => `B${i}`),  // optional
+  overrides: {
+    [stableStringify("vip-user")]: 0,                // pin by index
+    [stableStringify({ audited: true })]: "A",       // or by label
+  },
 });
 
 cat.index("ユーザーID:123");     // -> 0..31
 cat.labelOf({ id: 1 });          // -> "A".."Z","0".."5"
 cat.assign("hello");
-// -> { index: 5, label: "F", hash: "a1b2c3d4", key: "<canonicalized>" }
+// -> { index: 5, label: "F", hash: "a1b2c3d4", key: stableStringify("hello") }
 ```
 
 ## CLI

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -257,6 +257,22 @@ test("override by label", () => {
     assert.equal(a.index, 31);
     assert.equal(a.label, "L31");
 });
+test("README override example uses canonical keys", () => {
+    const c = new Cat32({
+        salt: "projectX",
+        namespace: "v1",
+        overrides: {
+            [stableStringify("vip-user")]: 0,
+            [stableStringify({ audited: true })]: "A",
+        },
+    });
+    const vip = c.assign("vip-user");
+    assert.equal(vip.index, 0);
+    assert.equal(vip.key, stableStringify("vip-user"));
+    const audited = c.assign({ audited: true });
+    assert.equal(audited.label, "A");
+    assert.equal(audited.key, stableStringify({ audited: true }));
+});
 test("override rejects NaN with explicit error", () => {
     assert.throws(() => new Cat32({ overrides: { foo: Number.NaN } }), (error) => error instanceof Error && error.message === "index out of range: NaN");
 });
@@ -314,6 +330,17 @@ test("NaN serialized distinctly from null", () => {
 });
 test("stableStringify leaves sentinel-like strings untouched", () => {
     assert.equal(stableStringify("__undefined__"), JSON.stringify("__undefined__"));
+});
+test("stableStringify serializes undefined and Date sentinels", () => {
+    const iso = "2024-01-02T03:04:05.678Z";
+    assert.equal(stableStringify(undefined), JSON.stringify("__undefined__"));
+    assert.equal(stableStringify(new Date(iso)), JSON.stringify(`__date__:${iso}`));
+});
+test("Cat32 assign handles undefined and Date literals", () => {
+    const cat = new Cat32();
+    const iso = "2024-01-02T03:04:05.678Z";
+    cat.assign(undefined);
+    cat.assign(new Date(iso));
 });
 test("stableStringify uses String() for functions and symbols", () => {
     const fn = function foo() { };

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ export interface CategorizerOptions {
   namespace?: string;
   labels?: string[];            // length === 32
   normalize?: NormalizeMode;    // default "nfkc"
-  overrides?: Record<string, number | string>;
+  overrides?: Record<string, number | string>;  // use Cat32.assign(...).key or stableStringify(...) for keys
 }
 
 export interface Assignment {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -386,6 +386,25 @@ test("override by label", () => {
   assert.equal(a.label, "L31");
 });
 
+test("README override example uses canonical keys", () => {
+  const c = new Cat32({
+    salt: "projectX",
+    namespace: "v1",
+    overrides: {
+      [stableStringify("vip-user")]: 0,
+      [stableStringify({ audited: true })]: "A",
+    },
+  });
+
+  const vip = c.assign("vip-user");
+  assert.equal(vip.index, 0);
+  assert.equal(vip.key, stableStringify("vip-user"));
+
+  const audited = c.assign({ audited: true });
+  assert.equal(audited.label, "A");
+  assert.equal(audited.key, stableStringify({ audited: true }));
+});
+
 test("override rejects NaN with explicit error", () => {
   assert.throws(
     () => new Cat32({ overrides: { foo: Number.NaN as any } }),
@@ -478,10 +497,8 @@ test("Cat32 assign handles undefined and Date literals", () => {
   const cat = new Cat32();
   const iso = "2024-01-02T03:04:05.678Z";
 
-  assert.doesNotThrow(() => {
-    cat.assign(undefined);
-    cat.assign(new Date(iso));
-  });
+  cat.assign(undefined);
+  cat.assign(new Date(iso));
 });
 
 test("stableStringify uses String() for functions and symbols", () => {


### PR DESCRIPTION
## Summary
- document using canonical override keys via `stableStringify` in the README usage example
- clarify in the API reference that `overrides` keys should come from `Cat32.assign(...).key` or `stableStringify`
- add a smoke test that mirrors the README override example and adjust an existing test to avoid `assert.doesNotThrow`

## Testing
- npm run build
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68efdba4625483219c225fe4ac9b9a42