### PR TITLE
Add regression coverage for dist hole sentinel handling

### DIFF
--- a/dist/serialize.js
+++ b/dist/serialize.js
@@ -5,7 +5,9 @@
 // - Maps/Sets are serialized as arrays in insertion order (keys sorted for Map via key string).
 const SENTINEL_PREFIX = "\u0000cat32:";
 const SENTINEL_SUFFIX = "\u0000";
-const HOLE_SENTINEL = JSON.stringify(typeSentinel("hole"));
+const HOLE_SENTINEL_PAYLOAD = "__hole__";
+const HOLE_SENTINEL_RAW = typeSentinel("hole", HOLE_SENTINEL_PAYLOAD);
+const HOLE_SENTINEL = JSON.stringify(HOLE_SENTINEL_RAW);
 const UNDEFINED_SENTINEL = "__undefined__";
 const DATE_SENTINEL_PREFIX = "__date__:";
 const BIGINT_SENTINEL_PREFIX = "__bigint__:";
@@ -180,12 +182,11 @@ function stringifyStringLiteral(value) {
     return JSON.stringify(normalizeStringLiteral(value));
 }
 function normalizeStringLiteral(value) {
-    if (isSentinelWrappedString(value)) {
+    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
         return value;
     }
-    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX) &&
-        isSentinelWrappedString(value.slice(STRING_LITERAL_SENTINEL_PREFIX.length))) {
-        return value.slice(STRING_LITERAL_SENTINEL_PREFIX.length);
+    if (value === HOLE_SENTINEL_RAW) {
+        return `${STRING_LITERAL_SENTINEL_PREFIX}${value}`;
     }
     return value;
 }
@@ -310,5 +311,5 @@ function reviveNumericSentinel(value) {
     return undefined;
 }
 function normalizePlainObjectKey(key) {
-    return key;
+    return normalizeStringLiteral(key);
 }

--- a/dist/src/serialize.js
+++ b/dist/src/serialize.js
@@ -5,7 +5,9 @@
 // - Maps/Sets are serialized as arrays in insertion order (keys sorted for Map via key string).
 const SENTINEL_PREFIX = "\u0000cat32:";
 const SENTINEL_SUFFIX = "\u0000";
-const HOLE_SENTINEL = JSON.stringify(typeSentinel("hole"));
+const HOLE_SENTINEL_PAYLOAD = "__hole__";
+const HOLE_SENTINEL_RAW = typeSentinel("hole", HOLE_SENTINEL_PAYLOAD);
+const HOLE_SENTINEL = JSON.stringify(HOLE_SENTINEL_RAW);
 const UNDEFINED_SENTINEL = "__undefined__";
 const DATE_SENTINEL_PREFIX = "__date__:";
 const BIGINT_SENTINEL_PREFIX = "__bigint__:";
@@ -180,12 +182,11 @@ function stringifyStringLiteral(value) {
     return JSON.stringify(normalizeStringLiteral(value));
 }
 function normalizeStringLiteral(value) {
-    if (isSentinelWrappedString(value)) {
+    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
         return value;
     }
-    if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX) &&
-        isSentinelWrappedString(value.slice(STRING_LITERAL_SENTINEL_PREFIX.length))) {
-        return value.slice(STRING_LITERAL_SENTINEL_PREFIX.length);
+    if (value === HOLE_SENTINEL_RAW) {
+        return `${STRING_LITERAL_SENTINEL_PREFIX}${value}`;
     }
     return value;
 }
