### PR TITLE
Fix Map bucket serialization stability

### DIFF
--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -128,6 +128,21 @@ test("dist stableStringify handles Map bucket ordering", async () => {
   );
 });
 
+test("stableStringify maps simple entries without throwing", () => {
+  const map = new Map([["k", 1]]);
+  const result = stableStringify(map);
+  assert.equal(result, "{\"k\":1}");
+});
+
+test("Cat32 assign handles Map input deterministically", () => {
+  const instance = new Cat32();
+  const assignment = instance.assign(new Map([["k", 1]]));
+  assert.equal(assignment.index, 23);
+  assert.equal(assignment.label, "X");
+  assert.equal(assignment.hash, "4f77d9b7");
+  assert.equal(assignment.key, "{\"k\":1}");
+});
+
 test("tsc succeeds without duplicate identifier errors", async () => {
   const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
     ? new URL("../../tests/categorizer.test.ts", import.meta.url)


### PR DESCRIPTION
## Summary
- add regression coverage ensuring Map inputs serialize without exceptions and Cat32 handles them deterministically
- simplify Map bucket handling in `stableStringify` by tracking serialized entry arrays and dedupe flags separately

## Testing
- node --test


------
https://chatgpt.com/codex/tasks/task_e_68f08d2a42448321bd7ffe3aca9be189