### PR TITLE
Fix analyze script path resolution

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -33,9 +33,9 @@ def _resolve_path(env_key: str, default: pathlib.Path) -> pathlib.Path:
     return pathlib.Path(text)
 
 
-LOG = _DEFAULT_LOG
-REPORT = _DEFAULT_REPORT
-ISSUE_OUT = _DEFAULT_ISSUE
+LOG = _resolve_path("ANALYZE_LOG_PATH", _DEFAULT_LOG)
+REPORT = _resolve_path("ANALYZE_REPORT_PATH", _DEFAULT_REPORT)
+ISSUE_OUT = _resolve_path("ANALYZE_ISSUE_PATH", _DEFAULT_ISSUE)
 
 
 def _log_path() -> pathlib.Path:


### PR DESCRIPTION
## Summary
- refresh analyze.py path resolution from the current environment to keep log/report/issue outputs aligned with updated ANALYZE_* variables

## Testing
- NODE_OPTIONS="--test-reporter=json --test-reporter-destination=logs/test.jsonl" node --test dist/tests/analyze-script.test.js
- python3 scripts/analyze.py

------
https://chatgpt.com/codex/tasks/task_e_68f32bbb53e08321997f53f7a346a6c1