### PR TITLE
Add lint gate to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
     branches: ["**"]
   pull_request:
 jobs:
-  lint:
+  typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,15 +15,6 @@ jobs:
         run: npm ci
       - name: Run lint
         run: npm run lint
-  typecheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-      - name: Install dependencies
-        run: npm ci
       - name: Build and run tests
         run: |
           npm run build

--- a/tests/workflows.test.ts
+++ b/tests/workflows.test.ts
@@ -61,3 +61,27 @@ test("test workflow runs lint", async () => {
 
   assert.ok(/npm run lint/.test(workflowContent));
 });
+
+test("typecheck job runs lint before building", async () => {
+  const readFile = await loadReadFile();
+  const workflowContent = await readFile(testWorkflowUrl, "utf8");
+
+  const typecheckJobMatch = workflowContent.match(
+    /  typecheck:\n((?: {4}.+\n)+)/,
+  );
+
+  assert.ok(typecheckJobMatch, "typecheck job is not defined");
+
+  const [, typecheckJobContent] = typecheckJobMatch;
+
+  assert.ok(/run: npm run lint/.test(typecheckJobContent));
+  const lintIndex = typecheckJobContent.indexOf("run: npm run lint");
+  const buildIndex = typecheckJobContent.indexOf("npm run build");
+
+  assert.ok(lintIndex !== -1, "lint step is missing in the typecheck job");
+  assert.ok(buildIndex !== -1, "build step is missing in the typecheck job");
+  assert.ok(
+    lintIndex < buildIndex,
+    "lint should run before the build step",
+  );
+});


### PR DESCRIPTION
## Summary
- add a workflow test that checks the typecheck job runs lint before building
- update the CI workflow so the typecheck job runs npm run lint prior to build and tests

## Testing
- npm run lint && npm run build && node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f27c2083248321a75dafa52406a358