### PR TITLE
Ensure analyze cleanup removes stale issue report

### DIFF
--- a/dist/tests/analyze-script.test.js
+++ b/dist/tests/analyze-script.test.js
@@ -6,6 +6,24 @@ const TEST_LOG_CONTENT = `${JSON.stringify({
     status: "pass",
     duration_ms: 150,
 })}\n`;
+const LOG_WITH_DIAGNOSTIC_CONTENT = `${JSON.stringify({
+    name: "sample::pass",
+    status: "pass",
+    duration_ms: 100,
+})}\n` +
+    `${JSON.stringify({
+        name: "sample::fail",
+        status: "fail",
+        duration_ms: 200,
+    })}\n` +
+    `${JSON.stringify({
+        type: "test:diagnostic",
+        data: { message: "informational" },
+    })}\n`;
+const PASS_ONLY_LOG_CONTENT = `${JSON.stringify({
+    type: "test:pass",
+    data: { name: "recovered", duration_ms: 10 },
+})}\n`;
 const DATA_WRAPPED_LOG_CONTENT = [
     { type: "test:pass", data: { name: "suite::alpha", status: "pass", duration_ms: 200 } },
     { type: "test:fail", data: { name: "suite::beta", status: "fail", duration_ms: 400 } },
@@ -38,6 +56,65 @@ test("analyze.py はサンプルが少なくても p95 を計算できる", asyn
         });
         const report = await readFile(reportPath, { encoding: "utf8" });
         assert.ok(report.includes("Duration p95: 150 ms"), "p95 がログの値と一致するはず");
