### PR TITLE
Add failure metadata handling for refresh queue

### DIFF
--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -1,0 +1,18 @@
+import type { RefreshQueueStore } from "./sw/refreshQueueStore.js";
+
+export type RetryAttempt = () => Promise<void>;
+
+export const retryQueueEntry = async (
+  store: RefreshQueueStore,
+  recordId: string,
+  attempt: RetryAttempt,
+): Promise<void> => {
+  store.recordAttempt(recordId);
+  try {
+    await attempt();
+    store.recordSuccess(recordId);
+  } catch (error) {
+    store.recordFailure(recordId, error);
+    throw error;
+  }
+};

--- a/frontend/src/sw/refreshQueueStore.ts
+++ b/frontend/src/sw/refreshQueueStore.ts
@@ -1,0 +1,68 @@
+export type RefreshQueueRecord = {
+  readonly id: string;
+  readonly request: Request;
+  readonly enqueuedAt: Date;
+  attempts: number;
+  lastAttemptedAt?: Date;
+  failedAt?: Date;
+  lastError?: unknown;
+};
+
+export type RefreshQueueStore = {
+  enqueue(request: Request): RefreshQueueRecord;
+  get(id: string): RefreshQueueRecord | undefined;
+  recordAttempt(id: string): void;
+  recordFailure(id: string, error: unknown): void;
+  recordSuccess(id: string): void;
+};
+
+let nextId = 0;
+
+const createRecord = (request: Request): RefreshQueueRecord => ({
+  id: `${Date.now().toString(36)}-${(nextId++).toString(36)}`,
+  request,
+  enqueuedAt: new Date(),
+  attempts: 0,
+});
+
+export const createRefreshQueueStore = (): RefreshQueueStore => {
+  const records = new Map<string, RefreshQueueRecord>();
+
+  const enqueue = (request: Request): RefreshQueueRecord => {
+    const record = createRecord(request);
+    records.set(record.id, record);
+    return record;
+  };
+
+  const get = (id: string): RefreshQueueRecord | undefined => records.get(id);
+
+  const recordAttempt = (id: string): void => {
+    const record = records.get(id);
+    if (!record) {
+      return;
+    }
+    record.attempts += 1;
+    record.lastAttemptedAt = new Date();
+  };
+
+  const recordFailure = (id: string, error: unknown): void => {
+    const record = records.get(id);
+    if (!record) {
+      return;
+    }
+    record.failedAt = new Date();
+    record.lastError = error;
+  };
+
+  const recordSuccess = (id: string): void => {
+    records.delete(id);
+  };
+
+  return {
+    enqueue,
+    get,
+    recordAttempt,
+    recordFailure,
+    recordSuccess,
+  };
+};

--- a/frontend/tests/sw/refresh-queue-store.test.ts
+++ b/frontend/tests/sw/refresh-queue-store.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createRefreshQueueStore } from "../../src/sw/refreshQueueStore.js";
+import { retryQueueEntry } from "../../src/sw.js";
+
+test("retryQueueEntry records failure metadata and preserves entry", async () => {
+  const store = createRefreshQueueStore();
+  const request = new Request("https://example.test/refresh", { method: "PUT" });
+  const { id } = store.enqueue(request);
+
+  const error = new Error("upstream unavailable");
+
+  let caught: unknown;
+  try {
+    await retryQueueEntry(store, id, async () => {
+      throw error;
+    });
+  } catch (thrown) {
+    caught = thrown;
+  }
+
+  if (caught === undefined) {
+    throw new Error("retryQueueEntry should throw when attempt fails");
+  }
+
+  assert.equal(caught, error, "retryQueueEntry should surface thrown error");
+
+  const record = store.get(id);
+  if (!record) {
+    throw new Error("record should still exist after retry failure");
+  }
+
+  assert.equal(record.attempts, 1, "recordAttempt should run before retry");
+  assert.equal(record.lastError, error, "recordFailure should store the thrown error");
+  assert.ok(record.failedAt instanceof Date, "failure timestamp should be saved");
+});

--- a/frontend/tests/sw/refreshQueueStore.test.ts
+++ b/frontend/tests/sw/refreshQueueStore.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createRefreshQueueStore } from "../../src/sw/refreshQueueStore.js";
+
+const createRequest = (input: string, init?: RequestInit): Request =>
+  new Request(input, init);
+
+test("recordFailure keeps entry with failure metadata", () => {
+  const store = createRefreshQueueStore();
+  const request = createRequest("https://example.test/api", { method: "POST" });
+
+  const { id } = store.enqueue(request);
+  store.recordAttempt(id);
+
+  const error = new Error("network down");
+  store.recordFailure(id, error);
+
+  const record = store.get(id);
+  if (!record) {
+    throw new Error("record should remain after failure");
+  }
+
+  assert.equal(record.lastError, error, "error reference should be stored");
+  assert.ok(record.failedAt instanceof Date, "failedAt should be timestamped");
+  assert.equal(record.attempts, 1, "attempt count should be preserved");
+});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && node -e \"const fs=require('node:fs');const path=require('node:path');const dist=path.resolve('dist');const srcRoot=path.join(dist,'src');if(fs.existsSync(srcRoot)){fs.cpSync(srcRoot,dist,{recursive:true,filter:(source)=>{if(source===srcRoot){return true;}const stat=fs.statSync(source);if(stat.isDirectory()){return true;}return source.endsWith('.js')||source.endsWith('.d.ts');}});}const reporterSrc=path.resolve('reporters/json');const reporterDest=path.resolve('node_modules/json');fs.rmSync(reporterDest,{recursive:true,force:true});fs.mkdirSync(reporterDest,{recursive:true});for(const filename of ['index.js','package.json']){fs.copyFileSync(path.join(reporterSrc,filename),path.join(reporterDest,filename));}\"",
-    "test": "npm run build && node --test dist/tests",
+    "test": "npm run build && node scripts/run-tests.js",
     "prepare": "npm run build",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
     "lint:fix": "npm run lint -- --fix"

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,0 +1,34 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+
+const defaultTargets = ["dist/tests", "dist/frontend/tests"];
+
+const mapArgument = (argument) => {
+  if (!argument.endsWith(".ts")) {
+    return argument;
+  }
+
+  const withoutExtension = argument.slice(0, -3);
+  const mapped = path.join("dist", `${withoutExtension}.js`);
+  return mapped;
+};
+
+const extraTargets = process.argv.slice(2).map(mapArgument);
+
+const child = spawn(process.execPath, ["--test", ...defaultTargets, ...extraTargets], {
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});
+
+child.on("error", (error) => {
+  throw error;
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "preserveConstEnums": true,
     "typeRoots": ["./types", "./node_modules/@types"]
   },
-  "include": ["src", "tests"]
+  "include": ["src", "tests", "frontend/src", "frontend/tests"]
 }


### PR DESCRIPTION
## Summary
- ensure refresh queue store keeps failed entries with timestamp and error metadata
- add retry helper coverage so recordAttempt runs before retry and errors propagate
- update test harness to run compiled frontend tests when TypeScript files are targeted

## Testing
- npm run test -- frontend/tests/sw/refreshQueueStore.test.ts frontend/tests/sw/refresh-queue-store.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f2855dfcf88321bc24614713e06694