### PR TITLE
ci: run real test workflow and keep reflection commits actionable

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -32,11 +32,12 @@ jobs:
           python -m pip install --upgrade pip
           python scripts/analyze.py
       - name: Commit report
+        if: github.event_name != 'workflow_run' || (github.event.workflow_run.head_commit.author.name != 'reflect-bot' && github.event.workflow_run.head_commit.author.email != 'bot@example.com')
         run: |
           git config user.name "reflect-bot"
           git config user.email "bot@example.com"
           git add reports/today.md
-          git commit -m "chore(report): reflection report [skip ci]" || echo "no changes"
+          git commit -m "chore(report): reflection report" || echo "no changes"
           git push || true
       - name: Open issue if needed (draft memo)
         if: ${{ hashFiles('reports/issue_suggestions.md') != '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,51 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # ★ プロジェクトに合わせて差し替え（ここはダミー出力）
-      - name: Run tests (dummy)
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install toolchain
+        run: npm install --no-save typescript
+      - name: Build project
+        run: npm run build
+      - name: Run test suite
         run: |
           mkdir -p logs
-          echo '{"name":"sample::ok","status":"pass","duration_ms":120}' >> logs/test.jsonl
-          echo '{"name":"sample::fail","status":"fail","duration_ms":900}' >> logs/test.jsonl
+          node --test \
+            --test-reporter tap \
+            --test-reporter-destination=logs/test.tap \
+            dist/tests
+      - name: Convert TAP to JSONL
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const tapPath = path.join('logs', 'test.tap');
+          const jsonlPath = path.join('logs', 'test.jsonl');
+          if (!fs.existsSync(tapPath)) {
+            fs.writeFileSync(jsonlPath, '');
+            process.exit(0);
+          }
+          const lines = fs.readFileSync(tapPath, 'utf8').split(/\r?\n/);
+          const fd = fs.openSync(jsonlPath, 'w');
+          let index = 0;
+          for (const rawLine of lines) {
+            const line = rawLine.trim();
+            if (!line || line.startsWith('#') || line.startsWith('TAP version') || line.startsWith('1..')) {
+              continue;
+            }
+            const match = /^(not ok|ok)\s+\d+\s*-?\s*(.*)$/.exec(line);
+            if (!match) {
+              continue;
+            }
+            index += 1;
+            const status = match[1] === 'ok' ? 'pass' : 'fail';
+            const name = match[2] ? match[2].trim() : `test-${index}`;
+            const entry = { name, status, duration_ms: 0 };
+            fs.writeSync(fd, JSON.stringify(entry) + '\n');
+          }
+          fs.closeSync(fd);
+          NODE
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- replace the placeholder CI step with a real TypeScript build and node:test run that emits TAP and converts it to JSONL logs for the reflection job
- stop adding the `[skip ci]` token to reflection commits while guarding against infinite loops by skipping bot-authored workflow_run commits

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f1ea974c9c8321a66ebaed44080645