+    }
+    finally {
+        if (originalLog === null) {
+            await rm(logPath, { force: true });
+        }
+        else {
+            await writeFile(logPath, originalLog, { encoding: "utf8" });
+        }
+        if (originalReport === null) {
+            await rm(reportPath, { force: true });
+        }
+        else {
+            await writeFile(reportPath, originalReport, { encoding: "utf8" });
+        }
+        if (originalIssue === null) {
+            await rm(issuePath, { force: true });
+        }
+        else {
+            await writeFile(issuePath, originalIssue, { encoding: "utf8" });
+        }
+    }
+});
+test("analyze.py は失敗後に成功すると issue_suggestions.md を片付ける", async () => {
+    const { execFile } = (await dynamicImport("node:child_process"));
+    const { readFile, rm, writeFile } = (await dynamicImport("node:fs/promises"));
+    const { join } = (await dynamicImport("node:path"));
+    const repoRootPath = process.cwd();
+    const logPath = join(repoRootPath, "logs", "test.jsonl");
+    const reportPath = join(repoRootPath, "reports", "today.md");
+    const issuePath = join(repoRootPath, "reports", "issue_suggestions.md");
+    const originalLog = await readFile(logPath, { encoding: "utf8" }).catch(() => null);
+    const originalReport = await readFile(reportPath, { encoding: "utf8" }).catch(() => null);
+    const originalIssue = await readFile(issuePath, { encoding: "utf8" }).catch(() => null);
+    const runAnalyze = () => new Promise((resolve, reject) => {
+        execFile("python3", ["scripts/analyze.py"], { cwd: repoRootPath, encoding: "utf8" }, (error, _stdout, stderr) => {
+            if (error) {
+                const message = stderr.length > 0 ? `analyze.py failed: ${stderr}` : "analyze.py exited with a non-zero status";
+                reject(new Error(message, { cause: error }));
+                return;
+            }
+            resolve();
+        });
+    });
+    try {
+        await writeFile(logPath, LOG_WITH_DIAGNOSTIC_CONTENT, { encoding: "utf8" });
+        await runAnalyze();
+        const issueReportAfterFailure = await readFile(issuePath, { encoding: "utf8" });
+        assert.ok(issueReportAfterFailure.includes("- [ ]"), "失敗時は issue_suggestions.md が生成されるはず");
+        await writeFile(logPath, PASS_ONLY_LOG_CONTENT, { encoding: "utf8" });
+        await runAnalyze();
+        const issueReportAfterSuccess = await readFile(issuePath, { encoding: "utf8" }).catch((error) => {
+            if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+                return null;
+            }
+            throw error;
+        });
+        if (issueReportAfterSuccess !== null) {
+            assert.equal(issueReportAfterSuccess.trim(), "", "成功時は issue_suggestions.md が空になるはず");
+        }
     }
     finally {
         if (originalLog === null) {

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -142,7 +142,7 @@ def load_results() -> Tuple[list[str], list[int], list[str]]:
             parsed = parsed_event if parsed_event is not None else _load_from_legacy(obj)
             if parsed is None:
                 continue
-            name, duration, is_failure = entry
+            name, duration, is_failure = parsed
             tests.append(name)
             durs.append(duration)
             if is_failure:
@@ -175,5 +175,10 @@ def main() -> None:
             f.write("### 反省TODO\n")
             for name in set(fails):
                 f.write(f"- [ ] {name} の再現手順/前提/境界値を追加\n")
+    else:
+        try:
+            ISSUE_OUT.unlink()
+        except FileNotFoundError:
+            pass
 if __name__ == "__main__":
     main()

--- a/tests/analyze-script.test.ts
+++ b/tests/analyze-script.test.ts
@@ -78,6 +78,11 @@ const MINIMAL_JSONL_LOG_CONTENT =
     data: { name: "ng", duration_ms: 7 },
   })}\n`;
 
+const PASS_ONLY_LOG_CONTENT = `${JSON.stringify({
+  type: "test:pass",
+  data: { name: "recovered", duration_ms: 10 },
+})}\n`;
+
 const EMPTY_LOG_CONTENT = "";
 
 test("analyze.py はサンプルが少なくても p95 を計算できる", async () => {
@@ -156,6 +161,77 @@ test("analyze.py はサンプルが少なくても p95 を計算できる", asyn
       rm(reportPath, { force: true }),
       rm(issuePath, { force: true }),
     ]);
+  }
+});
+
+test("analyze.py は失敗後に成功すると issue_suggestions.md を片付ける", async () => {
+  const { execFile } = (await dynamicImport("node:child_process")) as { execFile: ExecFile };
+  const { readFile, rm, writeFile } = (await dynamicImport("node:fs/promises")) as FsPromisesModule;
+  const { join } = (await dynamicImport("node:path")) as PathModule;
+
+  const envProcess = process as unknown as ProcessLike;
+  const repoRootPath = envProcess.cwd();
+  const logPath = join(repoRootPath, "logs", "test.jsonl");
+  const reportPath = join(repoRootPath, "reports", "today.md");
+  const issuePath = join(repoRootPath, "reports", "issue_suggestions.md");
+
+  const originalLog = await readFile(logPath, { encoding: "utf8" }).catch(() => null);
+  const originalReport = await readFile(reportPath, { encoding: "utf8" }).catch(() => null);
+  const originalIssue = await readFile(issuePath, { encoding: "utf8" }).catch(() => null);
+
+  const runAnalyze = async () =>
+    new Promise<void>((resolve, reject) => {
+      execFile(
+        "python3",
+        ["scripts/analyze.py"],
+        { cwd: repoRootPath, encoding: "utf8" },
+        (error: Error | null, _stdout: string, stderr: string) => {
+          if (error) {
+            const message =
+              stderr.length > 0 ? `analyze.py failed: ${stderr}` : "analyze.py exited with a non-zero status";
+            reject(new Error(message, { cause: error }));
+            return;
+          }
+          resolve();
+        },
+      );
+    });
+
+  try {
+    await writeFile(logPath, LOG_WITH_DIAGNOSTIC_CONTENT, { encoding: "utf8" });
+    await runAnalyze();
+
+    const issueReportAfterFailure = await readFile(issuePath, { encoding: "utf8" });
+    assert.ok(issueReportAfterFailure.includes("- [ ]"), "失敗時は issue_suggestions.md が生成されるはず");
+
+    await writeFile(logPath, PASS_ONLY_LOG_CONTENT, { encoding: "utf8" });
+    await runAnalyze();
+
+    const issueReportAfterSuccess = await readFile(issuePath, { encoding: "utf8" }).catch((error: unknown) => {
+      if (typeof error === "object" && error !== null && "code" in error && (error as { code?: string }).code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    });
+    if (issueReportAfterSuccess !== null) {
+      assert.equal(issueReportAfterSuccess.trim(), "", "成功時は issue_suggestions.md が空になるはず");
+    }
+  } finally {
+    if (originalLog === null) {
+      await rm(logPath, { force: true });
+    } else {
+      await writeFile(logPath, originalLog, { encoding: "utf8" });
+    }
+    if (originalReport === null) {
+      await rm(reportPath, { force: true });
+    } else {
+      await writeFile(reportPath, originalReport, { encoding: "utf8" });
+    }
+    if (originalIssue === null) {
+      await rm(issuePath, { force: true });
+    } else {
+      await writeFile(issuePath, originalIssue, { encoding: "utf8" });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- add a regression test that simulates a failure followed by success and ensures the issue suggestions report is cleared
- remove stale issue reports when no failures remain and fix result parsing to avoid NameError

## Testing
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f322a3e9808321a37c036b381e6853