### PR TITLE
Fix reflection workflow artifact download

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           name: test-logs
           path: logs
+          run-id: ${{ github.event.workflow_run.id }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- add the triggering workflow run ID when downloading artifacts in the reflection workflow so that the correct test logs are retrieved

## Testing
- not run (CI workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68efe41d6af483219de52b3760efcec1