### PR TITLE
Handle CLI double dash literal key

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -4,6 +4,19 @@ function parseArgs(argv) {
     const args = {};
     for (let i = 2; i < argv.length; i++) {
         const a = argv[i];
+        if (a === "--") {
+            const rest = argv.slice(i + 1);
+            if (rest.length > 0) {
+                const remainder = rest.join(" ");
+                if (Object.prototype.hasOwnProperty.call(args, "_")) {
+                    args._ = `${args._} ${remainder}`;
+                }
+                else {
+                    args._ = remainder;
+                }
+            }
+            break;
+        }
         if (a.startsWith("--")) {
             const eq = a.indexOf("=");
             if (eq >= 0) {

--- a/dist/src/cli.js
+++ b/dist/src/cli.js
@@ -4,6 +4,19 @@ function parseArgs(argv) {
     const args = {};
     for (let i = 2; i < argv.length; i++) {
         const a = argv[i];
+        if (a === "--") {
+            const rest = argv.slice(i + 1);
+            if (rest.length > 0) {
+                const remainder = rest.join(" ");
+                if (Object.prototype.hasOwnProperty.call(args, "_")) {
+                    args._ = `${args._} ${remainder}`;
+                }
+                else {
+                    args._ = remainder;
+                }
+            }
+            break;
+        }
         if (a.startsWith("--")) {
             const eq = a.indexOf("=");
             if (eq >= 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,18 @@ function parseArgs(argv: string[]) {
   const args: Record<string, string | true> = {};
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
+    if (a === "--") {
+      const rest = argv.slice(i + 1);
+      if (rest.length > 0) {
+        const remainder = rest.join(" ");
+        if (Object.prototype.hasOwnProperty.call(args, "_")) {
+          (args as { _: string })._ = `${(args as { _: string })._} ${remainder}`;
+        } else {
+          (args as { _: string })._ = remainder;
+        }
+      }
+      break;
+    }
     if (a.startsWith("--")) {
       const eq = a.indexOf("=");
       if (eq >= 0) {


### PR DESCRIPTION
## Summary
- add regression test that spawns the CLI via `cat32 -- --literal-key` and asserts the canonical key matches the literal value
- update CLI argument parsing to terminate option processing at `--` and treat remaining tokens as positional text
- sync compiled artifacts with the new test and parser behavior

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68eff41b08008321b67707f6d9025213