### PR TITLE
chore: pin TypeScript dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "eslint": "^9.0.0",
         "globals": "^15.0.0",
         "json": "file:reporters/json",
-        "typescript": "^5.6.3"
+        "typescript": "5.9.3"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "eslint": "^9.0.0",
     "globals": "^15.0.0",
     "json": "file:reporters/json",
-    "typescript": "^5.6.3"
+    "typescript": "5.9.3"
   }
 }

--- a/tests/package-metadata.test.ts
+++ b/tests/package-metadata.test.ts
@@ -24,5 +24,9 @@ test("package.json exposes a TypeScript dev dependency", async () => {
   );
 
   const version = (devDependencies!.typescript as string).trim();
-  assert.ok(version !== "", "expected TypeScript version to be non-empty");
+  assert.equal(
+    version,
+    "5.9.3",
+    "expected TypeScript version to be pinned to 5.9.3",
+  );
 });


### PR DESCRIPTION
## Summary
- extend the package metadata test to assert the pinned TypeScript devDependency version
- pin the TypeScript devDependency to 5.9.3 and update the lockfile to match

## Testing
- npm run build && node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f2857dcae08321889012997d1ee666