@@ -310,5 +311,5 @@ function reviveNumericSentinel(value) {
     return undefined;
 }
 function normalizePlainObjectKey(key) {
-    return key;
+    return normalizeStringLiteral(key);
 }

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -55,9 +55,28 @@ test("dist stableStringify matches JSON.stringify for string literals", async ()
 test("stableStringify matches JSON.stringify for string literals", () => {
     assert.equal(stableStringify("__string__:payload"), JSON.stringify("__string__:payload"));
 });
+test("stableStringify matches JSON.stringify for stringified sentinel string literals", () => {
+    const sentinelStringLiteral = `__string__:${typeSentinel("number", "NaN")}`;
+    assert.equal(stableStringify(sentinelStringLiteral), JSON.stringify(sentinelStringLiteral));
+});
+test("stableStringify preserves prefixed sentinel string literal content", () => {
+    const value = "__string__:" + typeSentinel("number", "NaN");
+    assert.equal(stableStringify(value), JSON.stringify(value));
+});
 test("stableStringify matches JSON.stringify for sentinel-like string literals", () => {
     const sentinelLike = "\u0000cat32:number:Infinity\u0000";
     assert.equal(stableStringify(sentinelLike), JSON.stringify(sentinelLike));
+});
+test("stableStringify distinguishes prefixed string literals from hole sentinels", () => {
+    const prefixedLiteral = `__string__:${typeSentinel("hole")}`;
+    const sentinelLiteral = typeSentinel("hole");
+    const sparseArray = new Array(1);
+    const prefixedResult = stableStringify([prefixedLiteral]);
+    const sentinelResult = stableStringify([sentinelLiteral]);
+    const sparseResult = stableStringify(sparseArray);
+    assert.ok(prefixedResult !== sentinelResult);
+    assert.ok(prefixedResult !== sparseResult);
+    assert.ok(sentinelResult !== sparseResult);
 });
 test("stableStringify differentiates sentinel key from literal NaN key", () => {
     const sentinelKey = typeSentinel("number", "NaN");
@@ -74,6 +93,11 @@ test("stableStringify distinguishes literal sentinel-like string keys from NaN",
 test("Cat32 assign key matches JSON.stringify for string literals", () => {
     const assignment = new Cat32().assign("__string__:payload");
     assert.equal(assignment.key, JSON.stringify("__string__:payload"));
+});
+test("Cat32 assign key preserves prefixed sentinel string literal content", () => {
+    const value = "__string__:" + typeSentinel("number", "NaN");
+    const assignment = new Cat32().assign(value);
+    assert.equal(assignment.key, JSON.stringify(value));
 });
 test("Cat32 assign key matches JSON.stringify for sentinel-like string literals", () => {
     const sentinelLike = "\u0000cat32:number:Infinity\u0000";
@@ -96,6 +120,31 @@ test("Cat32 assign keeps literal sentinel-like keys distinct from NaN", () => {
     assert.ok(sentinelAssignment.key !== literalAssignment.key);
     assert.ok(sentinelAssignment.hash !== literalAssignment.hash);
 });
+test("Cat32 assign keeps prefixed string literals distinct from hole sentinels", () => {
+    const categorizer = new Cat32();
+    const prefixedLiteral = `__string__:${typeSentinel("hole")}`;
+    const sentinelLiteral = typeSentinel("hole");
+    const sparseArray = new Array(1);
+    const prefixedAssignment = categorizer.assign([prefixedLiteral]);
+    const sentinelAssignment = categorizer.assign([sentinelLiteral]);
+    const sparseAssignment = categorizer.assign(sparseArray);
+    assert.ok(prefixedAssignment.key !== sentinelAssignment.key);
+    assert.ok(prefixedAssignment.key !== sparseAssignment.key);
+    assert.ok(sentinelAssignment.key !== sparseAssignment.key);
+    assert.ok(prefixedAssignment.hash !== sentinelAssignment.hash);
+    assert.ok(prefixedAssignment.hash !== sparseAssignment.hash);
+    assert.ok(sentinelAssignment.hash !== sparseAssignment.hash);
+});
+test("Cat32 assign treats prefixed literal strings as distinct from NaN", () => {
+    const categorizer = new Cat32();
+    const literalAssignment = categorizer.assign("__string__:\u0000cat32:number:NaN\u0000");
+    const nanAssignment = categorizer.assign(Number.NaN);
+    const sentinelAssignment = categorizer.assign(typeSentinel("number", "NaN"));
+    assert.ok(literalAssignment.key !== nanAssignment.key);
+    assert.ok(literalAssignment.hash !== nanAssignment.hash);
+    assert.ok(literalAssignment.key !== sentinelAssignment.key);
+    assert.ok(literalAssignment.hash !== sentinelAssignment.hash);
+});
 test("dist stableStringify handles Map bucket ordering", async () => {
     const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
         ? new URL("../../tests/categorizer.test.ts", import.meta.url)
@@ -112,6 +161,36 @@ test("dist stableStringify handles Map bucket ordering", async () => {
         [1, "number"],
     ]);
     assert.equal(distStableStringify(mapAscending), distStableStringify(mapDescending));
+});
+test("dist stableStringify and Cat32 assign keep hole sentinel cases distinct", async () => {
+    const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
+        ? new URL("../../tests/categorizer.test.ts", import.meta.url)
+        : import.meta.url;
+    const distSerializeModule = (await import(new URL("../dist/serialize.js", sourceImportMetaUrl).href));
+    assert.equal(typeof distSerializeModule.stableStringify, "function");
+    const distStableStringify = distSerializeModule.stableStringify;
+    const distModule = (await import(new URL("../dist/index.js", sourceImportMetaUrl).href));
+    assert.equal(typeof distModule.Cat32, "function");
+    const DistCat32 = distModule.Cat32;
+    const prefixedLiteral = `__string__:${typeSentinel("hole")}`;
+    const sentinelLiteral = typeSentinel("hole");
+    const sparseArray = new Array(1);
+    const prefixedKey = distStableStringify([prefixedLiteral]);
+    const sentinelKey = distStableStringify([sentinelLiteral]);
+    const sparseKey = distStableStringify(sparseArray);
+    assert.ok(prefixedKey !== sentinelKey);
+    assert.ok(prefixedKey !== sparseKey);
+    assert.ok(sentinelKey !== sparseKey);
+    const categorizer = new DistCat32();
+    const prefixedAssignment = categorizer.assign([prefixedLiteral]);
+    const sentinelAssignment = categorizer.assign([sentinelLiteral]);
+    const sparseAssignment = categorizer.assign(sparseArray);
+    assert.ok(prefixedAssignment.key !== sentinelAssignment.key);
+    assert.ok(prefixedAssignment.key !== sparseAssignment.key);
+    assert.ok(sentinelAssignment.key !== sparseAssignment.key);
+    assert.ok(prefixedAssignment.hash !== sentinelAssignment.hash);
+    assert.ok(prefixedAssignment.hash !== sparseAssignment.hash);
+    assert.ok(sentinelAssignment.hash !== sparseAssignment.hash);
 });
 test("dist Cat32 assign normalizes Map keys by string representation", async () => {
     const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")


### PR DESCRIPTION
## Summary
- add a dist regression test that dynamically imports the bundle to verify hole sentinel, prefixed literal, and sparse array cases yield distinct keys and hashes
- rebuild the dist bundle so the serialized output matches the current TypeScript implementation

## Testing
- npm run build && node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f1cf7a5060832185250007e4f05e06