### PR TITLE
feat: support json format options in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ npx deterministic-32 "user:123" --salt=proj --namespace=v1
 echo '{"id":1,"k":"v"}' | npx deterministic-32 --salt=proj
 # Output: one JSON per line (same shape as assign())
 ```
+- `--json=compact` で既定形式を明示し、`--json=pretty` または `--pretty` で整形出力できます。
 
 ## Determinism
 - Canonical key = **normalize(NFKC)** ∘ **stable stringify (key-sorted, cycle-check)**.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,7 +1,7 @@
 # CLI 仕様
 
 ```
-$ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfc|none]
+$ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfc|none --json[=compact|pretty] --pretty]
 ```
 
 - `<key>` が無い場合は **stdin** を読み取る。
@@ -9,6 +9,7 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfc|n
   ```json
   {"index":7,"label":"H","hash":"1a2b3c4d","key":"...canonical..."}
   ```
+- `--json` を付けない場合は従来通り **compact JSON**。`--json=compact` で明示指定でき、`--json=pretty` または `--pretty` でインデント付き JSON を得られる。
 - 終了コード:
   - `0` … 成功
   - `2` … 循環/labels長不正/override不正など仕様違反

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,67 +1,99 @@
 #!/usr/bin/env node
 import { Cat32 } from "./categorizer.js";
 
-const ALLOWED_FLAGS = new Set(["salt", "namespace", "normalize"]);
+type FlagSpec =
+  | { mode: "value" }
+  | { mode: "optional-value"; defaultValue: string }
+  | { mode: "boolean" };
 
-function parseArgs(argv: string[]) {
-  const args: Record<string, string | undefined> = {};
+const FLAG_SPECS = new Map<string, FlagSpec>([
+  ["salt", { mode: "value" }],
+  ["namespace", { mode: "value" }],
+  ["normalize", { mode: "value" }],
+  ["json", { mode: "optional-value", defaultValue: "compact" }],
+  ["pretty", { mode: "boolean" }],
+]);
+
+type ParsedArgs = Record<string, string | boolean | undefined> & {
+  _: string | undefined;
+  salt?: string;
+  namespace?: string;
+  normalize?: string;
+  json?: string;
+  pretty?: boolean;
+};
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args: Record<string, string | boolean | undefined> = {};
+  let positional: string | undefined;
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--") {
       const rest = argv.slice(i + 1);
       if (rest.length > 0) {
         const remainder = rest.join(" ");
-        if (Object.prototype.hasOwnProperty.call(args, "_")) {
-          const existing = args._;
-          args._ = existing === undefined ? remainder : `${existing} ${remainder}`;
-        } else {
-          args._ = remainder;
-        }
+        positional = positional === undefined ? remainder : `${positional} ${remainder}`;
       }
       break;
     }
     if (a.startsWith("--")) {
       const eq = a.indexOf("=");
       const key = a.slice(2, eq >= 0 ? eq : undefined);
-      if (!ALLOWED_FLAGS.has(key)) {
+      const spec = FLAG_SPECS.get(key);
+      if (spec === undefined) {
         throw new RangeError(`unknown flag "--${key}"`);
       }
-      if (eq >= 0) {
-        args[key] = a.slice(eq + 1);
-      } else {
-        const next = argv[i + 1];
-        if (next !== undefined && next !== "--" && !next.startsWith("--")) {
-          args[key] = next;
-          i += 1;
-        } else {
-          throw new RangeError(`flag "${a}" requires a value`);
+      if (spec.mode === "boolean") {
+        if (eq >= 0) {
+          throw new RangeError(`flag "${a}" does not accept a value`);
         }
+        args[key] = true;
+      } else {
+        let value: string | undefined;
+        if (eq >= 0) {
+          value = a.slice(eq + 1);
+        } else {
+          const next = argv[i + 1];
+          if (next !== undefined && next !== "--" && !next.startsWith("--")) {
+            value = next;
+            i += 1;
+          } else if (spec.mode === "optional-value") {
+            value = spec.defaultValue;
+          } else {
+            throw new RangeError(`flag "${a}" requires a value`);
+          }
+        }
+        args[key] = value;
       }
-    } else if (!("_" in args)) {
-      args._ = a;
+    } else if (positional === undefined) {
+      positional = a;
     } else {
-      const existing = args._;
-      args._ = existing === undefined ? a : `${existing} ${a}`;
+      positional = `${positional} ${a}`;
     }
   }
-  return args;
+  return Object.assign(args, { _: positional }) as ParsedArgs;
 }
 
 async function main() {
   const args = parseArgs(process.argv);
-  const key = Object.prototype.hasOwnProperty.call(args, "_")
-    ? args._
-    : undefined;
-  const salt = args.salt ?? "";
-  const namespace = args.namespace ?? "";
-  const norm = args.normalize ?? "nfkc";
+  const key = args._;
+  const salt = typeof args.salt === "string" ? args.salt : "";
+  const namespace = typeof args.namespace === "string" ? args.namespace : "";
+  const norm = typeof args.normalize === "string" ? args.normalize : "nfkc";
 
   const cat = new Cat32({ salt, namespace, normalize: norm as any });
 
   const shouldReadFromStdin = key === undefined;
   const input = shouldReadFromStdin ? await readStdin() : key;
   const res = cat.assign(input);
-  process.stdout.write(JSON.stringify(res) + "\n");
+  const jsonOption = typeof args.json === "string" ? args.json : undefined;
+  const jsonFormat = jsonOption ?? "compact";
+  if (jsonFormat !== "compact" && jsonFormat !== "pretty") {
+    throw new RangeError(`unsupported --json value "${jsonFormat}"`);
+  }
+  const pretty = args.pretty === true || jsonFormat === "pretty";
+  const indent = pretty ? 2 : 0;
+  process.stdout.write(JSON.stringify(res, null, indent) + "\n");
 }
 
 type ReadableStdin = typeof process.stdin & {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -1884,6 +1884,48 @@ test("CLI command cat32 \"\" exits successfully", async () => {
   assert.equal(result.hash, expected.hash);
 });
 
+test("CLI outputs compact JSON when --json=compact is provided", async () => {
+  const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
+  const child = spawn(process.argv[0], [CLI_PATH, "--json=compact", "json-flag"], {
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+
+  const exitCode: number | null = await new Promise((resolve) => {
+    child.on("close", (code: number | null) => resolve(code));
+  });
+  assert.equal(exitCode, 0);
+
+  const expected = new Cat32().assign("json-flag");
+  assert.equal(stdout, JSON.stringify(expected) + "\n");
+});
+
+test("CLI pretty flag indents JSON output", async () => {
+  const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
+  const child = spawn(process.argv[0], [CLI_PATH, "--pretty", "pretty-flag"], {
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+
+  const exitCode: number | null = await new Promise((resolve) => {
+    child.on("close", (code: number | null) => resolve(code));
+  });
+  assert.equal(exitCode, 0);
+
+  const expected = new Cat32().assign("pretty-flag");
+  assert.equal(stdout, JSON.stringify(expected, null, 2) + "\n");
+});
+
 test("CLI exits with code 2 for invalid normalize option using stdin", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
   const child = spawn(process.argv[0], [CLI_PATH, "--normalize=invalid"], {


### PR DESCRIPTION
## Summary
- extend the CLI parser to accept `--json` and `--pretty` flags while preserving the default compact JSON output
- add CLI test coverage for the new `--json=compact` and `--pretty` behaviors
- document the new flags in the CLI guide and README usage section

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f1d4fed33c832195410a1fcadd2da5