### PR TITLE
Handle optional --json value as positional input

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -61,9 +61,11 @@ function parseArgs(argv) {
                 }
                 else {
                     const next = argv[i + 1];
-                    if (next !== undefined &&
+                    const shouldConsumeNext = next !== undefined &&
                         next !== "--" &&
-                        !next.startsWith("--")) {
+                        !next.startsWith("--") &&
+                        (spec.allowedValues === undefined || spec.allowedValues.includes(next));
+                    if (shouldConsumeNext) {
                         value = next;
                         i += 1;
                     }

--- a/dist/src/cli.js
+++ b/dist/src/cli.js
@@ -61,9 +61,11 @@ function parseArgs(argv) {
                 }
                 else {
                     const next = argv[i + 1];
-                    if (next !== undefined &&
+                    const shouldConsumeNext = next !== undefined &&
                         next !== "--" &&
-                        !next.startsWith("--")) {
+                        !next.startsWith("--") &&
+                        (spec.allowedValues === undefined || spec.allowedValues.includes(next));
+                    if (shouldConsumeNext) {
                         value = next;
                         i += 1;
                     }

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -581,7 +581,7 @@ test("cat32 binary accepts flag values separated by whitespace", async () => {
     assert.equal(parsed.hash, expected.hash);
     assert.equal(parsed.key, expected.key);
 });
-test("cat32 binary exits with code 2 for unsupported --json value", async () => {
+test("cat32 binary treats unsupported --json value as positional input", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const child = spawn(process.argv[0], [CLI_BIN_PATH, "--json", "foo"], {
         stdio: ["pipe", "pipe", "pipe"],
@@ -592,16 +592,12 @@ test("cat32 binary exits with code 2 for unsupported --json value", async () => 
     child.stdout.on("data", (chunk) => {
         stdout += chunk;
     });
-    let stderr = "";
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk) => {
-        stderr += chunk;
-    });
     const exitCode = await new Promise((resolve) => {
         child.on("close", (code) => resolve(code));
     });
-    assert.equal(exitCode, 2, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
-    assert.ok(stderr.includes('RangeError: unsupported --json value "foo"'), `stderr missing unsupported --json value error\n${stderr}`);
+    assert.equal(exitCode, 0, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}`);
+    const expected = new Cat32().assign("foo");
+    assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 test("cat32 binary exits with code 2 for unsupported --json= value", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
@@ -1463,7 +1459,7 @@ test("CLI outputs compact JSON by default", async () => {
     const expected = new Cat32().assign("default-json");
     assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
-test("cat32 command exits with code 2 for unsupported --json value", async () => {
+test("cat32 command treats unsupported --json value as positional input", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const cat32CommandPath = import.meta.url.includes("/dist/tests/")
         ? new URL("../cli.js", import.meta.url).pathname
@@ -1480,18 +1476,19 @@ test("cat32 command exits with code 2 for unsupported --json value", async () =>
         commandArgs = [cat32CommandPath, "--json", "foo"];
     }
     const child = spawn(command, commandArgs, {
-        stdio: ["ignore", "ignore", "pipe"],
+        stdio: ["ignore", "pipe", "pipe"],
     });
-    let stderr = "";
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk) => {
-        stderr += chunk;
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+        stdout += chunk;
     });
     const exitCode = await new Promise((resolve) => {
         child.on("close", (code) => resolve(code));
     });
-    assert.equal(exitCode, 2, `cat32 failed: exit code ${exitCode}\nstderr:\n${stderr}`);
-    assert.ok(stderr.includes('RangeError: unsupported --json value "foo"'), `stderr missing unsupported --json value error\n${stderr}`);
+    assert.equal(exitCode, 0, `cat32 failed: exit code ${exitCode}`);
+    const expected = new Cat32().assign("foo");
+    assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 test("CLI outputs compact JSON when --json is provided without a value", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
@@ -1510,21 +1507,22 @@ test("CLI outputs compact JSON when --json is provided without a value", async (
     const expected = new Cat32().assign("json-flag");
     assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
-test("CLI exits with code 2 when --json has an invalid value", async () => {
+test("CLI treats unsupported --json value as positional input", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const child = spawn(process.argv[0], [CLI_PATH, "--json", "foo"], {
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["ignore", "pipe", "inherit"],
     });
-    let stderr = "";
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk) => {
-        stderr += chunk;
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+        stdout += chunk;
     });
     const exitCode = await new Promise((resolve) => {
         child.on("close", (code) => resolve(code));
     });
-    assert.equal(exitCode, 2);
-    assert.ok(stderr.includes('unsupported --json value "foo"'), `stderr did not include unsupported --json value message: ${stderr}`);
+    assert.equal(exitCode, 0);
+    const expected = new Cat32().assign("foo");
+    assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 test("CLI exits with code 2 when --json= has an invalid value", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));

--- a/dist/tests/cli-help.test.js
+++ b/dist/tests/cli-help.test.js
@@ -45,3 +45,15 @@ test("cat32 --help prints usage information", async () => {
     assert.equal(stderrChunks.join(""), "");
     assert.equal(stdoutChunks.join(""), HELP_OUTPUT);
 });
+test("CLI docs describe pretty JSON behavior", async () => {
+    const { readFile } = (await dynamicImport("node:fs/promises"));
+    const projectRoot = new URL("../..", import.meta.url);
+    const [readme, cliSpec] = await Promise.all([
+        readFile(new URL("README.md", projectRoot), "utf8"),
+        readFile(new URL("docs/CLI.md", projectRoot), "utf8"),
+    ]);
+    assert.ok(readme.includes("`--json=pretty` / `--pretty` / `--json --pretty` は複数行の整形 JSON"), "README should explain pretty-formatting produces multi-line JSON");
+    assert.ok(readme.includes("NDJSON はデフォルト/compact モードのみ"), "README should clarify NDJSON availability");
+    assert.ok(cliSpec.includes("整形モードでは 1 レコードが複数行の JSON"), "CLI spec should note multi-line pretty output");
+    assert.ok(cliSpec.includes("NDJSON (1 行 1 JSON オブジェクト) になるのは compact/既定モード"), "CLI spec should restrict NDJSON to compact/default modes");
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,11 +84,12 @@ function parseArgs(argv: string[]): ParsedArgs {
           value = a.slice(eq + 1);
         } else {
           const next = argv[i + 1];
-          if (
+          const shouldConsumeNext =
             next !== undefined &&
             next !== "--" &&
-            !next.startsWith("--")
-          ) {
+            !next.startsWith("--") &&
+            (spec.allowedValues === undefined || spec.allowedValues.includes(next));
+          if (shouldConsumeNext) {
             value = next;
             i += 1;
           } else {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -923,7 +923,7 @@ test("cat32 binary accepts flag values separated by whitespace", async () => {
   assert.equal(parsed.key, expected.key);
 });
 
-test("cat32 binary exits with code 2 for unsupported --json value", async () => {
+test("cat32 binary treats unsupported --json value as positional input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 
   const child = spawn(process.argv[0], [CLI_BIN_PATH, "--json", "foo"], {
@@ -938,25 +938,14 @@ test("cat32 binary exits with code 2 for unsupported --json value", async () => 
     stdout += chunk;
   });
 
-  let stderr = "";
-  child.stderr.setEncoding("utf8");
-  child.stderr.on("data", (chunk: string) => {
-    stderr += chunk;
-  });
-
   const exitCode: number | null = await new Promise((resolve) => {
     child.on("close", (code: number | null) => resolve(code));
   });
 
-  assert.equal(
-    exitCode,
-    2,
-    `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
-  );
-  assert.ok(
-    stderr.includes('RangeError: unsupported --json value "foo"'),
-    `stderr missing unsupported --json value error\n${stderr}`,
-  );
+  assert.equal(exitCode, 0, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}`);
+
+  const expected = new Cat32().assign("foo");
+  assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
 test("cat32 binary exits with code 2 for unsupported --json= value", async () => {
@@ -2078,7 +2067,7 @@ test("CLI outputs compact JSON by default", async () => {
   assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
-test("cat32 command exits with code 2 for unsupported --json value", async () => {
+test("cat32 command treats unsupported --json value as positional input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 
   const cat32CommandPath = import.meta.url.includes("/dist/tests/")
@@ -2102,28 +2091,23 @@ test("cat32 command exits with code 2 for unsupported --json value", async () =>
   }
 
   const child = spawn(command, commandArgs, {
-    stdio: ["ignore", "ignore", "pipe"],
+    stdio: ["ignore", "pipe", "pipe"],
   });
 
-  let stderr = "";
-  child.stderr.setEncoding("utf8");
-  child.stderr.on("data", (chunk: string) => {
-    stderr += chunk;
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
   });
 
   const exitCode: number | null = await new Promise((resolve) => {
     child.on("close", (code: number | null) => resolve(code));
   });
 
-  assert.equal(
-    exitCode,
-    2,
-    `cat32 failed: exit code ${exitCode}\nstderr:\n${stderr}`,
-  );
-  assert.ok(
-    stderr.includes('RangeError: unsupported --json value "foo"'),
-    `stderr missing unsupported --json value error\n${stderr}`,
-  );
+  assert.equal(exitCode, 0, `cat32 failed: exit code ${exitCode}`);
+
+  const expected = new Cat32().assign("foo");
+  assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
 test("CLI outputs compact JSON when --json is provided without a value", async () => {
@@ -2147,27 +2131,26 @@ test("CLI outputs compact JSON when --json is provided without a value", async (
   assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
-test("CLI exits with code 2 when --json has an invalid value", async () => {
+test("CLI treats unsupported --json value as positional input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
   const child = spawn(process.argv[0], [CLI_PATH, "--json", "foo"], {
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["ignore", "pipe", "inherit"],
   });
 
-  let stderr = "";
-  child.stderr.setEncoding("utf8");
-  child.stderr.on("data", (chunk: string) => {
-    stderr += chunk;
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
   });
 
   const exitCode: number | null = await new Promise((resolve) => {
     child.on("close", (code: number | null) => resolve(code));
   });
 
-  assert.equal(exitCode, 2);
-  assert.ok(
-    stderr.includes('unsupported --json value "foo"'),
-    `stderr did not include unsupported --json value message: ${stderr}`,
-  );
+  assert.equal(exitCode, 0);
+
+  const expected = new Cat32().assign("foo");
+  assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
 test("CLI exits with code 2 when --json= has an invalid value", async () => {


### PR DESCRIPTION
## Summary
- update CLI optional-value flag parsing so unsupported tokens fall back to defaults and become positional arguments
- refresh cat32 CLI tests to confirm `--json foo` succeeds and still enforces invalid `--json=` values
- rebuild distribution artifacts to capture the new parsing and test expectations

## Testing
- npm run build
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f273d843808321b2eab67651d4cc44