### PR TITLE
Ensure CI JSON runner executes frontend tests

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -5,7 +5,34 @@ import { pathToFileURL } from 'node:url';
 
 const DESTINATION_PREFIX = '--test-reporter-destination=';
 const DEFAULT_DESTINATION = 'logs/test.jsonl';
-const DEFAULT_TARGET = 'dist/tests';
+const DEFAULT_TARGETS = ['dist/tests', 'dist/frontend/tests'];
+
+const resolveTargets = () => {
+  const targets = [];
+  for (const candidate of DEFAULT_TARGETS) {
+    if (fs.existsSync(candidate)) {
+      targets.push(candidate);
+    }
+  }
+
+  for (const argument of process.argv.slice(2)) {
+    if (!argument || argument.startsWith('--')) {
+      continue;
+    }
+    if (!fs.existsSync(argument)) {
+      continue;
+    }
+    if (!targets.includes(argument)) {
+      targets.push(argument);
+    }
+  }
+
+  if (targets.length === 0) {
+    targets.push(DEFAULT_TARGETS[0]);
+  }
+
+  return targets;
+};
 
 const resolveDestination = () => {
   for (const entry of fs.readdirSync('.', { withFileTypes: true })) {
@@ -32,12 +59,13 @@ const destination = resolveDestination();
 const resolvedDestination = path.resolve(destination);
 fs.mkdirSync(path.dirname(resolvedDestination), { recursive: true });
 
+const targets = resolveTargets();
 const reporterSpecifier = pathToFileURL(path.resolve('reporters/json/index.js')).href;
 const args = [
   '--test',
   `--test-reporter=${reporterSpecifier}`,
   `--test-reporter-destination=${resolvedDestination}`,
-  DEFAULT_TARGET
+  ...targets
 ];
 
 const childEnv = { ...process.env };

--- a/tests/workflows.test.ts
+++ b/tests/workflows.test.ts
@@ -85,3 +85,14 @@ test("typecheck job runs lint before building", async () => {
     "lint should run before the build step",
   );
 });
+
+test("JSON reporter runner covers frontend tests", async () => {
+  const readFile = await loadReadFile();
+  const runnerUrl = new URL("--test-reporter=json", repositoryRoot);
+  const runnerContent = await readFile(runnerUrl, "utf8");
+
+  assert.ok(
+    runnerContent.includes("dist/frontend/tests"),
+    "frontend test suite must be executed by JSON reporter runner",
+  );
+});


### PR DESCRIPTION
## Summary
- ensure the JSON reporter bootstrap includes both backend and frontend compiled test suites
- add a regression test so the workflow keeps exercising the frontend tests when generating JSON reports

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f30d825e1c8321920c600b75687384