### PR TITLE
Normalize Map object keys with plain object stringification

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -88,7 +88,7 @@ function _stringify(v: unknown, stack: Set<any>): string {
     for (const [rawKey, rawValue] of v.entries()) {
       const serializedKey = _stringify(rawKey, stack);
       const revivedKey = reviveFromSerialized(serializedKey);
-      const propertyKey = toPropertyKeyString(revivedKey, serializedKey);
+      const propertyKey = toPropertyKeyString(rawKey, revivedKey, serializedKey);
       const serializedValue = _stringify(rawValue, stack);
       const candidate: SerializedEntry = { serializedKey, serializedValue };
       const shouldDedupe = typeof rawKey !== "symbol";
@@ -162,7 +162,7 @@ function _stringify(v: unknown, stack: Set<any>): string {
   }
 
   for (const symbol of enumerableSymbols) {
-    const symbolString = toPropertyKeyString(symbol, symbol.toString());
+    const symbolString = toPropertyKeyString(symbol, symbol, symbol.toString());
     entries.push({
       sortKey: symbolString,
       normalizedKey: symbolString,
@@ -264,31 +264,64 @@ function reviveSentinelValue(value: unknown): unknown {
   return value;
 }
 
-function toPropertyKeyString(value: unknown, fallback: string): string {
-  if (value === null) return "null";
-  const numeric = reviveNumericSentinel(value);
-  if (numeric !== undefined) {
-    return String(numeric);
+function toPropertyKeyString(
+  rawKey: unknown,
+  revivedKey: unknown,
+  serializedKey: string,
+): string {
+  if (typeof rawKey === "symbol") {
+    return (rawKey as symbol).toString();
   }
-  const type = typeof value;
-  if (type === "object" || type === "function") {
-    const fallbackNumeric = reviveNumericSentinel(fallback);
-    if (fallbackNumeric !== undefined) {
-      return String(fallbackNumeric);
+
+  if (rawKey === null) {
+    return "null";
+  }
+
+  const revivedNumeric = reviveNumericSentinel(revivedKey);
+  if (revivedNumeric !== undefined) {
+    return String(revivedNumeric);
+  }
+
+  const fallbackNumeric = reviveNumericSentinel(serializedKey);
+  if (fallbackNumeric !== undefined) {
+    return String(fallbackNumeric);
+  }
+
+  if (rawKey instanceof Date) {
+    if (typeof revivedKey === "string") {
+      return escapeSentinelString(revivedKey);
     }
-    return fallback;
+    return `${DATE_SENTINEL_PREFIX}${rawKey.toISOString()}`;
   }
-  if (type === "symbol") {
-    return (value as symbol).toString();
+
+  const rawType = typeof rawKey;
+  if (rawType === "string") {
+    return normalizePlainObjectKey(rawKey as string);
   }
+
   if (
-    type === "string" &&
-    (value as string).startsWith(STRING_SENTINEL_PREFIX) &&
-    (value as string).endsWith(SENTINEL_SUFFIX)
+    rawType === "number" ||
+    rawType === "bigint" ||
+    rawType === "boolean"
   ) {
-    return (value as string).slice(STRING_SENTINEL_PREFIX.length, -SENTINEL_SUFFIX.length);
+    return String(rawKey);
   }
-  return String(value);
+
+  if (rawType === "undefined") {
+    return "undefined";
+  }
+
+  if (rawType === "object" || rawType === "function") {
+    return normalizePlainObjectKey(String(rawKey));
+  }
+
+  if (typeof revivedKey === "string") {
+    return normalizePlainObjectKey(escapeSentinelString(revivedKey));
+  }
+
+  return normalizePlainObjectKey(
+    escapeSentinelString(String(revivedKey ?? serializedKey)),
+  );
 }
 
 function reviveNumericSentinel(value: unknown): number | bigint | undefined {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -1016,6 +1016,21 @@ test("Map values serialize identically to plain object values", () => {
   assert.equal(mapAssignment.hash, objectAssignment.hash);
 });
 
+test("Map object key matches plain object string key", () => {
+  const obj = { foo: 1 };
+  const map = new Map([[obj, "value"]]);
+  const plainObject = { [String(obj)]: "value" };
+
+  assert.equal(stableStringify(map), stableStringify(plainObject));
+
+  const cat = new Cat32();
+  const mapAssignment = cat.assign(map);
+  const objectAssignment = cat.assign(plainObject);
+
+  assert.equal(mapAssignment.key, objectAssignment.key);
+  assert.equal(mapAssignment.hash, objectAssignment.hash);
+});
+
 test("Map function value matches plain object value", () => {
   const c = new Cat32();
   const fn = function foo() {};


### PR DESCRIPTION
## Summary
- add a regression test covering Map entries keyed by object references
- update Map key normalization to prefer raw key String() output while retaining sentinel handling

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68f09133392483219ddf4ee3955ae3df