### PR TITLE
Add CLI flag whitelist and unknown flag test

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { Cat32 } from "./categorizer.js";
+const ALLOWED_FLAGS = new Set(["salt", "namespace", "normalize"]);
 function parseArgs(argv) {
     const args = {};
     for (let i = 2; i < argv.length; i++) {
@@ -20,11 +21,14 @@ function parseArgs(argv) {
         }
         if (a.startsWith("--")) {
             const eq = a.indexOf("=");
+            const key = a.slice(2, eq >= 0 ? eq : undefined);
+            if (!ALLOWED_FLAGS.has(key)) {
+                throw new RangeError(`unknown flag "--${key}"`);
+            }
             if (eq >= 0) {
-                args[a.slice(2, eq)] = a.slice(eq + 1);
+                args[key] = a.slice(eq + 1);
             }
             else {
-                const key = a.slice(2);
                 const next = argv[i + 1];
                 if (next !== undefined && next !== "--" && !next.startsWith("--")) {
                     args[key] = next;

--- a/dist/src/cli.js
+++ b/dist/src/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { Cat32 } from "./categorizer.js";
+const ALLOWED_FLAGS = new Set(["salt", "namespace", "normalize"]);
 function parseArgs(argv) {
     const args = {};
     for (let i = 2; i < argv.length; i++) {
@@ -20,11 +21,14 @@ function parseArgs(argv) {
         }
         if (a.startsWith("--")) {
             const eq = a.indexOf("=");
+            const key = a.slice(2, eq >= 0 ? eq : undefined);
+            if (!ALLOWED_FLAGS.has(key)) {
+                throw new RangeError(`unknown flag "--${key}"`);
+            }
             if (eq >= 0) {
-                args[a.slice(2, eq)] = a.slice(eq + 1);
+                args[key] = a.slice(eq + 1);
             }
             else {
-                const key = a.slice(2);
                 const next = argv[i + 1];
                 if (next !== undefined && next !== "--" && !next.startsWith("--")) {
                     args[key] = next;

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -416,6 +416,28 @@ test("CLI exits with code 2 when --salt is missing a value", async () => {
     });
     assert.equal(exitCode, 2, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
 });
+test("CLI exits with code 2 when an unknown flag is provided", async () => {
+    const { spawn } = (await dynamicImport("node:child_process"));
+    const child = spawn(process.argv[0], [CLI_PATH, "--namesapce", "foo", "bar"], {
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdin.end();
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+    });
+    const exitCode = await new Promise((resolve) => {
+        child.on("close", (code) => resolve(code));
+    });
+    assert.equal(exitCode, 2, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    assert.ok(/unknown flag "--namesapce"/.test(stderr));
+});
 test("cat32 binary accepts flag values separated by whitespace", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const child = spawn(process.argv[0], [CLI_BIN_PATH, "--salt", "foo", "bar"], {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { Cat32 } from "./categorizer.js";
 
+const ALLOWED_FLAGS = new Set(["salt", "namespace", "normalize"]);
+
 function parseArgs(argv: string[]) {
   const args: Record<string, string | undefined> = {};
   for (let i = 2; i < argv.length; i++) {
@@ -20,10 +22,13 @@ function parseArgs(argv: string[]) {
     }
     if (a.startsWith("--")) {
       const eq = a.indexOf("=");
+      const key = a.slice(2, eq >= 0 ? eq : undefined);
+      if (!ALLOWED_FLAGS.has(key)) {
+        throw new RangeError(`unknown flag "--${key}"`);
+      }
       if (eq >= 0) {
-        args[a.slice(2, eq)] = a.slice(eq + 1);
+        args[key] = a.slice(eq + 1);
       } else {
-        const key = a.slice(2);
         const next = argv[i + 1];
         if (next !== undefined && next !== "--" && !next.startsWith("--")) {
           args[key] = next;

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -666,6 +666,39 @@ test("CLI exits with code 2 when --salt is missing a value", async () => {
   );
 });
 
+test("CLI exits with code 2 when an unknown flag is provided", async () => {
+  const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
+
+  const child = spawn(process.argv[0], [CLI_PATH, "--namesapce", "foo", "bar"], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  child.stdin.end();
+
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const exitCode: number | null = await new Promise((resolve) => {
+    child.on("close", (code: number | null) => resolve(code));
+  });
+
+  assert.equal(
+    exitCode,
+    2,
+    `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+  );
+  assert.ok(/unknown flag "--namesapce"/.test(stderr));
+});
+
 test("cat32 binary accepts flag values separated by whitespace", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 


### PR DESCRIPTION
## Summary
- add a regression test covering the CLI behaviour when an unknown flag is supplied
- restrict the CLI argument parser to a whitelist of supported flags and refresh the compiled dist artifacts

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68f162700df0832184f46a4fc64d4bb1