### PR TITLE
Add Birdseye codemap metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Changing `labels/salt/namespace/normalize` changes results intentionally.
 - Not cryptographic. Do **not** use for secrecy or collision-critical workloads.
 - For compatibility flips, bump `namespace` (consumer side).
 - Overrides compare against **post-normalized keys**.
+- Birdseye map refresh: if `docs/birdseye/index.json.generated_at` is stale, run `codemap.update` (or regenerate manually) and commit the updated capsules.
 
 ## License
 MIT

--- a/docs/birdseye/caps/src.categorizer.ts.json
+++ b/docs/birdseye/caps/src.categorizer.ts.json
@@ -1,0 +1,8 @@
+{
+  "id": "src/categorizer.ts",
+  "role": "domain",
+  "summary": "Cat32 core: stable key normalization, 32-slot hashing, and override handling.",
+  "deps_out": ["src/hash.ts", "src/serialize.ts"],
+  "deps_in": ["src/index.ts", "src/cli.ts"],
+  "tests": ["tests/categorizer.test.ts"]
+}

--- a/docs/birdseye/caps/src.cli.ts.json
+++ b/docs/birdseye/caps/src.cli.ts.json
@@ -1,0 +1,8 @@
+{
+  "id": "src/cli.ts",
+  "role": "cli",
+  "summary": "Node CLI wrapping Cat32 to hash stdin or argv input with salt/namespace flags.",
+  "deps_out": ["src/categorizer.ts"],
+  "deps_in": [],
+  "tests": ["tests/categorizer.test.ts"]
+}

--- a/docs/birdseye/caps/src.hash.ts.json
+++ b/docs/birdseye/caps/src.hash.ts.json
@@ -1,0 +1,8 @@
+{
+  "id": "src/hash.ts",
+  "role": "utility",
+  "summary": "FNV-1a 32-bit hashing helpers returning unsigned int and padded hex.",
+  "deps_out": [],
+  "deps_in": ["src/categorizer.ts"],
+  "tests": ["tests/categorizer.test.ts"]
+}

--- a/docs/birdseye/caps/src.index.ts.json
+++ b/docs/birdseye/caps/src.index.ts.json
@@ -1,0 +1,8 @@
+{
+  "id": "src/index.ts",
+  "role": "entrypoint",
+  "summary": "ESM entrypoint that re-exports Cat32 and stableStringify for consumers.",
+  "deps_out": ["src/categorizer.ts", "src/serialize.ts"],
+  "deps_in": ["tests/categorizer.test.ts"],
+  "tests": ["tests/categorizer.test.ts"]
+}

--- a/docs/birdseye/caps/src.serialize.ts.json
+++ b/docs/birdseye/caps/src.serialize.ts.json
@@ -1,0 +1,8 @@
+{
+  "id": "src/serialize.ts",
+  "role": "utility",
+  "summary": "Stable JSON-like serializer with sentinel escapes for Maps, Sets, Dates, and edge primitives.",
+  "deps_out": [],
+  "deps_in": ["src/categorizer.ts", "src/index.ts", "tests/categorizer.test.ts"],
+  "tests": ["tests/categorizer.test.ts"]
+}

--- a/docs/birdseye/caps/tests.categorizer.test.ts.json
+++ b/docs/birdseye/caps/tests.categorizer.test.ts.json
@@ -1,0 +1,8 @@
+{
+  "id": "tests/categorizer.test.ts",
+  "role": "test",
+  "summary": "Node:test suite covering Cat32 hashing, stableStringify sentinels, CLI exit codes, and TypeScript builds.",
+  "deps_out": ["src/index.ts", "src/serialize.ts"],
+  "deps_in": [],
+  "tests": ["tests/categorizer.test.ts"]
+}

--- a/docs/birdseye/index.json
+++ b/docs/birdseye/index.json
@@ -1,0 +1,44 @@
+{
+  "generated_at": "2025-10-16T14:09:10Z",
+  "nodes": {
+    "src/index.ts": {
+      "role": "entrypoint",
+      "caps": "docs/birdseye/caps/src.index.ts.json",
+      "mtime": "2025-10-16T05:02:07+09:00"
+    },
+    "src/categorizer.ts": {
+      "role": "domain",
+      "caps": "docs/birdseye/caps/src.categorizer.ts.json",
+      "mtime": "2025-10-15T19:04:13+09:00"
+    },
+    "src/serialize.ts": {
+      "role": "utility",
+      "caps": "docs/birdseye/caps/src.serialize.ts.json",
+      "mtime": "2025-10-16T23:04:00+09:00"
+    },
+    "src/hash.ts": {
+      "role": "utility",
+      "caps": "docs/birdseye/caps/src.hash.ts.json",
+      "mtime": "2025-10-14T17:37:21+09:00"
+    },
+    "src/cli.ts": {
+      "role": "cli",
+      "caps": "docs/birdseye/caps/src.cli.ts.json",
+      "mtime": "2025-10-16T22:49:07+09:00"
+    },
+    "tests/categorizer.test.ts": {
+      "role": "test",
+      "caps": "docs/birdseye/caps/tests.categorizer.test.ts.json",
+      "mtime": "2025-10-16T23:07:06+09:00"
+    }
+  },
+  "edges": [
+    ["src/index.ts", "src/categorizer.ts"],
+    ["src/index.ts", "src/serialize.ts"],
+    ["src/categorizer.ts", "src/hash.ts"],
+    ["src/categorizer.ts", "src/serialize.ts"],
+    ["src/cli.ts", "src/categorizer.ts"],
+    ["tests/categorizer.test.ts", "src/index.ts"],
+    ["tests/categorizer.test.ts", "src/serialize.ts"]
+  ]
+}


### PR DESCRIPTION
## Summary
- add docs/birdseye index.json and capsules describing the core Cat32 modules and test entrypoints
- document the regeneration step for Birdseye metadata in the README

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f0fc5c0ea083218393c9ccb7987a3a