### PR TITLE
docs: add LLM bootstrap guidance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # deterministic-32
 
-Deterministic **32-way** categorizer for JS/TS.  
+<!-- LLM-BOOTSTRAP v1 -->
+読む順番:
+1. docs/birdseye/index.json  …… ノード一覧・隣接関係（軽量）
+2. docs/birdseye/caps/<path>.json …… 必要ノードだけ point read（個別カプセル）
+
+フォーカス手順:
+- 直近変更ファイル±2hopのノードIDを index.json から取得
+- 対応する caps/*.json のみ読み込み
+<!-- /LLM-BOOTSTRAP -->
+
+Deterministic **32-way** categorizer for JS/TS.
 Stable hashing (FNV-1a 32-bit), NFKC/NFC normalization, salt/namespace, label set, and rule overrides.  
 Runs in Node (>=18) and browsers, **no dependencies**.
 


### PR DESCRIPTION
## Summary
- add the Guardrails LLM-BOOTSTRAP bootstrap instructions near the top of the README

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f0fc5c1dc8832191d9d50bf7dfbdea