### PR TITLE
docs: clarify override canonical keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,15 @@ npm i deterministic-32
 ```ts
 import { Cat32, stableStringify } from "deterministic-32";
 
-const base = new Cat32({
-  salt: "projectX",
-  namespace: "v1",
-  // labels: Array(32).fill(0).map((_, i) => `B${i}`),  // optional
-});
-
 const overrides = {
   [stableStringify("vip-user")]: 0,              // canonical key via stable stringify
-  [base.assign({ id: "audited" }).key]: "A",    // canonical key via assign().key
+  [stableStringify({ id: "audited" })]: "A",    // canonical key via stable stringify
 };
 
 const cat = new Cat32({
   salt: "projectX",
   namespace: "v1",
+  // labels: Array(32).fill(0).map((_, i) => `B${i}`),  // optional
   overrides,
 });
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,3 +37,7 @@ const cat = new Cat32({ salt: "projX", namespace: "v1" });
 const a = cat.assign({ id: 1, tags: ["a", "b"] });
 // a = { index, label, hash, key }
 ```
+
+### overrides の canonical key 取得
+
+`overrides` のキーには `stableStringify(value)` で得た canonical key を渡してください。`Cat32.assign(value).key` でも同じ結果を得られますが、`overrides` 用に事前計算する場合は `stableStringify` のみで十分です（constructor 側で `normalize` が再適用されます）。

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -414,11 +414,9 @@ test("override by label", () => {
 });
 
 test("README library example overrides use canonical keys", () => {
-  const base = new Cat32({ salt: "projectX", namespace: "v1" });
-
   const overrides = {
     [stableStringify("vip-user")]: 0,
-    [base.assign({ id: "audited" }).key]: "A",
+    [stableStringify({ id: "audited" })]: "A",
   } as const;
 
   const cat = new Cat32({


### PR DESCRIPTION
## Summary
- update the README override example to supply canonical keys produced by `stableStringify`
- document how to obtain canonical keys for `overrides` in the TypeScript API guide
- align the README smoke test with the updated example

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68eff41748e48321956343af73b158fe