### PR TITLE
Fix duplicate constant name in analyze script test

### DIFF
--- a/tests/analyze-script.test.ts
+++ b/tests/analyze-script.test.ts
@@ -31,7 +31,7 @@ const dynamicImport = new Function(
   "return import(specifier);",
 ) as (specifier: string) => Promise<unknown>;
 
-const DATA_WRAPPED_LOG_CONTENT = `${JSON.stringify({
+const LEGACY_LOG_CONTENT = `${JSON.stringify({
   name: "sample::single",
   status: "pass",
   data: { duration_ms: 150 },
@@ -113,7 +113,7 @@ test("analyze.py はサンプルが少なくても p95 を計算できる", asyn
       rm(issuePath, { force: true }),
     ]);
 
-    await writeFile(logPath, DATA_WRAPPED_LOG_CONTENT, { encoding: "utf8" });
+    await writeFile(logPath, LEGACY_LOG_CONTENT, { encoding: "utf8" });
 
     await new Promise<void>((resolve, reject) => {
       execFile(


### PR DESCRIPTION
## Summary
- rename the legacy log fixture in analyze-script.test.ts to avoid a duplicate constant declaration
- use the renamed constant in the p95 calculation test so the legacy fixture is written correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f31e41fc9c832193f2c4e22dd3f25f