### PR TITLE
Handle enumerable symbol keys in stableStringify

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -121,11 +121,43 @@ function _stringify(v: unknown, stack: Set<any>): string {
   const o = v as Record<string, unknown>;
   if (stack.has(o)) throw new TypeError("Cyclic object");
   stack.add(o);
-  const keys = Object.keys(o).sort();
-  const body = keys.map((k) => {
-    const normalizedKey = normalizePlainObjectKey(k);
-    return JSON.stringify(normalizedKey) + ":" + _stringify(o[k], stack);
+  const target = o as Record<PropertyKey, unknown>;
+  const enumerableSymbols = Object.getOwnPropertySymbols(o).filter((symbol) =>
+    Object.prototype.propertyIsEnumerable.call(o, symbol),
+  );
+
+  const entries: Array<{
+    sortKey: string;
+    normalizedKey: string;
+    property: PropertyKey;
+  }> = [];
+
+  for (const key of Object.keys(o)) {
+    entries.push({
+      sortKey: key,
+      normalizedKey: normalizePlainObjectKey(key),
+      property: key,
+    });
+  }
+
+  for (const symbol of enumerableSymbols) {
+    const symbolString = toPropertyKeyString(symbol, symbol.toString());
+    entries.push({
+      sortKey: symbolString,
+      normalizedKey: symbolString,
+      property: symbol,
+    });
+  }
+
+  entries.sort((a, b) => {
+    if (a.sortKey < b.sortKey) return -1;
+    if (a.sortKey > b.sortKey) return 1;
+    return 0;
   });
+
+  const body = entries.map(({ normalizedKey, property }) =>
+    JSON.stringify(normalizedKey) + ":" + _stringify(target[property], stack),
+  );
   stack.delete(o);
   return "{" + body.join(",") + "}";
 }


### PR DESCRIPTION
## Summary
- add coverage for enumerable Symbol keys on plain objects to ensure hashes align with equivalent Maps
- include enumerable Symbol keys when serializing plain objects so stableStringify matches Map behavior

## Testing
- npm run build
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68effb10c5e88321a028b44083d21522