### PR TITLE
fix: retain test logs after failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,19 @@ jobs:
         run: |
           npm run build
           mkdir -p logs
+          set +e
           node --test \
             dist/tests \
             --test-reporter=json \
             --test-reporter-destination=logs/test.jsonl
+          status=$?
+          set -e
+          if [ ! -f logs/test.jsonl ]; then
+            touch logs/test.jsonl
+          fi
+          exit $status
       - name: Upload logs
-        if: success()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-logs


### PR DESCRIPTION
## Summary
- ensure the test workflow keeps generating the JSON log even when tests fail
- upload the test log artifact regardless of the workflow outcome so downstream jobs can download it

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f231922cd4832191910037ebfe9601