### PR TITLE
fix: update CI node version for test reporter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22.x"
+      - run: node -v
       - name: Install dependencies
         run: npm ci
       - name: Run lint
@@ -21,9 +22,9 @@ jobs:
           mkdir -p logs
           set +e
           node --test \
-            dist/tests \
             --test-reporter=json \
-            --test-reporter-destination=logs/test.jsonl
+            --test-reporter-destination=logs/test.jsonl \
+            dist/tests
           status=$?
           set -e
           if [ ! -f logs/test.jsonl ]; then


### PR DESCRIPTION
## Summary
- bump the CI Node.js runtime to 22.x so the JSON test reporter flag is recognized
- reorder the node --test arguments to pass reporter flags before the test directory
- add an explicit node -v step to surface the runtime version in logs

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f352908c00832197cda668a4140684