### PR TITLE
Add regression test for dist stableStringify sentinel prefix

### DIFF
--- a/dist/serialize.js
+++ b/dist/serialize.js
@@ -5,7 +5,9 @@
 // - Maps/Sets are serialized as arrays in insertion order (keys sorted for Map via key string).
 const SENTINEL_PREFIX = "\u0000cat32:";
 const SENTINEL_SUFFIX = "\u0000";
-const HOLE_SENTINEL = JSON.stringify(typeSentinel("hole"));
+const HOLE_SENTINEL_PAYLOAD = "__hole__";
+const HOLE_SENTINEL_RAW = typeSentinel("hole", HOLE_SENTINEL_PAYLOAD);
+const HOLE_SENTINEL = JSON.stringify(HOLE_SENTINEL_RAW);
 const UNDEFINED_SENTINEL = "__undefined__";
 const DATE_SENTINEL_PREFIX = "__date__:";
 const BIGINT_SENTINEL_PREFIX = "__bigint__:";
@@ -180,12 +182,11 @@ function stringifyStringLiteral(value) {
     return JSON.stringify(normalizeStringLiteral(value));
 }
 function normalizeStringLiteral(value) {
-    if (isSentinelWrappedString(value)) {
+    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
         return value;
     }
-    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX) &&
-        isSentinelWrappedString(value.slice(STRING_LITERAL_SENTINEL_PREFIX.length))) {
-        return value.slice(STRING_LITERAL_SENTINEL_PREFIX.length);
+    if (value === HOLE_SENTINEL_RAW) {
+        return `${STRING_LITERAL_SENTINEL_PREFIX}${value}`;
     }
     return value;
 }
@@ -310,5 +311,5 @@ function reviveNumericSentinel(value) {
     return undefined;
 }
 function normalizePlainObjectKey(key) {
-    return key;
+    return normalizeStringLiteral(key);
 }

--- a/dist/src/serialize.js
+++ b/dist/src/serialize.js
@@ -5,7 +5,9 @@
 // - Maps/Sets are serialized as arrays in insertion order (keys sorted for Map via key string).
 const SENTINEL_PREFIX = "\u0000cat32:";
 const SENTINEL_SUFFIX = "\u0000";
-const HOLE_SENTINEL = JSON.stringify(typeSentinel("hole"));
+const HOLE_SENTINEL_PAYLOAD = "__hole__";
+const HOLE_SENTINEL_RAW = typeSentinel("hole", HOLE_SENTINEL_PAYLOAD);
+const HOLE_SENTINEL = JSON.stringify(HOLE_SENTINEL_RAW);
 const UNDEFINED_SENTINEL = "__undefined__";
 const DATE_SENTINEL_PREFIX = "__date__:";
 const BIGINT_SENTINEL_PREFIX = "__bigint__:";
@@ -180,12 +182,11 @@ function stringifyStringLiteral(value) {
     return JSON.stringify(normalizeStringLiteral(value));
 }
 function normalizeStringLiteral(value) {
-    if (isSentinelWrappedString(value)) {
+    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
         return value;
     }
-    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX) &&
-        isSentinelWrappedString(value.slice(STRING_LITERAL_SENTINEL_PREFIX.length))) {
-        return value.slice(STRING_LITERAL_SENTINEL_PREFIX.length);
+    if (value === HOLE_SENTINEL_RAW) {
+        return `${STRING_LITERAL_SENTINEL_PREFIX}${value}`;
     }
     return value;
 }
@@ -310,5 +311,5 @@ function reviveNumericSentinel(value) {
     return undefined;
 }
 function normalizePlainObjectKey(key) {
-    return key;
+    return normalizeStringLiteral(key);
 }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -119,6 +119,31 @@ test("dist stableStringify matches JSON.stringify for string literals", async ()
   );
 });
 
+test(
+  "dist stableStringify preserves prefixed sentinel string literal content",
+  async () => {
+    const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
+      ? new URL("../../tests/categorizer.test.ts", import.meta.url)
+      : import.meta.url;
+
+    const distSerializeModule = (await import(
+      new URL("../dist/serialize.js", sourceImportMetaUrl).href,
+    )) as { stableStringify?: ((value: unknown) => string) | undefined };
+
+    assert.equal(typeof distSerializeModule.stableStringify, "function");
+    const distStableStringify = distSerializeModule.stableStringify!;
+
+    const prefixedLiteral = "__string__:" + typeSentinel("number", "NaN");
+    assert.equal(
+      distStableStringify(prefixedLiteral),
+      JSON.stringify(prefixedLiteral),
+    );
+    assert.ok(
+      distStableStringify(prefixedLiteral) !== distStableStringify(NaN),
+    );
+  },
+);
+
 test("stableStringify matches JSON.stringify for string literals", () => {
   assert.equal(
     stableStringify("__string__:payload"),


### PR DESCRIPTION
## Summary
- add a regression test covering the dist stableStringify output for prefixed string literal sentinels
- rebuild the dist bundle so normalizeStringLiteral retains the __string__ prefix consistently

## Testing
- npm run build && node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f1cf7a36c48321822201f031fc1ae8