### PR TITLE
Add CI typecheck job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,21 @@ on:
     branches: ["**"]
   pull_request:
 jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm ci
+      - name: Install TypeScript
+        run: npm install --no-save typescript
+      - name: Type check
+        run: npx tsc --noEmit
   run:
+    needs: typecheck
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "deterministic-32",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "deterministic-32",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "cat32": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated typecheck job that installs dependencies and runs `npx tsc --noEmit`
- make the existing run job depend on the typecheck results
- add the npm lockfile so that `npm ci` can run in CI

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f1f1ca9aec83218b13808b0f5fc1b9