### PR TITLE
Fix analyze.py p95 percentile handling

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1,6 +1,22 @@
 import json, statistics, pathlib, os, datetime
 from collections import Counter
 
+
+def compute_p95(durations: list[int]) -> int:
+    if not durations:
+        return 0
+    if len(durations) >= 20:
+        return int(statistics.quantiles(durations, n=20)[18])
+    ordered = sorted(durations)
+    if len(ordered) == 1:
+        return int(ordered[0])
+    position = 0.95 * (len(ordered) - 1)
+    lower_index = int(position)
+    upper_index = min(lower_index + 1, len(ordered) - 1)
+    fraction = position - lower_index
+    interpolated = ordered[lower_index] + (ordered[upper_index] - ordered[lower_index]) * fraction
+    return int(interpolated)
+
 LOG = pathlib.Path("logs/test.jsonl")
 REPORT = pathlib.Path("reports/today.md")
 ISSUE_OUT = pathlib.Path("reports/issue_suggestions.md")
@@ -22,7 +38,7 @@ def main():
     tests, durs, fails = load_results()
     total = len(tests) or 1
     pass_rate = (total - len(fails)) / total
-    p95 = int(statistics.quantiles(durs or [0], n=20)[18]) if durs else 0
+    p95 = compute_p95(durs)
     now = datetime.datetime.utcnow().isoformat()
     REPORT.parent.mkdir(parents=True, exist_ok=True)
     with REPORT.open("w", encoding="utf-8") as f:

--- a/tests/analyze-script.test.ts
+++ b/tests/analyze-script.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
+
+type ExecFile = (
+  file: string,
+  args: readonly string[],
+  options: { cwd?: string; encoding?: string },
+  callback: ExecFileCallback,
+) => void;
+
+type FsPromisesModule = {
+  readFile(path: string, options: { encoding: "utf8" }): Promise<string>;
+  writeFile(path: string, data: string, options: { encoding: "utf8" }): Promise<void>;
+  rm(path: string, options: { force?: boolean }): Promise<void>;
+};
+
+type PathModule = {
+  join(...segments: string[]): string;
+};
+
+const dynamicImport = new Function(
+  "specifier",
+  "return import(specifier);",
+) as (specifier: string) => Promise<unknown>;
+
+const TEST_LOG_CONTENT = `${JSON.stringify({
+  name: "sample::single",
+  status: "pass",
+  duration_ms: 150,
+})}\n`;
+
+test("analyze.py はサンプルが少なくても p95 を計算できる", async () => {
+  const { execFile } = (await dynamicImport("node:child_process")) as { execFile: ExecFile };
+  const { readFile, rm, writeFile } = (await dynamicImport("node:fs/promises")) as FsPromisesModule;
+  const { join } = (await dynamicImport("node:path")) as PathModule;
+
+  const repoRootPath = (process as unknown as { cwd(): string }).cwd();
+  const logPath = join(repoRootPath, "logs", "test.jsonl");
+  const reportPath = join(repoRootPath, "reports", "today.md");
+
+  const originalLog = await readFile(logPath, { encoding: "utf8" }).catch(() => null);
+  const originalReport = await readFile(reportPath, { encoding: "utf8" }).catch(() => null);
+
+  try {
+    await writeFile(logPath, TEST_LOG_CONTENT, { encoding: "utf8" });
+
+    await new Promise<void>((resolve, reject) => {
+      execFile(
+        "python3",
+        ["scripts/analyze.py"],
+        { cwd: repoRootPath, encoding: "utf8" },
+        (error: Error | null, _stdout: string, stderr: string) => {
+          if (error) {
+            const message =
+              stderr.length > 0 ? `analyze.py failed: ${stderr}` : "analyze.py exited with a non-zero status";
+            reject(new Error(message, { cause: error }));
+            return;
+          }
+          resolve();
+        },
+      );
+    });
+
+    const report = await readFile(reportPath, { encoding: "utf8" });
+    assert.ok(report.includes("Duration p95: 150 ms"), "p95 がログの値と一致するはず");
+  } finally {
+    if (originalLog === null) {
+      await rm(logPath, { force: true });
+    } else {
+      await writeFile(logPath, originalLog, { encoding: "utf8" });
+    }
+
+    if (originalReport === null) {
+      await rm(reportPath, { force: true });
+    } else {
+      await writeFile(reportPath, originalReport, { encoding: "utf8" });
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add a node:test regression that exercises scripts/analyze.py with a single log entry
- refactor analyze.py to compute p95 safely for fewer than 20 samples while retaining the existing path for larger sets

## Testing
- npm test -- tests/analyze-script.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f2b6e335c0832185915d45f815d60b