### PR TITLE
Add SharedArrayBuffer serialization check for dist JSON reporter

### DIFF
--- a/dist/tests/json-reporter-build.test.js
+++ b/dist/tests/json-reporter-build.test.js
@@ -13,3 +13,14 @@ test("dist JSON reporter removes seen references after normalization", async () 
     assert.ok(FINALLY_PATTERN.test(source), "expected finally block to be emitted");
     assert.ok(SEEN_DELETE_PATTERN.test(source), "expected seen.delete(value) to be emitted");
 });
+test("dist JSON reporter serializes SharedArrayBuffer data to a byte array", async () => {
+    if (typeof SharedArrayBuffer === "undefined") {
+        return;
+    }
+    const module = (await dynamicImport(distJsonReporterUrl.href));
+    const shared = new SharedArrayBuffer(4);
+    const view = new Uint8Array(shared);
+    view.set([1, 2, 3, 4]);
+    const serialized = module.toSerializableEvent({ type: "test", data: shared });
+    assert.deepEqual(serialized.data, [1, 2, 3, 4]);
+});

--- a/dist/tests/json-reporter.js
+++ b/dist/tests/json-reporter.js
@@ -20,8 +20,10 @@ function normalizeObject(value, seen) {
         if (ArrayBuffer.isView(value)) {
             return Array.from(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
         }
-        if (value instanceof ArrayBuffer) {
-            return Array.from(new Uint8Array(value, 0, value.byteLength));
+        const isSharedArrayBuffer = typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer;
+        if (value instanceof ArrayBuffer || isSharedArrayBuffer) {
+            const buffer = value;
+            return Array.from(new Uint8Array(buffer));
         }
         const plain = {};
         for (const [key, entryValue] of Object.entries(value)) {

--- a/tests/json-reporter-build.test.ts
+++ b/tests/json-reporter-build.test.ts
@@ -28,3 +28,23 @@ test("dist JSON reporter removes seen references after normalization", async () 
     "expected seen.delete(value) to be emitted",
   );
 });
+
+test("dist JSON reporter serializes SharedArrayBuffer data to a byte array", async () => {
+  if (typeof SharedArrayBuffer === "undefined") {
+    return;
+  }
+
+  const module = (await dynamicImport(distJsonReporterUrl.href)) as {
+    toSerializableEvent: (event: { type: string; data?: unknown }) => {
+      readonly data?: unknown;
+    };
+  };
+
+  const shared = new SharedArrayBuffer(4);
+  const view = new Uint8Array(shared);
+  view.set([1, 2, 3, 4]);
+
+  const serialized = module.toSerializableEvent({ type: "test", data: shared });
+
+  assert.deepEqual(serialized.data, [1, 2, 3, 4]);
+});


### PR DESCRIPTION
## Summary
- add a regression test that imports the dist JSON reporter to assert SharedArrayBuffer normalization
- regenerate the compiled dist reporter so SharedArrayBuffer instances serialize to byte arrays

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f2af58a1448321b0d569dc43600643