### PR TITLE
Fix literal handling for sentinel-like strings

### DIFF
--- a/dist/src/serialize.js
+++ b/dist/src/serialize.js
@@ -15,7 +15,7 @@ export function typeSentinel(type, payload = "") {
     return `${SENTINEL_PREFIX}${type}:${payload}${SENTINEL_SUFFIX}`;
 }
 export function escapeSentinelString(value) {
-    return value;
+    return normalizeStringLiteral(value);
 }
 export function stableStringify(v) {
     const stack = new Set();
@@ -177,7 +177,17 @@ function toMapPropertyKey(rawKey, serializedKey) {
     return toPropertyKeyString(rawKey, revivedKey, serializedKey);
 }
 function stringifyStringLiteral(value) {
-    return JSON.stringify(value);
+    return JSON.stringify(normalizeStringLiteral(value));
+}
+function normalizeStringLiteral(value) {
+    if (isSentinelWrappedString(value)) {
+        return value;
+    }
+    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX) &&
+        isSentinelWrappedString(value.slice(STRING_LITERAL_SENTINEL_PREFIX.length))) {
+        return value.slice(STRING_LITERAL_SENTINEL_PREFIX.length);
+    }
+    return value;
 }
 function stringifySentinelLiteral(value) {
     if (typeof value !== "string") {

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -39,6 +39,10 @@ test("dist stableStringify matches JSON.stringify for string literals", async ()
 test("stableStringify matches JSON.stringify for string literals", () => {
     assert.equal(stableStringify("__string__:payload"), JSON.stringify("__string__:payload"));
 });
+test("stableStringify matches JSON.stringify for sentinel-like string literals", () => {
+    const sentinelLike = "\u0000cat32:number:Infinity\u0000";
+    assert.equal(stableStringify(sentinelLike), JSON.stringify(sentinelLike));
+});
 test("stableStringify differentiates sentinel key from literal NaN key", () => {
     const sentinelKey = typeSentinel("number", "NaN");
     const sentinelObject = { [sentinelKey]: "sentinel" };
@@ -48,6 +52,11 @@ test("stableStringify differentiates sentinel key from literal NaN key", () => {
 test("Cat32 assign key matches JSON.stringify for string literals", () => {
     const assignment = new Cat32().assign("__string__:payload");
     assert.equal(assignment.key, JSON.stringify("__string__:payload"));
+});
+test("Cat32 assign key matches JSON.stringify for sentinel-like string literals", () => {
+    const sentinelLike = "\u0000cat32:number:Infinity\u0000";
+    const assignment = new Cat32().assign(sentinelLike);
+    assert.equal(assignment.key, JSON.stringify(sentinelLike));
 });
 test("Cat32 assign differentiates sentinel key from literal NaN key", () => {
     const sentinelKey = typeSentinel("number", "NaN");

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -18,7 +18,7 @@ export function typeSentinel(type: string, payload = ""): string {
 }
 
 export function escapeSentinelString(value: string): string {
-  return value;
+  return normalizeStringLiteral(value);
 }
 
 export function stableStringify(v: unknown): string {
@@ -195,7 +195,22 @@ function toMapPropertyKey(rawKey: unknown, serializedKey: string): string {
 }
 
 function stringifyStringLiteral(value: string): string {
-  return JSON.stringify(value);
+  return JSON.stringify(normalizeStringLiteral(value));
+}
+
+function normalizeStringLiteral(value: string): string {
+  if (isSentinelWrappedString(value)) {
+    return value;
+  }
+
+  if (
+    value.startsWith(STRING_LITERAL_SENTINEL_PREFIX) &&
+    isSentinelWrappedString(value.slice(STRING_LITERAL_SENTINEL_PREFIX.length))
+  ) {
+    return value.slice(STRING_LITERAL_SENTINEL_PREFIX.length);
+  }
+
+  return value;
 }
 
 function stringifySentinelLiteral(value: string): string {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -109,6 +109,11 @@ test("stableStringify matches JSON.stringify for string literals", () => {
   );
 });
 
+test("stableStringify matches JSON.stringify for sentinel-like string literals", () => {
+  const sentinelLike = "\u0000cat32:number:Infinity\u0000";
+  assert.equal(stableStringify(sentinelLike), JSON.stringify(sentinelLike));
+});
+
 test("stableStringify differentiates sentinel key from literal NaN key", () => {
   const sentinelKey = typeSentinel("number", "NaN");
   const sentinelObject = { [sentinelKey]: "sentinel" };
@@ -120,6 +125,12 @@ test("stableStringify differentiates sentinel key from literal NaN key", () => {
 test("Cat32 assign key matches JSON.stringify for string literals", () => {
   const assignment = new Cat32().assign("__string__:payload");
   assert.equal(assignment.key, JSON.stringify("__string__:payload"));
+});
+
+test("Cat32 assign key matches JSON.stringify for sentinel-like string literals", () => {
+  const sentinelLike = "\u0000cat32:number:Infinity\u0000";
+  const assignment = new Cat32().assign(sentinelLike);
+  assert.equal(assignment.key, JSON.stringify(sentinelLike));
 });
 
 test("Cat32 assign differentiates sentinel key from literal NaN key", () => {


### PR DESCRIPTION
## Summary
- add regression coverage ensuring sentinel-like strings use JSON literal keys
- normalize string literal handling in the serializer to avoid rewrapping sentinel-shaped strings
- update the prebuilt dist artifacts to match the source changes

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68f15b72d9088321a721fdf89d67d2e1