### PR TITLE
Clone refresh queue requests before storage

### DIFF
--- a/frontend/src/sw/refreshQueueStore.ts
+++ b/frontend/src/sw/refreshQueueStore.ts
@@ -18,12 +18,16 @@ export type RefreshQueueStore = {
 
 let nextId = 0;
 
-const createRecord = (request: Request): RefreshQueueRecord => ({
-  id: `${Date.now().toString(36)}-${(nextId++).toString(36)}`,
-  request,
-  enqueuedAt: new Date(),
-  attempts: 0,
-});
+const createRecord = (request: Request): RefreshQueueRecord => {
+  const clonedRequest = request.clone();
+
+  return {
+    id: `${Date.now().toString(36)}-${(nextId++).toString(36)}`,
+    request: clonedRequest,
+    enqueuedAt: new Date(),
+    attempts: 0,
+  };
+};
 
 export const createRefreshQueueStore = (): RefreshQueueStore => {
   const records = new Map<string, RefreshQueueRecord>();


### PR DESCRIPTION
## Summary
- add a regression test asserting that enqueue stores a cloned request
- clone incoming requests when creating refresh queue records

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f2a5e793408321a5667ccdbbb2aa00