### PR TITLE
Handle SharedArrayBuffer in JSON reporter

### DIFF
--- a/tests/json-reporter.test.ts
+++ b/tests/json-reporter.test.ts
@@ -99,6 +99,16 @@ test("JSON reporter serializes typed array views with byte offsets", () => {
   assert.deepEqual(normalized.data, [10, 15]);
 });
 
+test("JSON reporter serializes SharedArrayBuffer into byte arrays", () => {
+  const buffer = new SharedArrayBuffer(4);
+  new Uint8Array(buffer).set([7, 14, 21, 28]);
+  const event: TestEvent = { type: "test:data", data: buffer };
+
+  const normalized = toSerializableEvent(event);
+
+  assert.deepEqual(normalized.data, [7, 14, 21, 28]);
+});
+
 test("JSON reporter respects ArrayBuffer view offsets", () => {
   const source = new Uint8Array([10, 20, 30, 40]).buffer;
   const event: TestEvent = {

--- a/tests/json-reporter.ts
+++ b/tests/json-reporter.ts
@@ -28,6 +28,9 @@ function normalizeObject(value: object, seen: WeakSet<object>): JsonValue {
     if (value instanceof ArrayBuffer) {
       return Array.from(new Uint8Array(value, 0, value.byteLength));
     }
+    if (typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer) {
+      return Array.from(new Uint8Array(value));
+    }
     const plain: JsonObject = {};
     for (const [key, entryValue] of Object.entries(value)) {
       plain[key] = normalizeUnknown(entryValue, seen);


### PR DESCRIPTION
## Summary
- add coverage to ensure the JSON reporter serializes SharedArrayBuffer instances to byte arrays
- convert SharedArrayBuffer objects to Uint8Array output when normalizing events

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f2a5e7483483218721fcca62516d84