### PR TITLE
Update birdseye index metadata timestamps

### DIFF
--- a/docs/birdseye/index.json
+++ b/docs/birdseye/index.json
@@ -1,36 +1,36 @@
 {
   "version": "guardrails@0.1",
-  "generated_at": "2025-10-16T16:52:00Z",
+  "generated_at": "2025-10-16T22:44:04+00:00",
   "nodes": {
     "src/categorizer.ts": {
       "role": "domain",
       "caps": "docs/birdseye/caps/src.categorizer.ts.json",
-      "mtime": "2025-10-16T20:55:08+00:00"
+      "mtime": "2025-10-16T21:24:54+00:00"
     },
     "src/serialize.ts": {
       "role": "utility",
       "caps": "docs/birdseye/caps/src.serialize.ts.json",
-      "mtime": "2025-10-16T22:32:17+00:00"
+      "mtime": "2025-10-16T22:44:04+00:00"
     },
     "src/cli.ts": {
       "role": "cli",
       "caps": "docs/birdseye/caps/src.cli.ts.json",
-      "mtime": "2025-10-16T22:32:17+00:00"
+      "mtime": "2025-10-16T22:44:04+00:00"
     },
     "src/hash.ts": {
       "role": "utility",
       "caps": "docs/birdseye/caps/src.hash.ts.json",
-      "mtime": "2025-10-16T20:55:08+00:00"
+      "mtime": "2025-10-16T21:24:54+00:00"
     },
     "src/index.ts": {
       "role": "entrypoint",
       "caps": "docs/birdseye/caps/src.index.ts.json",
-      "mtime": "2025-10-16T20:55:08+00:00"
+      "mtime": "2025-10-16T21:24:54+00:00"
     },
     "tests/categorizer.test.ts": {
       "role": "test",
       "caps": "docs/birdseye/caps/tests.categorizer.test.ts.json",
-      "mtime": "2025-10-16T22:32:17+00:00"
+      "mtime": "2025-10-16T22:44:04+00:00"
     }
   },
   "edges": [


### PR DESCRIPTION
## Summary
- refresh the birdseye index metadata so each node records its current modification time
- update the generated_at marker to the latest node timestamp while keeping the guardrails schema intact

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f17529107483218884d03531124d7d