### PR TITLE
Fix string literal sentinel serialization

### DIFF
--- a/dist/serialize.js
+++ b/dist/serialize.js
@@ -19,9 +19,6 @@ export function escapeSentinelString(value) {
     if (isSentinelWrappedString(value) && !value.startsWith(STRING_SENTINEL_PREFIX)) {
         return typeSentinel("string", value);
     }
-    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
-        return typeSentinel("string", value);
-    }
     return value;
 }
 export function stableStringify(v) {
@@ -35,8 +32,14 @@ function _stringify(v, stack) {
     if (v === null)
         return "null";
     const t = typeof v;
-    if (t === "string")
-        return stringifyStringLiteral(v);
+    if (t === "string") {
+        const value = v;
+        if (isSentinelWrappedString(value) &&
+            !value.startsWith(STRING_SENTINEL_PREFIX)) {
+            return stringifyStringLiteral(typeSentinel("string", value));
+        }
+        return stringifyStringLiteral(value);
+    }
     if (t === "number") {
         const value = v;
         if (Number.isNaN(value) || !Number.isFinite(value)) {
@@ -182,15 +185,6 @@ function toMapPropertyKey(rawKey, serializedKey) {
     return toPropertyKeyString(rawKey, revivedKey, serializedKey);
 }
 function stringifyStringLiteral(value) {
-    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
-        return JSON.stringify(typeSentinel("string", value));
-    }
-    if (isSentinelWrappedString(value)) {
-        if (value.startsWith(STRING_SENTINEL_PREFIX)) {
-            return JSON.stringify(value);
-        }
-        return JSON.stringify(typeSentinel("string", value));
-    }
     return JSON.stringify(value);
 }
 function stringifySentinelLiteral(value) {

--- a/dist/src/serialize.js
+++ b/dist/src/serialize.js
@@ -19,9 +19,6 @@ export function escapeSentinelString(value) {
     if (isSentinelWrappedString(value) && !value.startsWith(STRING_SENTINEL_PREFIX)) {
         return typeSentinel("string", value);
     }
-    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
-        return typeSentinel("string", value);
-    }
     return value;
 }
 export function stableStringify(v) {
@@ -35,8 +32,14 @@ function _stringify(v, stack) {
     if (v === null)
         return "null";
     const t = typeof v;
-    if (t === "string")
-        return stringifyStringLiteral(v);
+    if (t === "string") {
+        const value = v;
+        if (isSentinelWrappedString(value) &&
+            !value.startsWith(STRING_SENTINEL_PREFIX)) {
+            return stringifyStringLiteral(typeSentinel("string", value));
+        }
+        return stringifyStringLiteral(value);
+    }
     if (t === "number") {
         const value = v;
         if (Number.isNaN(value) || !Number.isFinite(value)) {
@@ -182,15 +185,6 @@ function toMapPropertyKey(rawKey, serializedKey) {
     return toPropertyKeyString(rawKey, revivedKey, serializedKey);
 }
 function stringifyStringLiteral(value) {
-    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
-        return JSON.stringify(typeSentinel("string", value));
-    }
-    if (isSentinelWrappedString(value)) {
-        if (value.startsWith(STRING_SENTINEL_PREFIX)) {
-            return JSON.stringify(value);
-        }
-        return JSON.stringify(typeSentinel("string", value));
-    }
     return JSON.stringify(value);
 }
 function stringifySentinelLiteral(value) {

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -27,14 +27,21 @@ test("direct dist import exposes stableStringify", async () => {
     const distModule = (await import("../dist/index.js"));
     assert.equal(typeof distModule.stableStringify, "function");
 });
-test("dist stableStringify wraps string literal sentinels", async () => {
+test("dist stableStringify matches JSON.stringify for string literals", async () => {
     const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
         ? new URL("../../tests/categorizer.test.ts", import.meta.url)
         : import.meta.url;
     const distSerializeModule = (await import(new URL("../dist/serialize.js", sourceImportMetaUrl).href));
     assert.equal(typeof distSerializeModule.stableStringify, "function");
     const distStableStringify = distSerializeModule.stableStringify;
-    assert.equal(distStableStringify("__string__:payload"), JSON.stringify(typeSentinel("string", "__string__:payload")));
+    assert.equal(distStableStringify("__string__:payload"), JSON.stringify("__string__:payload"));
+});
+test("stableStringify matches JSON.stringify for string literals", () => {
+    assert.equal(stableStringify("__string__:payload"), JSON.stringify("__string__:payload"));
+});
+test("Cat32 assign key matches JSON.stringify for string literals", () => {
+    const assignment = new Cat32().assign("__string__:payload");
+    assert.equal(assignment.key, JSON.stringify("__string__:payload"));
 });
 test("dist stableStringify handles Map bucket ordering", async () => {
     const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
@@ -594,7 +601,7 @@ test("stableStringify serializes undefined and Date sentinels", () => {
 test("stableStringify serializes string literal sentinels as JSON strings", () => {
     const literal = "__string__:payload";
     const serialized = stableStringify(literal);
-    const expected = JSON.stringify(typeSentinel("string", literal));
+    const expected = JSON.stringify(literal);
     assert.equal(serialized, expected);
     const cat = new Cat32();
     const assignment = cat.assign(literal);
@@ -623,9 +630,9 @@ test("string sentinel literals remain literal canonical keys", () => {
     const assignment = new Cat32().assign("__date__:2024-01-01Z");
     assert.equal(assignment.key, stableStringify("__date__:2024-01-01Z"));
 });
-test("escapeSentinelString wraps string literal sentinel prefix", () => {
+test("escapeSentinelString leaves string literal sentinel prefix untouched", () => {
     const sentinelLike = "__string__:wrapped";
-    assert.equal(escapeSentinelString(sentinelLike), typeSentinel("string", sentinelLike));
+    assert.equal(escapeSentinelString(sentinelLike), sentinelLike);
 });
 test("stableStringify serializes explicit string sentinels", () => {
     const sentinel = typeSentinel("string", "already-wrapped");
@@ -635,10 +642,8 @@ test("stableStringify serializes explicit string sentinels", () => {
 test("values containing __string__ escape exactly once", () => {
     const literal = "__string__:payload";
     const sentinel = typeSentinel("string", literal);
-    const serialized = stableStringify(literal);
-    const expected = JSON.stringify(sentinel);
-    assert.equal(serialized, expected);
-    assert.equal(stableStringify(sentinel), expected);
+    assert.equal(stableStringify(literal), JSON.stringify(literal));
+    assert.equal(stableStringify(sentinel), JSON.stringify(sentinel));
 });
 test("undefined sentinel string matches literal undefined in arrays", () => {
     const c = new Cat32();

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -22,9 +22,6 @@ export function escapeSentinelString(value: string): string {
   if (isSentinelWrappedString(value) && !value.startsWith(STRING_SENTINEL_PREFIX)) {
     return typeSentinel("string", value);
   }
-  if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
-    return typeSentinel("string", value);
-  }
   return value;
 }
 
@@ -41,7 +38,16 @@ function _stringify(v: unknown, stack: Set<any>): string {
   if (v === null) return "null";
   const t = typeof v;
 
-  if (t === "string") return stringifyStringLiteral(v as string);
+  if (t === "string") {
+    const value = v as string;
+    if (
+      isSentinelWrappedString(value) &&
+      !value.startsWith(STRING_SENTINEL_PREFIX)
+    ) {
+      return stringifyStringLiteral(typeSentinel("string", value));
+    }
+    return stringifyStringLiteral(value);
+  }
   if (t === "number") {
     const value = v as number;
     if (Number.isNaN(value) || !Number.isFinite(value)) {
@@ -199,15 +205,6 @@ function toMapPropertyKey(rawKey: unknown, serializedKey: string): string {
 }
 
 function stringifyStringLiteral(value: string): string {
-  if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
-    return JSON.stringify(typeSentinel("string", value));
-  }
-  if (isSentinelWrappedString(value)) {
-    if (value.startsWith(STRING_SENTINEL_PREFIX)) {
-      return JSON.stringify(value);
-    }
-    return JSON.stringify(typeSentinel("string", value));
-  }
   return JSON.stringify(value);
 }
 

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -84,7 +84,7 @@ test("direct dist import exposes stableStringify", async () => {
   assert.equal(typeof distModule.stableStringify, "function");
 });
 
-test("dist stableStringify wraps string literal sentinels", async () => {
+test("dist stableStringify matches JSON.stringify for string literals", async () => {
   const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
     ? new URL("../../tests/categorizer.test.ts", import.meta.url)
     : import.meta.url;
@@ -98,8 +98,20 @@ test("dist stableStringify wraps string literal sentinels", async () => {
 
   assert.equal(
     distStableStringify("__string__:payload"),
-    JSON.stringify(typeSentinel("string", "__string__:payload")),
+    JSON.stringify("__string__:payload"),
   );
+});
+
+test("stableStringify matches JSON.stringify for string literals", () => {
+  assert.equal(
+    stableStringify("__string__:payload"),
+    JSON.stringify("__string__:payload"),
+  );
+});
+
+test("Cat32 assign key matches JSON.stringify for string literals", () => {
+  const assignment = new Cat32().assign("__string__:payload");
+  assert.equal(assignment.key, JSON.stringify("__string__:payload"));
 });
 
 test("dist stableStringify handles Map bucket ordering", async () => {
@@ -883,7 +895,7 @@ test("stableStringify serializes undefined and Date sentinels", () => {
 test("stableStringify serializes string literal sentinels as JSON strings", () => {
   const literal = "__string__:payload";
   const serialized = stableStringify(literal);
-  const expected = JSON.stringify(typeSentinel("string", literal));
+  const expected = JSON.stringify(literal);
   assert.equal(serialized, expected);
 
   const cat = new Cat32();
@@ -921,9 +933,9 @@ test("string sentinel literals remain literal canonical keys", () => {
   assert.equal(assignment.key, stableStringify("__date__:2024-01-01Z"));
 });
 
-test("escapeSentinelString wraps string literal sentinel prefix", () => {
+test("escapeSentinelString leaves string literal sentinel prefix untouched", () => {
   const sentinelLike = "__string__:wrapped";
-  assert.equal(escapeSentinelString(sentinelLike), typeSentinel("string", sentinelLike));
+  assert.equal(escapeSentinelString(sentinelLike), sentinelLike);
 });
 
 test("stableStringify serializes explicit string sentinels", () => {
@@ -935,10 +947,8 @@ test("stableStringify serializes explicit string sentinels", () => {
 test("values containing __string__ escape exactly once", () => {
   const literal = "__string__:payload";
   const sentinel = typeSentinel("string", literal);
-  const serialized = stableStringify(literal);
-  const expected = JSON.stringify(sentinel);
-  assert.equal(serialized, expected);
-  assert.equal(stableStringify(sentinel), expected);
+  assert.equal(stableStringify(literal), JSON.stringify(literal));
+  assert.equal(stableStringify(sentinel), JSON.stringify(sentinel));
 });
 
 test("undefined sentinel string matches literal undefined in arrays", () => {


### PR DESCRIPTION
## Summary
- ensure string literal sentinel inputs serialize exactly like JSON.stringify while preserving sentinel collision avoidance
- update tests to cover the new behavior and adjust escapeSentinelString handling
- rebuild dist artifacts to include the updated serialization logic

## Testing
- npm run build
- node --test
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f0f5a4e5b88321a698ce85c46a897b