### PR TITLE
Handle SharedArrayBuffer normalization in JSON reporter tests

### DIFF
--- a/tests/json-reporter.test.ts
+++ b/tests/json-reporter.test.ts
@@ -109,6 +109,16 @@ test("JSON reporter serializes SharedArrayBuffer into byte arrays", () => {
   assert.deepEqual(normalized.data, [7, 14, 21, 28]);
 });
 
+test("JSON reporter normalizes SharedArrayBuffer entries inside objects", () => {
+  const buffer = new SharedArrayBuffer(3);
+  new Uint8Array(buffer).set([1, 2, 3]);
+  const event: TestEvent = { type: "test:data", data: { payload: buffer } };
+
+  const normalized = toSerializableEvent(event);
+
+  assert.deepEqual(normalized.data, { payload: [1, 2, 3] });
+});
+
 test("JSON reporter respects ArrayBuffer view offsets", () => {
   const source = new Uint8Array([10, 20, 30, 40]).buffer;
   const event: TestEvent = {

--- a/tests/json-reporter.ts
+++ b/tests/json-reporter.ts
@@ -25,11 +25,11 @@ function normalizeObject(value: object, seen: WeakSet<object>): JsonValue {
     if (ArrayBuffer.isView(value)) {
       return Array.from(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
     }
-    if (value instanceof ArrayBuffer) {
-      return Array.from(new Uint8Array(value, 0, value.byteLength));
-    }
-    if (typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer) {
-      return Array.from(new Uint8Array(value));
+    const isSharedArrayBuffer =
+      typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer;
+    if (value instanceof ArrayBuffer || isSharedArrayBuffer) {
+      const buffer = value as ArrayBuffer | SharedArrayBuffer;
+      return Array.from(new Uint8Array(buffer));
     }
     const plain: JsonObject = {};
     for (const [key, entryValue] of Object.entries(value)) {


### PR DESCRIPTION
## Summary
- add a regression test covering SharedArrayBuffer normalization inside serialized events
- normalize SharedArrayBuffer instances to byte arrays when converting events

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f2abd6cb30832195a9554bfaa01cb3