### PR TITLE
Ensure analyze.py ignores diagnostic events

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -138,11 +138,17 @@ def load_results() -> Tuple[list[str], list[int], list[str]]:
             obj = json.loads(line)
             if not isinstance(obj, dict):
                 continue
-            parsed_event = _load_from_event(obj)
-            parsed = parsed_event if parsed_event is not None else _load_from_legacy(obj)
+            event_type = obj.get("type")
+            parsed: Optional[ParsedEntry]
+            if isinstance(event_type, str):
+                if event_type not in ALLOWED_EVENT_TYPES:
+                    continue
+                parsed = _load_from_event(obj)
+            else:
+                parsed = _load_from_legacy(obj)
             if parsed is None:
                 continue
-            name, duration, is_failure = entry
+            name, duration, is_failure = parsed
             tests.append(name)
             durs.append(duration)
             if is_failure:


### PR DESCRIPTION
## Summary
- add a regression test that exercises load_results to ensure diagnostic events are ignored
- adjust scripts/analyze.py to only aggregate pass/fail events while keeping legacy entries supported

## Testing
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f322a32ea08321b646fe30fadf11cc