### PR TITLE
Update test workflow to Node 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
       - name: Install dependencies
         run: npm ci
       - name: Build and run tests


### PR DESCRIPTION
## Summary
- update the CI test workflow to use Node.js 20 so that the json test reporter flag is supported

## Testing
- npm run build
- node --test dist/tests --test-reporter=json --test-reporter-destination=logs/test.jsonl

------
https://chatgpt.com/codex/tasks/task_e_68f224636f34832180774f4f27bf9aaf