### PR TITLE
Handle SharedArrayBuffer in stable stringify

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -13,6 +13,20 @@ const UNDEFINED_SENTINEL = "__undefined__";
 const DATE_SENTINEL_PREFIX = "__date__:";
 const STRING_LITERAL_SENTINEL_PREFIX = "__string__:";
 
+type ArrayBufferLikeConstructor = {
+  new (...args: unknown[]): ArrayBufferLike;
+  prototype: ArrayBufferLike;
+};
+
+const sharedArrayBufferGlobal = globalThis as unknown as {
+  SharedArrayBuffer?: ArrayBufferLikeConstructor;
+};
+
+const sharedArrayBufferCtor =
+  typeof sharedArrayBufferGlobal.SharedArrayBuffer === "function"
+    ? sharedArrayBufferGlobal.SharedArrayBuffer
+    : undefined;
+
 export function typeSentinel(type: string, payload = ""): string {
   return `${SENTINEL_PREFIX}${type}:${payload}${SENTINEL_SUFFIX}`;
 }
@@ -71,6 +85,10 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
   }
 
   if (ArrayBuffer.isView(v)) {
+    return stringifyStringLiteral(String(v));
+  }
+
+  if (sharedArrayBufferCtor && v instanceof sharedArrayBufferCtor) {
     return stringifyStringLiteral(String(v));
   }
 

--- a/tests/serialize-typed-array.test.ts
+++ b/tests/serialize-typed-array.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { Cat32, stableStringify } from "../src/index.js";
+
+const typedArray = new Uint8Array([10, 20, 30]);
+
+const sharedArrayBuffer =
+  typeof SharedArrayBuffer === "function" ? new SharedArrayBuffer(4) : undefined;
+
+if (sharedArrayBuffer) {
+  const sharedView = new Uint8Array(sharedArrayBuffer);
+  for (let i = 0; i < sharedView.length; i += 1) {
+    sharedView[i] = i + 1;
+  }
+}
+
+test("stableStringify of Uint8Array matches JSON string of its String coercion", () => {
+  const value = new Uint8Array(typedArray);
+  assert.equal(stableStringify(value), JSON.stringify(String(value)));
+});
+
+test("Cat32.assign key for Uint8Array matches JSON string of its String coercion", () => {
+  const value = new Uint8Array(typedArray);
+  const assignment = new Cat32().assign(value);
+  assert.equal(assignment.key, JSON.stringify(String(value)));
+});
+
+if (sharedArrayBuffer) {
+  test("stableStringify of SharedArrayBuffer view matches JSON string of its String coercion", () => {
+    const view = new Uint8Array(sharedArrayBuffer);
+    assert.equal(stableStringify(view), JSON.stringify(String(view)));
+  });
+
+  test("Cat32.assign key for SharedArrayBuffer view matches JSON string of its String coercion", () => {
+    const view = new Uint8Array(sharedArrayBuffer);
+    const assignment = new Cat32().assign(view);
+    assert.equal(assignment.key, JSON.stringify(String(view)));
+  });
+}


### PR DESCRIPTION
## Summary
- add regression tests covering typed array serialization for stableStringify and Cat32.assign
- normalize SharedArrayBuffer instances by stringifying their String() output just like typed array views

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f29e1a814483218694718d99dc69db