### PR TITLE
Fix optional --json flag handling

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -55,24 +55,23 @@ function parseArgs(argv) {
                 args[key] = true;
             }
             else if (spec.mode === "optional-value") {
-                let value;
                 if (eq >= 0) {
-                    value = a.slice(eq + 1);
+                    const explicitValue = a.slice(eq + 1);
+                    assertAllowedFlagValue(key, explicitValue, spec.allowedValues);
+                    args[key] = explicitValue;
+                    continue;
+                }
+                const next = argv[i + 1];
+                const hasNextToken = next !== undefined && next !== "--" && !next.startsWith("--");
+                const nextIsAllowedValue = hasNextToken &&
+                    (spec.allowedValues === undefined || spec.allowedValues.includes(next));
+                if (nextIsAllowedValue) {
+                    args[key] = next;
+                    i += 1;
                 }
                 else {
-                    const next = argv[i + 1];
-                    if (next !== undefined &&
-                        next !== "--" &&
-                        !next.startsWith("--")) {
-                        value = next;
-                        i += 1;
-                    }
-                    else {
-                        value = spec.defaultValue;
-                    }
+                    args[key] = spec.defaultValue;
                 }
-                assertAllowedFlagValue(key, value, spec.allowedValues);
-                args[key] = value;
             }
             else {
                 let value;

--- a/dist/src/cli.js
+++ b/dist/src/cli.js
@@ -55,24 +55,23 @@ function parseArgs(argv) {
                 args[key] = true;
             }
             else if (spec.mode === "optional-value") {
-                let value;
                 if (eq >= 0) {
-                    value = a.slice(eq + 1);
+                    const explicitValue = a.slice(eq + 1);
+                    assertAllowedFlagValue(key, explicitValue, spec.allowedValues);
+                    args[key] = explicitValue;
+                    continue;
+                }
+                const next = argv[i + 1];
+                const hasNextToken = next !== undefined && next !== "--" && !next.startsWith("--");
+                const nextIsAllowedValue = hasNextToken &&
+                    (spec.allowedValues === undefined || spec.allowedValues.includes(next));
+                if (nextIsAllowedValue) {
+                    args[key] = next;
+                    i += 1;
                 }
                 else {
-                    const next = argv[i + 1];
-                    if (next !== undefined &&
-                        next !== "--" &&
-                        !next.startsWith("--")) {
-                        value = next;
-                        i += 1;
-                    }
-                    else {
-                        value = spec.defaultValue;
-                    }
+                    args[key] = spec.defaultValue;
                 }
-                assertAllowedFlagValue(key, value, spec.allowedValues);
-                args[key] = value;
             }
             else {
                 let value;

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -581,7 +581,7 @@ test("cat32 binary accepts flag values separated by whitespace", async () => {
     assert.equal(parsed.hash, expected.hash);
     assert.equal(parsed.key, expected.key);
 });
-test("cat32 binary exits with code 2 for unsupported --json value", async () => {
+test("cat32 binary outputs compact JSON when --json is followed by positional input", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const child = spawn(process.argv[0], [CLI_BIN_PATH, "--json", "foo"], {
         stdio: ["pipe", "pipe", "pipe"],
@@ -600,8 +600,14 @@ test("cat32 binary exits with code 2 for unsupported --json value", async () => 
     const exitCode = await new Promise((resolve) => {
         child.on("close", (code) => resolve(code));
     });
-    assert.equal(exitCode, 2, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
-    assert.ok(stderr.includes('RangeError: unsupported --json value "foo"'), `stderr missing unsupported --json value error\n${stderr}`);
+    assert.equal(exitCode, 0, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    assert.ok(stdout.endsWith("\n"));
+    const body = stdout.slice(0, -1);
+    const parsed = JSON.parse(body);
+    const expected = new Cat32().assign("foo");
+    assert.equal(parsed.hash, expected.hash);
+    assert.equal(parsed.key, expected.key);
+    assert.equal(body, JSON.stringify(parsed));
 });
 test("cat32 binary exits with code 2 for unsupported --json= value", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
@@ -1463,7 +1469,7 @@ test("CLI outputs compact JSON by default", async () => {
     const expected = new Cat32().assign("default-json");
     assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
-test("cat32 command exits with code 2 for unsupported --json value", async () => {
+test("cat32 command outputs compact JSON when --json is followed by positional input", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const cat32CommandPath = import.meta.url.includes("/dist/tests/")
         ? new URL("../cli.js", import.meta.url).pathname
@@ -1480,18 +1486,19 @@ test("cat32 command exits with code 2 for unsupported --json value", async () =>
         commandArgs = [cat32CommandPath, "--json", "foo"];
     }
     const child = spawn(command, commandArgs, {
-        stdio: ["ignore", "ignore", "pipe"],
+        stdio: ["ignore", "pipe", "inherit"],
     });
-    let stderr = "";
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk) => {
-        stderr += chunk;
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+        stdout += chunk;
     });
     const exitCode = await new Promise((resolve) => {
         child.on("close", (code) => resolve(code));
     });
-    assert.equal(exitCode, 2, `cat32 failed: exit code ${exitCode}\nstderr:\n${stderr}`);
-    assert.ok(stderr.includes('RangeError: unsupported --json value "foo"'), `stderr missing unsupported --json value error\n${stderr}`);
+    assert.equal(exitCode, 0);
+    const expected = new Cat32().assign("foo");
+    assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 test("CLI outputs compact JSON when --json is provided without a value", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
@@ -1510,21 +1517,22 @@ test("CLI outputs compact JSON when --json is provided without a value", async (
     const expected = new Cat32().assign("json-flag");
     assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
-test("CLI exits with code 2 when --json has an invalid value", async () => {
+test("CLI outputs compact JSON when --json is followed by positional input", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const child = spawn(process.argv[0], [CLI_PATH, "--json", "foo"], {
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["ignore", "pipe", "inherit"],
     });
-    let stderr = "";
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk) => {
-        stderr += chunk;
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+        stdout += chunk;
     });
     const exitCode = await new Promise((resolve) => {
         child.on("close", (code) => resolve(code));
     });
-    assert.equal(exitCode, 2);
-    assert.ok(stderr.includes('unsupported --json value "foo"'), `stderr did not include unsupported --json value message: ${stderr}`);
+    assert.equal(exitCode, 0);
+    const expected = new Cat32().assign("foo");
+    assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 test("CLI exits with code 2 when --json= has an invalid value", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));

--- a/dist/tests/workflows.test.js
+++ b/dist/tests/workflows.test.js
@@ -29,3 +29,16 @@ test("test workflow runs lint", async () => {
     const workflowContent = await readFile(testWorkflowUrl, "utf8");
     assert.ok(/npm run lint/.test(workflowContent));
 });
+test("typecheck job runs lint before building", async () => {
+    const readFile = await loadReadFile();
+    const workflowContent = await readFile(testWorkflowUrl, "utf8");
+    const typecheckJobMatch = workflowContent.match(/  typecheck:\n((?: {4}.+\n)+)/);
+    assert.ok(typecheckJobMatch, "typecheck job is not defined");
+    const [, typecheckJobContent] = typecheckJobMatch;
+    assert.ok(/run: npm run lint/.test(typecheckJobContent));
+    const lintIndex = typecheckJobContent.indexOf("run: npm run lint");
+    const buildIndex = typecheckJobContent.indexOf("npm run build");
+    assert.ok(lintIndex !== -1, "lint step is missing in the typecheck job");
+    assert.ok(buildIndex !== -1, "build step is missing in the typecheck job");
+    assert.ok(lintIndex < buildIndex, "lint should run before the build step");
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,25 +79,25 @@ function parseArgs(argv: string[]): ParsedArgs {
         }
         args[key] = true;
       } else if (spec.mode === "optional-value") {
-        let value: string;
         if (eq >= 0) {
-          value = a.slice(eq + 1);
-        } else {
-          const next = argv[i + 1];
-          const nextIsAllowedValue =
-            next !== undefined &&
-            next !== "--" &&
-            !next.startsWith("--") &&
-            (spec.allowedValues === undefined || spec.allowedValues.includes(next));
-          if (nextIsAllowedValue) {
-            value = next;
-            i += 1;
-          } else {
-            value = spec.defaultValue;
-          }
+          const explicitValue = a.slice(eq + 1);
+          assertAllowedFlagValue(key, explicitValue, spec.allowedValues);
+          args[key] = explicitValue;
+          continue;
         }
-        assertAllowedFlagValue(key, value, spec.allowedValues);
-        args[key] = value;
+
+        const next = argv[i + 1];
+        const hasNextToken = next !== undefined && next !== "--" && !next.startsWith("--");
+        const nextIsAllowedValue =
+          hasNextToken &&
+          (spec.allowedValues === undefined || spec.allowedValues.includes(next));
+
+        if (nextIsAllowedValue) {
+          args[key] = next;
+          i += 1;
+        } else {
+          args[key] = spec.defaultValue;
+        }
       } else {
         let value: string | undefined;
         if (eq >= 0) {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -923,7 +923,7 @@ test("cat32 binary accepts flag values separated by whitespace", async () => {
   assert.equal(parsed.key, expected.key);
 });
 
-test("cat32 binary treats --json separated value as positional input", async () => {
+test("cat32 binary outputs compact JSON when --json is followed by positional input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 
   const child = spawn(process.argv[0], [CLI_BIN_PATH, "--json", "foo"], {
@@ -954,10 +954,13 @@ test("cat32 binary treats --json separated value as positional input", async () 
     `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
   );
 
-  const parsed = JSON.parse(stdout) as { hash: string; key: string };
+  assert.ok(stdout.endsWith("\n"));
+  const body = stdout.slice(0, -1);
+  const parsed = JSON.parse(body) as { hash: string; key: string };
   const expected = new Cat32().assign("foo");
   assert.equal(parsed.hash, expected.hash);
   assert.equal(parsed.key, expected.key);
+  assert.equal(body, JSON.stringify(parsed));
 });
 
 test("cat32 binary exits with code 2 for unsupported --json= value", async () => {
@@ -2079,7 +2082,7 @@ test("CLI outputs compact JSON by default", async () => {
   assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
-test("cat32 command treats --json separated value as positional input", async () => {
+test("cat32 command outputs compact JSON when --json is followed by positional input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 
   const cat32CommandPath = import.meta.url.includes("/dist/tests/")
@@ -2143,7 +2146,7 @@ test("CLI outputs compact JSON when --json is provided without a value", async (
   assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
-test("CLI treats --json separated value as positional input", async () => {
+test("CLI outputs compact JSON when --json is followed by positional input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
   const child = spawn(process.argv[0], [CLI_PATH, "--json", "foo"], {
     stdio: ["ignore", "pipe", "inherit"],


### PR DESCRIPTION
## Summary
- ensure optional-value flags keep the default when the next token is not an allowed value
- update CLI and binary tests to expect compact JSON output for `--json` followed by positional input
- regenerate dist artifacts to reflect the new behaviour

## Testing
- npm run build
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f2857d6b888321a2bcbb4729e92a43