### PR TITLE
Require CLI flags to provide values

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -9,7 +9,8 @@ function parseArgs(argv) {
             if (rest.length > 0) {
                 const remainder = rest.join(" ");
                 if (Object.prototype.hasOwnProperty.call(args, "_")) {
-                    args._ = `${args._} ${remainder}`;
+                    const existing = args._;
+                    args._ = existing === undefined ? remainder : `${existing} ${remainder}`;
                 }
                 else {
                     args._ = remainder;
@@ -30,7 +31,7 @@ function parseArgs(argv) {
                     i += 1;
                 }
                 else {
-                    args[key] = true;
+                    throw new RangeError(`flag "${a}" requires a value`);
                 }
             }
         }
@@ -38,7 +39,8 @@ function parseArgs(argv) {
             args._ = a;
         }
         else {
-            args._ = String(args._ + " " + a);
+            const existing = args._;
+            args._ = existing === undefined ? a : `${existing} ${a}`;
         }
     }
     return args;
@@ -46,7 +48,7 @@ function parseArgs(argv) {
 async function main() {
     const args = parseArgs(process.argv);
     const key = Object.prototype.hasOwnProperty.call(args, "_")
-        ? (args._)
+        ? args._
         : undefined;
     const salt = args.salt ?? "";
     const namespace = args.namespace ?? "";

--- a/dist/src/cli.js
+++ b/dist/src/cli.js
@@ -9,7 +9,8 @@ function parseArgs(argv) {
             if (rest.length > 0) {
                 const remainder = rest.join(" ");
                 if (Object.prototype.hasOwnProperty.call(args, "_")) {
-                    args._ = `${args._} ${remainder}`;
+                    const existing = args._;
+                    args._ = existing === undefined ? remainder : `${existing} ${remainder}`;
                 }
                 else {
                     args._ = remainder;
@@ -30,7 +31,7 @@ function parseArgs(argv) {
                     i += 1;
                 }
                 else {
-                    args[key] = true;
+                    throw new RangeError(`flag "${a}" requires a value`);
                 }
             }
         }
@@ -38,7 +39,8 @@ function parseArgs(argv) {
             args._ = a;
         }
         else {
-            args._ = String(args._ + " " + a);
+            const existing = args._;
+            args._ = existing === undefined ? a : `${existing} ${a}`;
         }
     }
     return args;
@@ -46,7 +48,7 @@ function parseArgs(argv) {
 async function main() {
     const args = parseArgs(process.argv);
     const key = Object.prototype.hasOwnProperty.call(args, "_")
-        ? (args._)
+        ? args._
         : undefined;
     const salt = args.salt ?? "";
     const namespace = args.namespace ?? "";

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -351,6 +351,27 @@ test("CLI accepts flag values separated by whitespace", async () => {
     assert.equal(parsed.hash, expected.hash);
     assert.equal(parsed.key, expected.key);
 });
+test("CLI exits with code 2 when --salt is missing a value", async () => {
+    const { spawn } = (await dynamicImport("node:child_process"));
+    const child = spawn(process.argv[0], [CLI_PATH, "--salt"], {
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdin.end();
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+    });
+    const exitCode = await new Promise((resolve) => {
+        child.on("close", (code) => resolve(code));
+    });
+    assert.equal(exitCode, 2, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+});
 test("cat32 binary accepts flag values separated by whitespace", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const child = spawn(process.argv[0], [CLI_BIN_PATH, "--salt", "foo", "bar"], {
@@ -375,6 +396,27 @@ test("cat32 binary accepts flag values separated by whitespace", async () => {
     const expected = new Cat32({ salt: "foo" }).assign("bar");
     assert.equal(parsed.hash, expected.hash);
     assert.equal(parsed.key, expected.key);
+});
+test("cat32 binary exits with code 2 when --namespace is missing a value", async () => {
+    const { spawn } = (await dynamicImport("node:child_process"));
+    const child = spawn(process.argv[0], [CLI_BIN_PATH, "--namespace"], {
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdin.end();
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+    });
+    const exitCode = await new Promise((resolve) => {
+        child.on("close", (code) => resolve(code));
+    });
+    assert.equal(exitCode, 2, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
 });
 const CLI_SET_ASSIGN_SCRIPT = [
     "(async () => {",

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -569,6 +569,38 @@ test("CLI accepts flag values separated by whitespace", async () => {
   assert.equal(parsed.key, expected.key);
 });
 
+test("CLI exits with code 2 when --salt is missing a value", async () => {
+  const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
+
+  const child = spawn(process.argv[0], [CLI_PATH, "--salt"], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  child.stdin.end();
+
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const exitCode: number | null = await new Promise((resolve) => {
+    child.on("close", (code: number | null) => resolve(code));
+  });
+
+  assert.equal(
+    exitCode,
+    2,
+    `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+  );
+});
+
 test("cat32 binary accepts flag values separated by whitespace", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 
@@ -604,6 +636,38 @@ test("cat32 binary accepts flag values separated by whitespace", async () => {
   const expected = new Cat32({ salt: "foo" }).assign("bar");
   assert.equal(parsed.hash, expected.hash);
   assert.equal(parsed.key, expected.key);
+});
+
+test("cat32 binary exits with code 2 when --namespace is missing a value", async () => {
+  const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
+
+  const child = spawn(process.argv[0], [CLI_BIN_PATH, "--namespace"], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  child.stdin.end();
+
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const exitCode: number | null = await new Promise((resolve) => {
+    child.on("close", (code: number | null) => resolve(code));
+  });
+
+  assert.equal(
+    exitCode,
+    2,
+    `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+  );
 });
 
 const CLI_SET_ASSIGN_SCRIPT = [


### PR DESCRIPTION
## Summary
- add CLI coverage expecting exit code 2 when --salt/--namespace flags lack values
- update CLI argument parsing to throw a RangeError if any flag is missing a value so salt/namespace stay strings

## Testing
- npm run build
- node --test
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f0f5a6263c832190f8a7db4210785a