### PR TITLE
Add test vectors validation against documentation

### DIFF
--- a/dist/tests/test_vectors.test.js
+++ b/dist/tests/test_vectors.test.js
@@ -8,29 +8,45 @@ const TEST_VECTOR_DOC_PATH = import.meta.url.includes("/dist/tests/")
 const testVectorsPromise = (async () => {
     const { readFile } = (await dynamicImport("node:fs/promises"));
     const markdown = await readFile(TEST_VECTOR_DOC_PATH.pathname, { encoding: "utf8" });
-    return {
-        unsalted: parseTable(markdown, "Unsalted"),
-        salted: parseTable(markdown, "Salted (salt=projX, namespace=v1)"),
-    };
+    return parseTables(markdown);
 })();
-test("Cat32 matches documented unsalted vectors", async () => {
-    const { unsalted } = await testVectorsPromise;
-    const cat = new Cat32();
-    for (const vector of unsalted) {
-        const assignment = cat.assign(vector.input);
-        assert.equal(assignment.hash, vector.hash, `hash mismatch for input ${JSON.stringify(vector.input)}`);
-        assert.equal(assignment.index, vector.index, `index mismatch for input ${JSON.stringify(vector.input)}`);
+const VECTOR_SUITES = [
+    {
+        heading: "Unsalted",
+        description: "Cat32 matches documented unsalted vectors",
+        options: {},
+    },
+    {
+        heading: "Salted (salt=projX, namespace=v1)",
+        description: "Cat32 matches documented salted vectors",
+        options: { salt: "projX", namespace: "v1" },
+    },
+];
+for (const suite of VECTOR_SUITES) {
+    test(suite.description, async () => {
+        const tables = await testVectorsPromise;
+        const rows = tables.get(suite.heading);
+        if (!rows) {
+            throw new Error(`table not found for heading: ${suite.heading}`);
+        }
+        const cat = new Cat32(suite.options);
+        for (const vector of rows) {
+            const assignment = cat.assign(vector.input);
+            assert.equal(assignment.key, vector.normalizedKey, `key mismatch for input ${JSON.stringify(vector.input)}`);
+            assert.equal(deriveSaltedKey(assignment.key, suite.options), vector.saltedKey, `salted key mismatch for input ${JSON.stringify(vector.input)}`);
+            assert.equal(assignment.hash, vector.hash, `hash mismatch for input ${JSON.stringify(vector.input)}`);
+            assert.equal(assignment.index, vector.index, `index mismatch for input ${JSON.stringify(vector.input)}`);
+        }
+    });
+}
+function parseTables(markdown) {
+    const headings = [...markdown.matchAll(/^##\s+(.+)$/gm)].map((match) => match[1]);
+    const tables = new Map();
+    for (const heading of headings) {
+        tables.set(heading, parseTable(markdown, heading));
     }
-});
-test("Cat32 matches documented salted vectors", async () => {
-    const { salted } = await testVectorsPromise;
-    const cat = new Cat32({ salt: "projX", namespace: "v1" });
-    for (const vector of salted) {
-        const assignment = cat.assign(vector.input);
-        assert.equal(assignment.hash, vector.hash, `hash mismatch for input ${JSON.stringify(vector.input)}`);
-        assert.equal(assignment.index, vector.index, `index mismatch for input ${JSON.stringify(vector.input)}`);
-    }
-});
+    return tables;
+}
 function parseTable(markdown, heading) {
     const sectionStart = markdown.indexOf(`## ${heading}`);
     if (sectionStart === -1) {
@@ -42,6 +58,19 @@ function parseTable(markdown, heading) {
     if (headerIndex === -1) {
         throw new Error(`table header missing for heading: ${heading}`);
     }
+    const headerCells = splitMarkdownRow(lines[headerIndex]).map((cell) => cell.trim().toLowerCase());
+    const columnIndex = new Map();
+    headerCells.forEach((name, idx) => {
+        if (name) {
+            columnIndex.set(name, idx);
+        }
+    });
+    const requiredColumns = ["input", "normalized", "salted_key", "hash_hex", "index"];
+    for (const column of requiredColumns) {
+        if (!columnIndex.has(column)) {
+            throw new Error(`column \"${column}\" missing for heading: ${heading}`);
+        }
+    }
     const rows = [];
     for (let i = headerIndex + 2; i < lines.length; i++) {
         const line = lines[i];
@@ -52,9 +81,15 @@ function parseTable(markdown, heading) {
         if (cells.length < 5) {
             continue;
         }
-        const [rawInput, , , rawHash, rawIndex] = cells;
+        const rawInput = cells[columnIndex.get("input")];
+        const rawNormalizedKey = cells[columnIndex.get("normalized")];
+        const rawSaltedKey = cells[columnIndex.get("salted_key")];
+        const rawHash = cells[columnIndex.get("hash_hex")];
+        const rawIndex = cells[columnIndex.get("index")];
         rows.push({
             input: decodeCell(rawInput),
+            normalizedKey: unescapeInlineCode(decodeCell(rawNormalizedKey)),
+            saltedKey: unescapeInlineCode(decodeCell(rawSaltedKey)),
             hash: decodeCell(rawHash).toLowerCase(),
             index: parseInt(rawIndex, 10),
         });
@@ -66,6 +101,9 @@ function decodeCell(cell) {
         return cell.slice(1, -1);
     }
     return cell;
+}
+function unescapeInlineCode(value) {
+    return value.replace(/\\`/g, "`").replace(/\\\"/g, '"');
 }
 function splitMarkdownRow(line) {
     const trimmed = line.trim();
@@ -90,4 +128,10 @@ function splitMarkdownRow(line) {
         current += char;
     }
     return cells;
+}
+function deriveSaltedKey(key, options) {
+    const baseSalt = options.salt ?? "";
+    const namespaceSuffix = options.namespace ? `|ns:${options.namespace}` : "";
+    const combined = `${baseSalt}${namespaceSuffix}`;
+    return combined ? `${key}|salt:${combined}` : key;
 }


### PR DESCRIPTION
## Summary
- parse the TEST_VECTORS.md tables dynamically so new columns remain easy to consume
- validate that Cat32-derived keys, salted keys, hashes, and indexes match the documented vectors for unsalted and salted suites

## Testing
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f1efb7bdc48321ba8daa8d65d70f19