### PR TITLE
Ensure frontend tests polyfill Request

### DIFF
--- a/dist/frontend/tests/sw/refresh-queue-store.test.js
+++ b/dist/frontend/tests/sw/refresh-queue-store.test.js
@@ -11,22 +11,95 @@ const normalizeBody = (body) => {
     }
     return String(body);
 };
+const isIterableHeaders = (value) => typeof value === "object" && value !== null && Symbol.iterator in value;
+const toHeaderTuples = (headers) => {
+    if (!headers) {
+        return [];
+    }
+    if (Array.isArray(headers)) {
+        return headers.map(([name, value]) => [String(name), String(value)]);
+    }
+    if (isIterableHeaders(headers)) {
+        return Array.from(headers).map(([name, value]) => [String(name), String(value)]);
+    }
+    return Object.entries(headers).map(([name, value]) => [
+        name,
+        String(value),
+    ]);
+};
+const createFallbackHeaders = (headers) => {
+    if (typeof Headers !== "undefined") {
+        return new Headers(headers);
+    }
+    class MinimalHeaders {
+        #map = new Map();
+        constructor(init) {
+            for (const [name, value] of toHeaderTuples(init)) {
+                this.set(name, value);
+            }
+        }
+        #normalize(name) {
+            return name.toLowerCase();
+        }
+        append(name, value) {
+            this.set(name, value);
+        }
+        delete(name) {
+            this.#map.delete(this.#normalize(name));
+        }
+        get(name) {
+            return this.#map.get(this.#normalize(name)) ?? null;
+        }
+        has(name) {
+            return this.#map.has(this.#normalize(name));
+        }
+        set(name, value) {
+            this.#map.set(this.#normalize(name), String(value));
+        }
+        forEach(callback, thisArg) {
+            for (const [name, value] of this.#map.entries()) {
+                callback.call(thisArg, value, name, this);
+            }
+        }
+        *entries() {
+            for (const [name, value] of this.#map.entries()) {
+                yield [name, value];
+            }
+        }
+        *keys() {
+            yield* this.#map.keys();
+        }
+        *values() {
+            yield* this.#map.values();
+        }
+        [Symbol.iterator]() {
+            return this.entries();
+        }
+    }
+    return new MinimalHeaders(headers);
+};
+const cloneHeaders = (headers) => {
+    if (typeof Headers !== "undefined" && headers instanceof Headers) {
+        return headers;
+    }
+    return Array.from(headers, ([name, value]) => [String(name), String(value)]);
+};
 const createFallbackRequest = () => {
     class MinimalRequest {
         method;
         url;
+        headers;
         #body;
-        #headers;
         constructor(input, init) {
             this.url = typeof input === "string" ? input : input.toString();
             this.method = init?.method ?? "GET";
-            this.#headers = init?.headers;
+            this.headers = createFallbackHeaders(init?.headers);
             this.#body = normalizeBody(init?.body);
         }
         clone() {
             return new MinimalRequest(this.url, {
                 method: this.method,
-                headers: this.#headers,
+                headers: cloneHeaders(this.headers),
                 body: this.#body,
             });
         }

--- a/dist/frontend/tests/sw/refreshQueueStore.test.js
+++ b/dist/frontend/tests/sw/refreshQueueStore.test.js
@@ -10,22 +10,95 @@ const normalizeBody = (body) => {
     }
     return String(body);
 };
+const isIterableHeaders = (value) => typeof value === "object" && value !== null && Symbol.iterator in value;
+const toHeaderTuples = (headers) => {
+    if (!headers) {
+        return [];
+    }
+    if (Array.isArray(headers)) {
+        return headers.map(([name, value]) => [String(name), String(value)]);
+    }
+    if (isIterableHeaders(headers)) {
+        return Array.from(headers).map(([name, value]) => [String(name), String(value)]);
+    }
+    return Object.entries(headers).map(([name, value]) => [
+        name,
+        String(value),
+    ]);
+};
+const createFallbackHeaders = (headers) => {
+    if (typeof Headers !== "undefined") {
+        return new Headers(headers);
+    }
+    class MinimalHeaders {
+        #map = new Map();
+        constructor(init) {
+            for (const [name, value] of toHeaderTuples(init)) {
+                this.set(name, value);
+            }
+        }
+        #normalize(name) {
+            return name.toLowerCase();
+        }
+        append(name, value) {
+            this.set(name, value);
+        }
+        delete(name) {
+            this.#map.delete(this.#normalize(name));
+        }
+        get(name) {
+            return this.#map.get(this.#normalize(name)) ?? null;
+        }
+        has(name) {
+            return this.#map.has(this.#normalize(name));
+        }
+        set(name, value) {
+            this.#map.set(this.#normalize(name), String(value));
+        }
+        forEach(callback, thisArg) {
+            for (const [name, value] of this.#map.entries()) {
+                callback.call(thisArg, value, name, this);
+            }
+        }
+        *entries() {
+            for (const [name, value] of this.#map.entries()) {
+                yield [name, value];
+            }
+        }
+        *keys() {
+            yield* this.#map.keys();
+        }
+        *values() {
+            yield* this.#map.values();
+        }
+        [Symbol.iterator]() {
+            return this.entries();
+        }
+    }
+    return new MinimalHeaders(headers);
+};
+const cloneHeaders = (headers) => {
+    if (typeof Headers !== "undefined" && headers instanceof Headers) {
+        return headers;
+    }
+    return Array.from(headers, ([name, value]) => [String(name), String(value)]);
+};
 const createFallbackRequest = () => {
     class MinimalRequest {
         method;
         url;
+        headers;
         #body;
-        #headers;
         constructor(input, init) {
             this.url = typeof input === "string" ? input : input.toString();
             this.method = init?.method ?? "GET";
-            this.#headers = init?.headers;
+            this.headers = createFallbackHeaders(init?.headers);
             this.#body = normalizeBody(init?.body);
         }
         clone() {
             return new MinimalRequest(this.url, {
                 method: this.method,
-                headers: this.#headers,
+                headers: cloneHeaders(this.headers),
                 body: this.#body,
             });
         }

--- a/frontend/tests/sw/refresh-queue-store.test.ts
+++ b/frontend/tests/sw/refresh-queue-store.test.ts
@@ -5,6 +5,7 @@ import { createRefreshQueueStore } from "../../src/sw/refreshQueueStore.js";
 import { retryQueueEntry } from "../../src/sw.js";
 
 type RequestConstructor = new (input: string | URL, init?: RequestInit) => Request;
+type HeadersInput = RequestInit["headers"] | Iterable<readonly [string, string]>;
 
 const normalizeBody = (body: unknown): string => {
   if (typeof body === "string") {
@@ -16,24 +17,126 @@ const normalizeBody = (body: unknown): string => {
   return String(body);
 };
 
+const isIterableHeaders = (
+  value: unknown,
+): value is Iterable<readonly [string, string]> =>
+  typeof value === "object" && value !== null && Symbol.iterator in value;
+
+const toHeaderTuples = (
+  headers?: HeadersInput,
+): Array<readonly [string, string]> => {
+  if (!headers) {
+    return [];
+  }
+  if (Array.isArray(headers)) {
+    return headers.map(([name, value]) => [String(name), String(value)]);
+  }
+  if (isIterableHeaders(headers)) {
+    return Array.from(headers).map(([name, value]) => [String(name), String(value)]);
+  }
+  return Object.entries(headers as Record<string, unknown>).map(([name, value]) => [
+    name,
+    String(value),
+  ]);
+};
+
+const createFallbackHeaders = (headers?: HeadersInput): Headers => {
+  if (typeof Headers !== "undefined") {
+    return new Headers(headers as HeadersInit);
+  }
+
+  class MinimalHeaders implements Iterable<readonly [string, string]> {
+    readonly #map = new Map<string, string>();
+
+    constructor(init?: HeadersInput) {
+      for (const [name, value] of toHeaderTuples(init)) {
+        this.set(name, value);
+      }
+    }
+
+    #normalize(name: string): string {
+      return name.toLowerCase();
+    }
+
+    append(name: string, value: string): void {
+      this.set(name, value);
+    }
+
+    delete(name: string): void {
+      this.#map.delete(this.#normalize(name));
+    }
+
+    get(name: string): string | null {
+      return this.#map.get(this.#normalize(name)) ?? null;
+    }
+
+    has(name: string): boolean {
+      return this.#map.has(this.#normalize(name));
+    }
+
+    set(name: string, value: string): void {
+      this.#map.set(this.#normalize(name), String(value));
+    }
+
+    forEach(
+      callback: (value: string, name: string, parent: Headers) => void,
+      thisArg?: unknown,
+    ): void {
+      for (const [name, value] of this.#map.entries()) {
+        callback.call(thisArg, value, name, this as unknown as Headers);
+      }
+    }
+
+    *entries(): IterableIterator<readonly [string, string]> {
+      for (const [name, value] of this.#map.entries()) {
+        yield [name, value];
+      }
+    }
+
+    *keys(): IterableIterator<string> {
+      yield* this.#map.keys();
+    }
+
+    *values(): IterableIterator<string> {
+      yield* this.#map.values();
+    }
+
+    [Symbol.iterator](): IterableIterator<readonly [string, string]> {
+      return this.entries();
+    }
+  }
+
+  return new MinimalHeaders(headers) as unknown as Headers;
+};
+
+const cloneHeaders = (headers: Headers): RequestInit["headers"] => {
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    return headers;
+  }
+  return Array.from(
+    headers as Iterable<readonly [string, string]>,
+    ([name, value]) => [String(name), String(value)] as [string, string],
+  );
+};
+
 const createFallbackRequest = (): RequestConstructor => {
   class MinimalRequest {
     readonly method: string;
     readonly url: string;
+    readonly headers: Headers;
     readonly #body: string;
-    readonly #headers: RequestInit["headers"];
 
     constructor(input: string | URL, init?: RequestInit) {
       this.url = typeof input === "string" ? input : input.toString();
       this.method = init?.method ?? "GET";
-      this.#headers = init?.headers;
+      this.headers = createFallbackHeaders(init?.headers);
       this.#body = normalizeBody(init?.body);
     }
 
     clone(): Request {
       return new MinimalRequest(this.url, {
         method: this.method,
-        headers: this.#headers,
+        headers: cloneHeaders(this.headers),
         body: this.#body,
       }) as unknown as Request;
     }

--- a/frontend/tests/sw/refreshQueueStore.test.ts
+++ b/frontend/tests/sw/refreshQueueStore.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import { createRefreshQueueStore } from "../../src/sw/refreshQueueStore.js";
 
 type RequestConstructor = new (input: string | URL, init?: RequestInit) => Request;
+type HeadersInput = RequestInit["headers"] | Iterable<readonly [string, string]>;
 
 const normalizeBody = (body: unknown): string => {
   if (typeof body === "string") {
@@ -15,24 +16,126 @@ const normalizeBody = (body: unknown): string => {
   return String(body);
 };
 
+const isIterableHeaders = (
+  value: unknown,
+): value is Iterable<readonly [string, string]> =>
+  typeof value === "object" && value !== null && Symbol.iterator in value;
+
+const toHeaderTuples = (
+  headers?: HeadersInput,
+): Array<readonly [string, string]> => {
+  if (!headers) {
+    return [];
+  }
+  if (Array.isArray(headers)) {
+    return headers.map(([name, value]) => [String(name), String(value)]);
+  }
+  if (isIterableHeaders(headers)) {
+    return Array.from(headers).map(([name, value]) => [String(name), String(value)]);
+  }
+  return Object.entries(headers as Record<string, unknown>).map(([name, value]) => [
+    name,
+    String(value),
+  ]);
+};
+
+const createFallbackHeaders = (headers?: HeadersInput): Headers => {
+  if (typeof Headers !== "undefined") {
+    return new Headers(headers as HeadersInit);
+  }
+
+  class MinimalHeaders implements Iterable<readonly [string, string]> {
+    readonly #map = new Map<string, string>();
+
+    constructor(init?: HeadersInput) {
+      for (const [name, value] of toHeaderTuples(init)) {
+        this.set(name, value);
+      }
+    }
+
+    #normalize(name: string): string {
+      return name.toLowerCase();
+    }
+
+    append(name: string, value: string): void {
+      this.set(name, value);
+    }
+
+    delete(name: string): void {
+      this.#map.delete(this.#normalize(name));
+    }
+
+    get(name: string): string | null {
+      return this.#map.get(this.#normalize(name)) ?? null;
+    }
+
+    has(name: string): boolean {
+      return this.#map.has(this.#normalize(name));
+    }
+
+    set(name: string, value: string): void {
+      this.#map.set(this.#normalize(name), String(value));
+    }
+
+    forEach(
+      callback: (value: string, name: string, parent: Headers) => void,
+      thisArg?: unknown,
+    ): void {
+      for (const [name, value] of this.#map.entries()) {
+        callback.call(thisArg, value, name, this as unknown as Headers);
+      }
+    }
+
+    *entries(): IterableIterator<readonly [string, string]> {
+      for (const [name, value] of this.#map.entries()) {
+        yield [name, value];
+      }
+    }
+
+    *keys(): IterableIterator<string> {
+      yield* this.#map.keys();
+    }
+
+    *values(): IterableIterator<string> {
+      yield* this.#map.values();
+    }
+
+    [Symbol.iterator](): IterableIterator<readonly [string, string]> {
+      return this.entries();
+    }
+  }
+
+  return new MinimalHeaders(headers) as unknown as Headers;
+};
+
+const cloneHeaders = (headers: Headers): RequestInit["headers"] => {
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    return headers;
+  }
+  return Array.from(
+    headers as Iterable<readonly [string, string]>,
+    ([name, value]) => [String(name), String(value)] as [string, string],
+  );
+};
+
 const createFallbackRequest = (): RequestConstructor => {
   class MinimalRequest {
     readonly method: string;
     readonly url: string;
+    readonly headers: Headers;
     readonly #body: string;
-    readonly #headers: RequestInit["headers"];
 
     constructor(input: string | URL, init?: RequestInit) {
       this.url = typeof input === "string" ? input : input.toString();
       this.method = init?.method ?? "GET";
-      this.#headers = init?.headers;
+      this.headers = createFallbackHeaders(init?.headers);
       this.#body = normalizeBody(init?.body);
     }
 
     clone(): Request {
       return new MinimalRequest(this.url, {
         method: this.method,
-        headers: this.#headers,
+        headers: cloneHeaders(this.headers),
         body: this.#body,
       }) as unknown as Request;
     }


### PR DESCRIPTION
## Summary
- add a minimal Request fallback for service worker tests so they run when the global Request constructor is missing
- regenerate the compiled frontend test outputs to reflect the fallback helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f34d969af88321a425f72c453f341b