### PR TITLE
Fix prefixed sentinel string serialization

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -203,13 +203,6 @@ function normalizeStringLiteral(value: string): string {
     return value;
   }
 
-  if (
-    value.startsWith(STRING_LITERAL_SENTINEL_PREFIX) &&
-    isSentinelWrappedString(value.slice(STRING_LITERAL_SENTINEL_PREFIX.length))
-  ) {
-    return value.slice(STRING_LITERAL_SENTINEL_PREFIX.length);
-  }
-
   return value;
 }
 

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -184,6 +184,20 @@ test("Cat32 assign keeps literal sentinel-like keys distinct from NaN", () => {
   assert.ok(sentinelAssignment.hash !== literalAssignment.hash);
 });
 
+test("Cat32 assign treats prefixed literal strings as distinct from NaN", () => {
+  const categorizer = new Cat32();
+  const literalAssignment = categorizer.assign(
+    "__string__:\u0000cat32:number:NaN\u0000",
+  );
+  const nanAssignment = categorizer.assign(Number.NaN);
+  const sentinelAssignment = categorizer.assign(typeSentinel("number", "NaN"));
+
+  assert.ok(literalAssignment.key !== nanAssignment.key);
+  assert.ok(literalAssignment.hash !== nanAssignment.hash);
+  assert.ok(literalAssignment.key !== sentinelAssignment.key);
+  assert.ok(literalAssignment.hash !== sentinelAssignment.hash);
+});
+
 test("dist stableStringify handles Map bucket ordering", async () => {
   const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
     ? new URL("../../tests/categorizer.test.ts", import.meta.url)


### PR DESCRIPTION
## Summary
- add coverage ensuring Cat32 assignments with prefixed sentinel-like strings stay distinct from NaN inputs
- stop stripping the string literal sentinel prefix during normalization so these literals serialize unchanged

## Testing
- node --test


------
https://chatgpt.com/codex/tasks/task_e_68f16942b8288321a6d4b0b4b402e774