### PR TITLE
Ensure tsconfig includes DOM lib for service worker types

### DIFF
--- a/tests/workflows.test.ts
+++ b/tests/workflows.test.ts
@@ -25,6 +25,8 @@ const testWorkflowUrl = new URL(
   repositoryRoot,
 );
 
+const tsconfigUrl = new URL("tsconfig.json", repositoryRoot);
+
 type ReadFile = (path: URL, options: "utf8") => Promise<string>;
 
 const loadReadFile = async (): Promise<ReadFile> => {
@@ -94,5 +96,23 @@ test("JSON reporter runner covers frontend tests", async () => {
   assert.ok(
     runnerContent.includes("dist/frontend/tests"),
     "frontend test suite must be executed by JSON reporter runner",
+  );
+});
+
+test("tsconfig exposes DOM lib for service worker Request types", async () => {
+  const readFile = await loadReadFile();
+  const tsconfigContent = await readFile(tsconfigUrl, "utf8");
+
+  const config = JSON.parse(tsconfigContent) as {
+    readonly compilerOptions?: { readonly lib?: readonly unknown[] };
+  };
+
+  const libs = config.compilerOptions?.lib;
+  assert.ok(Array.isArray(libs), "tsconfig compilerOptions.lib must be defined");
+
+  const normalized = libs.map((lib) => String(lib).toLowerCase());
+  assert.ok(
+    normalized.includes("dom"),
+    "tsconfig must include the DOM lib to provide Request typings",
   );
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "skipLibCheck": true,
     "preserveConstEnums": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "typeRoots": ["./types", "./node_modules/@types"]
   },
   "include": ["src", "tests", "scripts", "frontend/src", "frontend/tests"]


### PR DESCRIPTION
## Summary
- add a workflow test that ensures tsconfig.json declares DOM typings needed by the service worker utilities
- explicitly list ES2022 and DOM libs in tsconfig.json so Request stays available during typecheck

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f3331a930c832182d56881feae1339