### PR TITLE
Fix string sentinel prefix handling

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -199,6 +199,17 @@ function stringifyStringLiteral(value: string): string {
 }
 
 function normalizeStringLiteral(value: string): string {
+  if (isSentinelWrappedString(value)) {
+    return value;
+  }
+
+  if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
+    const literalSentinel = value.slice(STRING_LITERAL_SENTINEL_PREFIX.length);
+    if (isSentinelWrappedString(literalSentinel)) {
+      return STRING_LITERAL_SENTINEL_PREFIX + literalSentinel;
+    }
+  }
+
   return value;
 }
 

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -137,6 +137,11 @@ test(
   },
 );
 
+test("stableStringify preserves prefixed sentinel string literal content", () => {
+  const value = "__string__:" + typeSentinel("number", "NaN");
+  assert.equal(stableStringify(value), JSON.stringify(value));
+});
+
 test("stableStringify matches JSON.stringify for sentinel-like string literals", () => {
   const sentinelLike = "\u0000cat32:number:Infinity\u0000";
   assert.equal(stableStringify(sentinelLike), JSON.stringify(sentinelLike));
@@ -163,6 +168,12 @@ test("stableStringify distinguishes literal sentinel-like string keys from NaN",
 test("Cat32 assign key matches JSON.stringify for string literals", () => {
   const assignment = new Cat32().assign("__string__:payload");
   assert.equal(assignment.key, JSON.stringify("__string__:payload"));
+});
+
+test("Cat32 assign key preserves prefixed sentinel string literal content", () => {
+  const value = "__string__:" + typeSentinel("number", "NaN");
+  const assignment = new Cat32().assign(value);
+  assert.equal(assignment.key, JSON.stringify(value));
 });
 
 test("Cat32 assign key matches JSON.stringify for sentinel-like string literals", () => {


### PR DESCRIPTION
## Summary
- add regression coverage ensuring string literals prefixed with `__string__:` plus a sentinel match `JSON.stringify`
- adjust `normalizeStringLiteral` so literal sentinel-prefixed strings remain untouched when serialized

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68f16ea199188321a6d4c6a50f0ac1c2