### PR TITLE
chore: bump typescript-eslint tooling to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   ],
   "devDependencies": {
     "eslint": "^9.0.0",
-    "@typescript-eslint/parser": "^7.0.0",
-    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@eslint/js": "^9.0.0",
     "globals": "^15.0.0"
   }


### PR DESCRIPTION
## Summary
- bump @typescript-eslint/parser and @typescript-eslint/eslint-plugin to ^8.0.0 to align with ESLint 9

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@eslint%2fjs)*
- npm ci *(fails: 403 Forbidden - GET https://registry.npmjs.org/@eslint%2fjs)*
- npm run lint *(fails: Cannot find package '@eslint/js' due to install failure)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f1fe8a0a7c8321af4ae482a4321bf3