### PR TITLE
Fix Map Date key normalization

### DIFF
--- a/dist/serialize.js
+++ b/dist/serialize.js
@@ -175,6 +175,9 @@ function compareSerializedEntry(left, right) {
     return 0;
 }
 function toMapPropertyKey(rawKey, serializedKey) {
+    if (rawKey instanceof Date) {
+        return normalizePlainObjectKey(String(rawKey));
+    }
     const revivedKey = reviveFromSerialized(serializedKey);
     return toPropertyKeyString(rawKey, revivedKey, serializedKey);
 }

--- a/dist/src/serialize.js
+++ b/dist/src/serialize.js
@@ -175,6 +175,9 @@ function compareSerializedEntry(left, right) {
     return 0;
 }
 function toMapPropertyKey(rawKey, serializedKey) {
+    if (rawKey instanceof Date) {
+        return normalizePlainObjectKey(String(rawKey));
+    }
     const revivedKey = reviveFromSerialized(serializedKey);
     return toPropertyKeyString(rawKey, revivedKey, serializedKey);
 }

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -894,6 +894,14 @@ test("Map keys match plain object representation regardless of entry order", () 
     assert.equal(duplicateKeyMapAssignment.key, duplicateKeyObjectAssignment.key);
     assert.equal(duplicateKeyMapAssignment.hash, duplicateKeyObjectAssignment.hash);
 });
+test("Map Date key matches plain object string key", () => {
+    const c = new Cat32();
+    const date = new Date("2024-05-01T00:00:00.000Z");
+    const mapAssignment = c.assign(new Map([[date, "value"]]));
+    const objectAssignment = c.assign({ [String(date)]: "value" });
+    assert.equal(mapAssignment.key, objectAssignment.key);
+    assert.equal(mapAssignment.hash, objectAssignment.hash);
+});
 test("Map duplicate property keys deterministically pick a single representative", () => {
     const c = new Cat32();
     const mapAssignment = c.assign(new Map([

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -192,6 +192,9 @@ function compareSerializedEntry(
 }
 
 function toMapPropertyKey(rawKey: unknown, serializedKey: string): string {
+  if (rawKey instanceof Date) {
+    return normalizePlainObjectKey(String(rawKey));
+  }
   const revivedKey = reviveFromSerialized(serializedKey);
   return toPropertyKeyString(rawKey, revivedKey, serializedKey);
 }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -1326,6 +1326,17 @@ test("Map keys match plain object representation regardless of entry order", () 
   assert.equal(duplicateKeyMapAssignment.hash, duplicateKeyObjectAssignment.hash);
 });
 
+test("Map Date key matches plain object string key", () => {
+  const c = new Cat32();
+  const date = new Date("2024-05-01T00:00:00.000Z");
+
+  const mapAssignment = c.assign(new Map([[date, "value"]]));
+  const objectAssignment = c.assign({ [String(date)]: "value" });
+
+  assert.equal(mapAssignment.key, objectAssignment.key);
+  assert.equal(mapAssignment.hash, objectAssignment.hash);
+});
+
 test("Map duplicate property keys deterministically pick a single representative", () => {
   const c = new Cat32();
 


### PR DESCRIPTION
## Summary
- add regression coverage ensuring Map Date keys match plain object string keys
- normalize Map Date keys during serialization using their string representation

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68f1d230cdbc8321b3bb145d753cbf20