### PR TITLE
Validate JSON flag values

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,14 +72,25 @@ function parseArgs(argv: string[]): ParsedArgs {
         let value: string;
         if (eq >= 0) {
           value = a.slice(eq + 1);
+          if (
+            spec.allowedValues !== undefined &&
+            !spec.allowedValues.includes(value)
+          ) {
+            throw new RangeError(`unsupported --${key} value "${value}"`);
+          }
         } else {
           const next = argv[i + 1];
           if (
             next !== undefined &&
             next !== "--" &&
-            !next.startsWith("--") &&
-            (spec.allowedValues === undefined || spec.allowedValues.includes(next))
+            !next.startsWith("--")
           ) {
+            if (
+              spec.allowedValues !== undefined &&
+              !spec.allowedValues.includes(next)
+            ) {
+              throw new RangeError(`unsupported --${key} value "${next}"`);
+            }
             value = next;
             i += 1;
           } else {


### PR DESCRIPTION
## Summary
- validate optional flag parsing so unsupported --json values raise a RangeError for both spaced and equals forms
- update CLI tests to keep the no-value behaviour via `--` and cover the invalid --json case

## Testing
- npm run build && node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f21dd2fa448321b2cc1ad44c16d3d2