### PR TITLE
Fix JSON reporter view normalization

### DIFF
--- a/tests/json-reporter.test.ts
+++ b/tests/json-reporter.test.ts
@@ -54,3 +54,20 @@ test("JSON reporter normalizes errors", () => {
     },
   });
 });
+
+test("JSON reporter respects view ranges when normalizing binary data", () => {
+  const bytes = new Uint8Array([10, 20, 30, 40]);
+  const uint8View = bytes.subarray(1, 3);
+  const dataView = new DataView(bytes.buffer, 2, 2);
+  const event: TestEvent = {
+    type: "test:data",
+    data: { uint8View, dataView },
+  };
+
+  const normalized = toSerializableEvent(event);
+
+  assert.deepEqual(normalized.data, {
+    uint8View: [20, 30],
+    dataView: [30, 40],
+  });
+});

--- a/tests/json-reporter.ts
+++ b/tests/json-reporter.ts
@@ -21,7 +21,10 @@ function normalizeObject(value: Record<string, unknown>, seen: WeakSet<object>):
   if (seen.has(value)) return CIRCULAR;
   seen.add(value);
   if (Array.isArray(value)) return value.map((item) => normalizeUnknown(item, seen));
-  if (ArrayBuffer.isView(value)) return Array.from(new Uint8Array(value.buffer));
+  if (ArrayBuffer.isView(value)) {
+    const view = value as ArrayBufferView;
+    return Array.from(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
+  }
   if (value instanceof ArrayBuffer) return Array.from(new Uint8Array(value));
   const plain: JsonObject = {};
   for (const key of Object.keys(value)) {


### PR DESCRIPTION
## Summary
- add a regression test covering JSON reporter serialization of typed array and DataView subviews
- respect byteOffset and byteLength when normalizing ArrayBuffer views in the JSON reporter

## Testing
- npm run build && node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f28f966308832191ce8be6980a03fd