### PR TITLE
Ensure analyze cleanup removes stale issue suggestions

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -55,6 +55,18 @@ def _issue_path() -> pathlib.Path:
     ISSUE_OUT = _resolve_path("ANALYZE_ISSUE_PATH", _DEFAULT_ISSUE)
     return ISSUE_OUT
 
+
+def _clear_issue_report(issue_path: pathlib.Path) -> None:
+    try:
+        issue_path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError:
+        try:
+            issue_path.write_text("", encoding="utf-8")
+        except OSError:
+            pass
+
 def extract_duration(entry: dict[str, object]) -> int:
     duration = entry.get("duration_ms")
     if duration is None:
@@ -216,9 +228,6 @@ def main() -> None:
             for name in set(fails):
                 f.write(f"- [ ] {name} の再現手順/前提/境界値を追加\n")
     else:
-        try:
-            issue_path.unlink()
-        except FileNotFoundError:
-            pass
+        _clear_issue_report(issue_path)
 if __name__ == "__main__":
     main()

--- a/tests/analyze-script.test.ts
+++ b/tests/analyze-script.test.ts
@@ -155,6 +155,77 @@ const SUCCESS_LOG_CONTENT = `${JSON.stringify({
   duration_ms: 120,
 })}\n`;
 
+test("analyze.py は失敗ログと成功ログを順に処理すると issue_suggestions.md を片付ける", async () => {
+  const { execFile } = (await dynamicImport("node:child_process")) as { execFile: ExecFile };
+  const { readFile, rm, writeFile } = (await dynamicImport("node:fs/promises")) as FsPromisesModule;
+  const { join } = (await dynamicImport("node:path")) as PathModule;
+
+  const repoRootPath = (process as unknown as { cwd(): string }).cwd();
+  const logPath = join(repoRootPath, "logs", "test.jsonl");
+  const reportPath = join(repoRootPath, "reports", "today.md");
+  const issuePath = join(repoRootPath, "reports", "issue_suggestions.md");
+
+  const originalLog = await readFile(logPath, { encoding: "utf8" }).catch(() => null);
+  const originalReport = await readFile(reportPath, { encoding: "utf8" }).catch(() => null);
+  const originalIssue = await readFile(issuePath, { encoding: "utf8" }).catch(() => null);
+
+  const runAnalyze = () =>
+    new Promise<void>((resolve, reject) => {
+      execFile(
+        "python3",
+        ["scripts/analyze.py"],
+        { cwd: repoRootPath, encoding: "utf8" },
+        (error: Error | null, _stdout: string, stderr: string) => {
+          if (error) {
+            const message =
+              stderr.length > 0 ? `analyze.py failed: ${stderr}` : "analyze.py exited with a non-zero status";
+            reject(new Error(message, { cause: error }));
+            return;
+          }
+          resolve();
+        },
+      );
+    });
+
+  const restore = async (path: string, original: string | null) => {
+    if (original === null) {
+      await rm(path, { force: true });
+      return;
+    }
+    await writeFile(path, original, { encoding: "utf8" });
+  };
+
+  try {
+    await writeFile(logPath, FAILURE_LOG_CONTENT, { encoding: "utf8" });
+    await runAnalyze();
+
+    const issueAfterFailure = await readFile(issuePath, { encoding: "utf8" });
+    assert.ok(issueAfterFailure.includes("sample::failing"), "失敗ログ処理後は issue_suggestions.md が生成されるはず");
+
+    await writeFile(logPath, SUCCESS_LOG_CONTENT, { encoding: "utf8" });
+    await runAnalyze();
+
+    const issueAfterSuccess = await readFile(issuePath, { encoding: "utf8" }).catch((error: unknown) => {
+      if (typeof error === "object" && error !== null && "code" in error) {
+        const { code } = error as { code?: unknown };
+        if (code === "ENOENT") {
+          return null;
+        }
+      }
+      throw error;
+    });
+
+    assert.ok(
+      issueAfterSuccess === null || issueAfterSuccess.trim().length === 0,
+      "成功ログ処理後は issue_suggestions.md が削除されるか空になるはず",
+    );
+  } finally {
+    await restore(logPath, originalLog);
+    await restore(reportPath, originalReport);
+    await restore(issuePath, originalIssue);
+  }
+});
+
 test("analyze.py はサンプルが少なくても p95 を計算できる", async () => {
   const { execFile } = (await dynamicImport("node:child_process")) as { execFile: ExecFile };
   const { mkdir, readFile, rm, writeFile } = (await dynamicImport("node:fs/promises")) as FsPromisesModule;


### PR DESCRIPTION
## Summary
- add an integration test that runs analyze.py against failing then passing logs and asserts issue_suggestions.md is cleared
- refactor the cleanup branch in analyze.py to remove or truncate the issue suggestions file when no failures remain

## Testing
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f3441fb544832198851aca34c3beca