### PR TITLE
Update analyze script log parsing to skip non-test events

### DIFF
--- a/tests/analyze-script.test.ts
+++ b/tests/analyze-script.test.ts
@@ -31,7 +31,7 @@ const dynamicImport = new Function(
   "return import(specifier);",
 ) as (specifier: string) => Promise<unknown>;
 
-const DATA_WRAPPED_LOG_CONTENT = `${JSON.stringify({
+const SINGLE_ENTRY_LOG_CONTENT = `${JSON.stringify({
   name: "sample::single",
   status: "pass",
   data: { duration_ms: 150 },
@@ -115,7 +115,7 @@ test("analyze.py はサンプルが少なくても p95 を計算できる", asyn
       rm(issuePath, { force: true }),
     ]);
 
-    await writeFile(logPath, DATA_WRAPPED_LOG_CONTENT, { encoding: "utf8" });
+    await writeFile(logPath, SINGLE_ENTRY_LOG_CONTENT, { encoding: "utf8" });
 
     await new Promise<void>((resolve, reject) => {
       execFile(


### PR DESCRIPTION
## Summary
- parse analyze log entries using event-aware helpers while still supporting legacy records
- skip non-test events and keep nested duration fields when computing report metrics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f31f21bc9c8321bcce3f0a96c1d51f