### PR TITLE
Handle malformed entries in analyze log loader

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -134,13 +134,15 @@ def load_results() -> Tuple[list[str], list[int], list[str]]:
     if not LOG.exists():
         return tests, durs, fails
     with LOG.open(encoding="utf-8") as f:
-        for line in f:
-            if not line.strip():
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line:
                 continue
-            obj = json.loads(line)
-            loaded = _load_from_event(obj)
-            if loaded is None:
-                loaded = _load_from_legacy(obj)
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            loaded = _load_entry(obj)
             if loaded is None:
                 continue
             name, duration, is_failure = loaded


### PR DESCRIPTION
## Summary
- skip empty and malformed JSONL entries when loading test results
- route log parsing through the unified entry loader helper

## Testing
- npm run build
- node --test dist/tests/analyze-script.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f3291c2a6c832199518b8bf2a9c281