### PR TITLE
Remove duplicate CLI literal key script constant in tests

### DIFF
--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -68,12 +68,6 @@ const CLI_LITERAL_KEY_SCRIPT = [
   "})();",
 ].join("\n");
 
-const CLI_LITERAL_KEY_SCRIPT = [
-  "const cliPath = process.argv.at(-1);",
-  "process.argv = [process.argv[0], cliPath, '--', '--literal-key'];",
-  "import(cliPath).catch((error) => { console.error(error); process.exit(1); });",
-].join(" ");
-
 test("dist build re-exports stableStringify", async () => {
   const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
     ? new URL("../../tests/categorizer.test.ts", import.meta.url)


### PR DESCRIPTION
## Summary
- remove the duplicate CLI literal key script definition from the categorizer CLI tests to avoid conflicting const declarations

## Testing
- npm run build
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f002f324048321afbdb7ccc82ade8a