### PR TITLE
Handle typed array serialization in stableStringify

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -70,6 +70,14 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
     return stringifySentinelLiteral(`${DATE_SENTINEL_PREFIX}${v.toISOString()}`);
   }
 
+  if (ArrayBuffer.isView(v)) {
+    return stringifyStringLiteral(String(v));
+  }
+
+  if (v instanceof ArrayBuffer) {
+    return stringifyStringLiteral(String(v));
+  }
+
   // Map
   if (v instanceof Map) {
     if (stack.has(v)) throw new TypeError("Cyclic object");

--- a/tests/stable-stringify-typed-array.test.ts
+++ b/tests/stable-stringify-typed-array.test.ts
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { Cat32, stableStringify } from "../src/index.js";
+
+test("Cat32 assign key matches JSON.stringify for typed array views", () => {
+  const value = new Uint8Array([1, 2]);
+  const assignment = new Cat32().assign(value);
+  assert.equal(assignment.key, JSON.stringify(String(value)));
+});
+
+test("Cat32 assign key matches JSON.stringify for ArrayBuffer", () => {
+  const value = new ArrayBuffer(4);
+  const assignment = new Cat32().assign(value);
+  assert.equal(assignment.key, JSON.stringify(String(value)));
+});
+
+test("stableStringify matches JSON.stringify for typed array views", () => {
+  const value = new Uint8Array([1, 2]);
+  assert.equal(stableStringify(value), JSON.stringify(String(value)));
+});
+
+test("stableStringify matches JSON.stringify for ArrayBuffer", () => {
+  const value = new ArrayBuffer(4);
+  assert.equal(stableStringify(value), JSON.stringify(String(value)));
+});


### PR DESCRIPTION
## Summary
- add regression coverage for Cat32.assign and stableStringify with typed arrays and ArrayBuffers
- normalize ArrayBuffer views and ArrayBuffers via stringifyStringLiteral in stable stringify

## Testing
- npm run build
- node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f29a0f1aa8832180704b9564b0c735