### PR TITLE
Propagate retryQueueEntry attempt result

### DIFF
--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -1,16 +1,17 @@
 import type { RefreshQueueStore } from "./sw/refreshQueueStore.js";
 
-export type RetryAttempt = () => unknown | PromiseLike<unknown>;
+export type RetryAttempt<TResult = unknown> = () => TResult | PromiseLike<TResult>;
 
-export const retryQueueEntry = async (
+export const retryQueueEntry = async <T>(
   store: RefreshQueueStore,
   recordId: string,
-  attempt: RetryAttempt,
-): Promise<void> => {
+  attempt: RetryAttempt<T>,
+): Promise<T> => {
   store.recordAttempt(recordId);
   try {
-    await attempt();
+    const result = await attempt();
     store.recordSuccess(recordId);
+    return result;
   } catch (error) {
     store.recordFailure(recordId, error);
     throw error;

--- a/frontend/tests/sw/retry-attempt.types.test.ts
+++ b/frontend/tests/sw/retry-attempt.types.test.ts
@@ -1,7 +1,18 @@
 import type { RetryAttempt } from "../../src/sw.js";
+import { retryQueueEntry } from "../../src/sw.js";
+import type { RefreshQueueStore } from "../../src/sw/refreshQueueStore.js";
 
 const acceptsPromiseReturningValue: RetryAttempt = async () => {
   return "ok";
 };
 
 const acceptsSynchronousValue: RetryAttempt = () => "ok";
+
+const assertRetryQueueEntryResult = async (store: RefreshQueueStore) => {
+  const promiseResult: Promise<string> = retryQueueEntry(store, "record", async () => "ok");
+  const syncResult: Promise<string> = retryQueueEntry(store, "record", () => "ok");
+
+  return { promiseResult, syncResult };
+};
+
+void assertRetryQueueEntryResult;


### PR DESCRIPTION
## Summary
- make `retryQueueEntry` generic so callers receive the attempt's resolved value while still recording queue state
- extend the TypeScript-only test to assert the returned promise type reflects the attempt result

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f34eda85e88321aec4670c8f4f018c