### PR TITLE
Align birdseye metadata with guardrails schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Changing `labels/salt/namespace/normalize` changes results intentionally.
 - Not cryptographic. Do **not** use for secrecy or collision-critical workloads.
 - For compatibility flips, bump `namespace` (consumer side).
 - Overrides compare against **post-normalized keys**.
-- Birdseye map refresh: if `docs/birdseye/index.json.generated_at` is stale, run `codemap.update` (or regenerate manually) and commit the updated capsules.
+- Birdseye map refresh: when touching `src/categorizer.ts` or `src/serialize.ts`, run `codemap.update --targets src/categorizer.ts src/serialize.ts --emit index+caps` before merge; if `generated_at` drifts, regenerate both `index.json` and the matching capsules and commit them together.
 
 ## License
 MIT

--- a/docs/birdseye/caps/src.categorizer.ts.json
+++ b/docs/birdseye/caps/src.categorizer.ts.json
@@ -1,8 +1,8 @@
 {
   "id": "src/categorizer.ts",
   "role": "domain",
-  "summary": "Cat32 core: stable key normalization, 32-slot hashing, and override handling.",
+  "summary": "Cat32 core orchestrates normalization, hashing, and override resolution for 32-way assignments.",
   "deps_out": ["src/hash.ts", "src/serialize.ts"],
-  "deps_in": ["src/index.ts", "src/cli.ts"],
+  "deps_in": ["src/cli.ts", "src/index.ts"],
   "tests": ["tests/categorizer.test.ts"]
 }

--- a/docs/birdseye/caps/src.serialize.ts.json
+++ b/docs/birdseye/caps/src.serialize.ts.json
@@ -1,7 +1,7 @@
 {
   "id": "src/serialize.ts",
   "role": "utility",
-  "summary": "Stable JSON-like serializer with sentinel escapes for Maps, Sets, Dates, and edge primitives.",
+  "summary": "Stable stringify, normalization helpers, and canonical key helpers shared across Cat32 APIs.",
   "deps_out": [],
   "deps_in": ["src/categorizer.ts", "src/index.ts", "tests/categorizer.test.ts"],
   "tests": ["tests/categorizer.test.ts"]

--- a/docs/birdseye/index.json
+++ b/docs/birdseye/index.json
@@ -1,44 +1,19 @@
 {
-  "generated_at": "2025-10-16T14:09:10Z",
-  "nodes": {
-    "src/index.ts": {
-      "role": "entrypoint",
-      "caps": "docs/birdseye/caps/src.index.ts.json",
-      "mtime": "2025-10-16T05:02:07+09:00"
-    },
-    "src/categorizer.ts": {
+  "version": "guardrails@0.1",
+  "generated_at": "2025-10-16T16:52:00Z",
+  "nodes": [
+    {
+      "id": "src/categorizer.ts",
       "role": "domain",
-      "caps": "docs/birdseye/caps/src.categorizer.ts.json",
-      "mtime": "2025-10-15T19:04:13+09:00"
+      "caps": "docs/birdseye/caps/src.categorizer.ts.json"
     },
-    "src/serialize.ts": {
+    {
+      "id": "src/serialize.ts",
       "role": "utility",
-      "caps": "docs/birdseye/caps/src.serialize.ts.json",
-      "mtime": "2025-10-16T23:04:00+09:00"
-    },
-    "src/hash.ts": {
-      "role": "utility",
-      "caps": "docs/birdseye/caps/src.hash.ts.json",
-      "mtime": "2025-10-14T17:37:21+09:00"
-    },
-    "src/cli.ts": {
-      "role": "cli",
-      "caps": "docs/birdseye/caps/src.cli.ts.json",
-      "mtime": "2025-10-16T22:49:07+09:00"
-    },
-    "tests/categorizer.test.ts": {
-      "role": "test",
-      "caps": "docs/birdseye/caps/tests.categorizer.test.ts.json",
-      "mtime": "2025-10-16T23:07:06+09:00"
+      "caps": "docs/birdseye/caps/src.serialize.ts.json"
     }
-  },
+  ],
   "edges": [
-    ["src/index.ts", "src/categorizer.ts"],
-    ["src/index.ts", "src/serialize.ts"],
-    ["src/categorizer.ts", "src/hash.ts"],
-    ["src/categorizer.ts", "src/serialize.ts"],
-    ["src/cli.ts", "src/categorizer.ts"],
-    ["tests/categorizer.test.ts", "src/index.ts"],
-    ["tests/categorizer.test.ts", "src/serialize.ts"]
+    ["src/categorizer.ts", "src/serialize.ts"]
   ]
 }


### PR DESCRIPTION
## Summary
- reshape docs/birdseye/index.json to the guardrails minimum schema and keep the core nodes registered
- refresh the capsules for src/categorizer.ts and src/serialize.ts with concise summaries and dependency metadata
- document when to run codemap.update for future birdseye refreshes in the README

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68f12260a2b48321806b61a969f1dc62