### PR TITLE
Fix CLI --json optional value handling for separated tokens

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,11 +84,12 @@ function parseArgs(argv: string[]): ParsedArgs {
           value = a.slice(eq + 1);
         } else {
           const next = argv[i + 1];
-          if (
+          const nextIsAllowedValue =
             next !== undefined &&
             next !== "--" &&
-            !next.startsWith("--")
-          ) {
+            !next.startsWith("--") &&
+            (spec.allowedValues === undefined || spec.allowedValues.includes(next));
+          if (nextIsAllowedValue) {
             value = next;
             i += 1;
           } else {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -927,7 +927,7 @@ test("cat32 binary accepts flag values separated by whitespace", async () => {
   assert.equal(parsed.key, expected.key);
 });
 
-test("cat32 binary exits with code 2 for unsupported --json value", async () => {
+test("cat32 binary treats --json separated value as positional input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 
   const child = spawn(process.argv[0], [CLI_BIN_PATH, "--json", "foo"], {
@@ -954,13 +954,14 @@ test("cat32 binary exits with code 2 for unsupported --json value", async () => 
 
   assert.equal(
     exitCode,
-    2,
+    0,
     `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
   );
-  assert.ok(
-    stderr.includes('RangeError: unsupported --json value "foo"'),
-    `stderr missing unsupported --json value error\n${stderr}`,
-  );
+
+  const parsed = JSON.parse(stdout) as { hash: string; key: string };
+  const expected = new Cat32().assign("foo");
+  assert.equal(parsed.hash, expected.hash);
+  assert.equal(parsed.key, expected.key);
 });
 
 test("cat32 binary exits with code 2 for unsupported --json= value", async () => {
@@ -2082,7 +2083,7 @@ test("CLI outputs compact JSON by default", async () => {
   assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
-test("cat32 command exits with code 2 for unsupported --json value", async () => {
+test("cat32 command treats --json separated value as positional input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 
   const cat32CommandPath = import.meta.url.includes("/dist/tests/")
@@ -2106,28 +2107,23 @@ test("cat32 command exits with code 2 for unsupported --json value", async () =>
   }
 
   const child = spawn(command, commandArgs, {
-    stdio: ["ignore", "ignore", "pipe"],
+    stdio: ["ignore", "pipe", "inherit"],
   });
 
-  let stderr = "";
-  child.stderr.setEncoding("utf8");
-  child.stderr.on("data", (chunk: string) => {
-    stderr += chunk;
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
   });
 
   const exitCode: number | null = await new Promise((resolve) => {
     child.on("close", (code: number | null) => resolve(code));
   });
 
-  assert.equal(
-    exitCode,
-    2,
-    `cat32 failed: exit code ${exitCode}\nstderr:\n${stderr}`,
-  );
-  assert.ok(
-    stderr.includes('RangeError: unsupported --json value "foo"'),
-    `stderr missing unsupported --json value error\n${stderr}`,
-  );
+  assert.equal(exitCode, 0);
+
+  const expected = new Cat32().assign("foo");
+  assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
 test("CLI outputs compact JSON when --json is provided without a value", async () => {
@@ -2151,27 +2147,26 @@ test("CLI outputs compact JSON when --json is provided without a value", async (
   assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
-test("CLI exits with code 2 when --json has an invalid value", async () => {
+test("CLI treats --json separated value as positional input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
   const child = spawn(process.argv[0], [CLI_PATH, "--json", "foo"], {
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["ignore", "pipe", "inherit"],
   });
 
-  let stderr = "";
-  child.stderr.setEncoding("utf8");
-  child.stderr.on("data", (chunk: string) => {
-    stderr += chunk;
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
   });
 
   const exitCode: number | null = await new Promise((resolve) => {
     child.on("close", (code: number | null) => resolve(code));
   });
 
-  assert.equal(exitCode, 2);
-  assert.ok(
-    stderr.includes('unsupported --json value "foo"'),
-    `stderr did not include unsupported --json value message: ${stderr}`,
-  );
+  assert.equal(exitCode, 0);
+
+  const expected = new Cat32().assign("foo");
+  assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
 test("CLI exits with code 2 when --json= has an invalid value", async () => {


### PR DESCRIPTION
## Summary
- update the CLI optional-value parsing so only allowed values are consumed and the default format is kept otherwise
- adjust CLI and cat32 binary tests to cover --json tokens separated by whitespace producing compact JSON output

## Testing
- npm run build && node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f271b8e5608321a9a99e3659b0383e