### PR TITLE
Add coverage for resolveOutputFormat in CLI build artifacts

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -23,6 +23,11 @@ const HELP_TEXT = [
     "  --help                   Show this help message and exit.",
     "",
 ].join("\n");
+function assertAllowedFlagValue(key, value, allowedValues) {
+    if (allowedValues !== undefined && !allowedValues.includes(value)) {
+        throw new RangeError(`unsupported --${key} value "${value}"`);
+    }
+}
 function parseArgs(argv) {
     const args = {};
     let positional;
@@ -53,20 +58,14 @@ function parseArgs(argv) {
                 let value;
                 if (eq >= 0) {
                     value = a.slice(eq + 1);
-                    if (spec.allowedValues !== undefined &&
-                        !spec.allowedValues.includes(value)) {
-                        throw new RangeError(`unsupported --${key} value "${value}"`);
-                    }
+                    assertAllowedFlagValue(key, value, spec.allowedValues);
                 }
                 else {
                     const next = argv[i + 1];
                     if (next !== undefined &&
                         next !== "--" &&
                         !next.startsWith("--")) {
-                        if (spec.allowedValues !== undefined &&
-                            !spec.allowedValues.includes(next)) {
-                            throw new RangeError(`unsupported --${key} value "${next}"`);
-                        }
+                        assertAllowedFlagValue(key, next, spec.allowedValues);
                         value = next;
                         i += 1;
                     }

--- a/dist/src/cli.js
+++ b/dist/src/cli.js
@@ -23,6 +23,11 @@ const HELP_TEXT = [
     "  --help                   Show this help message and exit.",
     "",
 ].join("\n");
+function assertAllowedFlagValue(key, value, allowedValues) {
+    if (allowedValues !== undefined && !allowedValues.includes(value)) {
+        throw new RangeError(`unsupported --${key} value "${value}"`);
+    }
+}
 function parseArgs(argv) {
     const args = {};
     let positional;
@@ -53,20 +58,14 @@ function parseArgs(argv) {
                 let value;
                 if (eq >= 0) {
                     value = a.slice(eq + 1);
-                    if (spec.allowedValues !== undefined &&
-                        !spec.allowedValues.includes(value)) {
-                        throw new RangeError(`unsupported --${key} value "${value}"`);
-                    }
+                    assertAllowedFlagValue(key, value, spec.allowedValues);
                 }
                 else {
                     const next = argv[i + 1];
                     if (next !== undefined &&
                         next !== "--" &&
                         !next.startsWith("--")) {
-                        if (spec.allowedValues !== undefined &&
-                            !spec.allowedValues.includes(next)) {
-                            throw new RangeError(`unsupported --${key} value "${next}"`);
-                        }
+                        assertAllowedFlagValue(key, next, spec.allowedValues);
                         value = next;
                         i += 1;
                     }

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -581,6 +581,50 @@ test("cat32 binary accepts flag values separated by whitespace", async () => {
     assert.equal(parsed.hash, expected.hash);
     assert.equal(parsed.key, expected.key);
 });
+test("cat32 binary exits with code 2 for unsupported --json value", async () => {
+    const { spawn } = (await dynamicImport("node:child_process"));
+    const child = spawn(process.argv[0], [CLI_BIN_PATH, "--json", "foo"], {
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdin.end();
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+    });
+    const exitCode = await new Promise((resolve) => {
+        child.on("close", (code) => resolve(code));
+    });
+    assert.equal(exitCode, 2, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    assert.ok(stderr.includes('RangeError: unsupported --json value "foo"'), `stderr missing unsupported --json value error\n${stderr}`);
+});
+test("cat32 binary exits with code 2 for unsupported --json= value", async () => {
+    const { spawn } = (await dynamicImport("node:child_process"));
+    const child = spawn(process.argv[0], [CLI_BIN_PATH, "--json=foo"], {
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdin.end();
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+    });
+    const exitCode = await new Promise((resolve) => {
+        child.on("close", (code) => resolve(code));
+    });
+    assert.equal(exitCode, 2, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    assert.ok(stderr.includes('RangeError: unsupported --json value "foo"'), `stderr missing unsupported --json value error\n${stderr}`);
+});
 test("cat32 binary outputs NDJSON by default", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const child = spawn(process.argv[0], [CLI_BIN_PATH, "cli-bin-default"], {
@@ -1439,6 +1483,22 @@ test("CLI outputs compact JSON when --json is provided without a value", async (
 test("CLI exits with code 2 when --json has an invalid value", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const child = spawn(process.argv[0], [CLI_PATH, "--json", "foo"], {
+        stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+    });
+    const exitCode = await new Promise((resolve) => {
+        child.on("close", (code) => resolve(code));
+    });
+    assert.equal(exitCode, 2);
+    assert.ok(stderr.includes('unsupported --json value "foo"'), `stderr did not include unsupported --json value message: ${stderr}`);
+});
+test("CLI exits with code 2 when --json= has an invalid value", async () => {
+    const { spawn } = (await dynamicImport("node:child_process"));
+    const child = spawn(process.argv[0], [CLI_PATH, "--json=foo"], {
         stdio: ["ignore", "pipe", "pipe"],
     });
     let stderr = "";

--- a/dist/tests/cli-build.test.js
+++ b/dist/tests/cli-build.test.js
@@ -5,18 +5,29 @@ const EXPECTED_SNIPPETS = [
     "function resolveOutputFormat(args) {",
     "const jsonOption = typeof args.json === \"string\" ? args.json : undefined;",
     "const prettyFlag = args.pretty === true;",
+    "if (jsonOption === undefined) {",
     "return prettyFlag ? \"pretty\" : \"compact\";",
+    "if (jsonOption === \"compact\" || jsonOption === \"pretty\") {",
+    "if (prettyFlag) {",
+    "return jsonOption;",
     "throw new RangeError(`unsupported --json value \"${jsonOption}\"`);",
 ];
 test("dist CLI build contains resolveOutputFormat logic", async () => {
     const { fileURLToPath } = (await dynamicImport("node:url"));
     const { readFile } = (await dynamicImport("node:fs/promises"));
-    const distCliUrl = import.meta.url.includes("/dist/tests/")
-        ? new URL("../src/cli.js", import.meta.url)
-        : new URL("../dist/src/cli.js", import.meta.url);
-    const distCliPath = fileURLToPath(distCliUrl);
-    const cliSource = await readFile(distCliPath, "utf8");
-    for (const snippet of EXPECTED_SNIPPETS) {
-        assert.ok(cliSource.includes(snippet), `expected to find ${JSON.stringify(snippet)} in dist/src/cli.js`);
+    const isBuiltTest = import.meta.url.includes("/dist/tests/");
+    const distDirUrl = isBuiltTest
+        ? new URL("..", import.meta.url)
+        : new URL("../dist/", import.meta.url);
+    const targets = [
+        { description: "dist/src/cli.js", url: new URL("src/cli.js", distDirUrl) },
+        { description: "dist/cli.js", url: new URL("cli.js", distDirUrl) },
+    ];
+    for (const target of targets) {
+        const distCliPath = fileURLToPath(target.url);
+        const cliSource = await readFile(distCliPath, "utf8");
+        for (const snippet of EXPECTED_SNIPPETS) {
+            assert.ok(cliSource.includes(snippet), `expected to find ${JSON.stringify(snippet)} in ${target.description}`);
+        }
     }
 });


### PR DESCRIPTION
## Summary
- extend the CLI build test to assert that both dist/src/cli.js and the published dist/cli.js include the resolveOutputFormat logic
- rebuild the CLI bundle to include the shared flag validation helper and refreshed resolveOutputFormat implementation
- regenerate the compiled test suite so the binary checks cover unsupported --json inputs

## Testing
- npm run build
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f26103b7a083219a49e77bf017ef35