### PR TITLE
Add ESLint configuration and CI lint step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix["node-version"] }}
-      - name: Install toolchain
-        run: npm install --no-save typescript
+      - name: Install dependencies
+        run: npm install
+      - name: Run lint
+        run: npm run lint
       - name: Build project
         run: npm run build
       - name: Run test suite

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,31 @@
+// ESLint を採用する理由: 既存の TypeScript コードベースとエコシステム互換性が高く、@typescript-eslint/recommended により型安全な静的解析を最小コストで導入できるため。
+// 基本ルールセット: eslint:recommended, plugin:@typescript-eslint/recommended
+import js from "@eslint/js";
+import globals from "globals";
+import tsParser from "@typescript-eslint/parser";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+
+export default [
+  {
+    ignores: ["dist/**"],
+  },
+  js.configs.recommended,
+  {
+    files: ["src/**/*.ts", "tests/**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+      globals: globals.node,
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -23,8 +23,26 @@
   "scripts": {
     "build": "tsc -p tsconfig.json && node -e \"const fs=require('node:fs');const path=require('node:path');const dist=path.resolve('dist');const src=path.join(dist,'src');for (const entry of fs.readdirSync(src,{withFileTypes:true})){if(entry.isFile()&&(/\\.(js|d.ts)$/.test(entry.name))){fs.copyFileSync(path.join(src,entry.name),path.join(dist,entry.name));}}\"",
     "test": "npm run build && node --test dist/tests",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint:fix": "npm run lint -- --fix"
   },
-  "engines": { "node": ">=18" },
-  "keywords": ["deterministic", "hash", "categorize", "bucketing", "consistent", "32"]
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "deterministic",
+    "hash",
+    "categorize",
+    "bucketing",
+    "consistent",
+    "32"
+  ],
+  "devDependencies": {
+    "eslint": "^9.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@eslint/js": "^9.0.0",
+    "globals": "^15.0.0"
+  }
 }


### PR DESCRIPTION
## Summary
- add an ESLint flat configuration aligned with the `@typescript-eslint/recommended` ruleset and document the rationale inline
- expose lint and lint:fix npm scripts with the necessary dev dependencies
- install dependencies and execute lint as part of the existing CI workflow

## Testing
- npm run lint *(fails locally: package downloads blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f1f1cbcd6483219b2ae127ac15432e