### PR TITLE
Handle literal sentinel-like keys distinctly

### DIFF
--- a/dist/src/serialize.js
+++ b/dist/src/serialize.js
@@ -243,14 +243,6 @@ function toPropertyKeyString(rawKey, revivedKey, serializedKey) {
     if (rawKey === null) {
         return "null";
     }
-    const revivedNumeric = reviveNumericSentinel(revivedKey);
-    if (revivedNumeric !== undefined) {
-        return String(revivedNumeric);
-    }
-    const fallbackNumeric = reviveNumericSentinel(serializedKey);
-    if (fallbackNumeric !== undefined) {
-        return String(fallbackNumeric);
-    }
     if (rawKey instanceof Date) {
         if (typeof revivedKey === "string") {
             return escapeSentinelString(revivedKey);

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -45,6 +45,12 @@ test("stableStringify differentiates sentinel key from literal NaN key", () => {
     const literalObject = { NaN: "literal" };
     assert.ok(stableStringify(sentinelObject) !== stableStringify(literalObject));
 });
+test("stableStringify distinguishes literal sentinel-like string keys from NaN", () => {
+    const sentinelStringKey = "\u0000cat32:number:NaN\u0000";
+    const literalObject = { NaN: 1 };
+    assert.ok(stableStringify({ [sentinelStringKey]: 1 }) !==
+        stableStringify(literalObject));
+});
 test("Cat32 assign key matches JSON.stringify for string literals", () => {
     const assignment = new Cat32().assign("__string__:payload");
     assert.equal(assignment.key, JSON.stringify("__string__:payload"));
@@ -56,6 +62,14 @@ test("Cat32 assign differentiates sentinel key from literal NaN key", () => {
     const categorizer = new Cat32();
     assert.ok(categorizer.assign(sentinelObject).key !==
         categorizer.assign(literalObject).key);
+});
+test("Cat32 assign keeps literal sentinel-like keys distinct from NaN", () => {
+    const sentinelStringKey = "\u0000cat32:number:NaN\u0000";
+    const categorizer = new Cat32();
+    const sentinelAssignment = categorizer.assign({ [sentinelStringKey]: 1 });
+    const literalAssignment = categorizer.assign({ NaN: 1 });
+    assert.ok(sentinelAssignment.key !== literalAssignment.key);
+    assert.ok(sentinelAssignment.hash !== literalAssignment.hash);
 });
 test("dist stableStringify handles Map bucket ordering", async () => {
     const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -268,16 +268,6 @@ function toPropertyKeyString(
     return "null";
   }
 
-  const revivedNumeric = reviveNumericSentinel(revivedKey);
-  if (revivedNumeric !== undefined) {
-    return String(revivedNumeric);
-  }
-
-  const fallbackNumeric = reviveNumericSentinel(serializedKey);
-  if (fallbackNumeric !== undefined) {
-    return String(fallbackNumeric);
-  }
-
   if (rawKey instanceof Date) {
     if (typeof revivedKey === "string") {
       return escapeSentinelString(revivedKey);

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -117,6 +117,16 @@ test("stableStringify differentiates sentinel key from literal NaN key", () => {
   assert.ok(stableStringify(sentinelObject) !== stableStringify(literalObject));
 });
 
+test("stableStringify distinguishes literal sentinel-like string keys from NaN", () => {
+  const sentinelStringKey = "\u0000cat32:number:NaN\u0000";
+  const literalObject = { NaN: 1 };
+
+  assert.ok(
+    stableStringify({ [sentinelStringKey]: 1 }) !==
+      stableStringify(literalObject),
+  );
+});
+
 test("Cat32 assign key matches JSON.stringify for string literals", () => {
   const assignment = new Cat32().assign("__string__:payload");
   assert.equal(assignment.key, JSON.stringify("__string__:payload"));
@@ -133,6 +143,17 @@ test("Cat32 assign differentiates sentinel key from literal NaN key", () => {
     categorizer.assign(sentinelObject).key !==
       categorizer.assign(literalObject).key,
   );
+});
+
+test("Cat32 assign keeps literal sentinel-like keys distinct from NaN", () => {
+  const sentinelStringKey = "\u0000cat32:number:NaN\u0000";
+  const categorizer = new Cat32();
+
+  const sentinelAssignment = categorizer.assign({ [sentinelStringKey]: 1 });
+  const literalAssignment = categorizer.assign({ NaN: 1 });
+
+  assert.ok(sentinelAssignment.key !== literalAssignment.key);
+  assert.ok(sentinelAssignment.hash !== literalAssignment.hash);
 });
 
 test("dist stableStringify handles Map bucket ordering", async () => {


### PR DESCRIPTION
## Summary
- add coverage ensuring literal sentinel-like keys remain distinct from NaN in stableStringify and Cat32.assign
- stop Map key normalization from coercing sentinel-style strings into numeric keys for plain objects while retaining existing handling elsewhere

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68f15b705a14832191a9cfa9daa92790