### PR TITLE
Fix Python snippet assembly in analyze script test

### DIFF
--- a/tests/analyze-script.test.ts
+++ b/tests/analyze-script.test.ts
@@ -142,7 +142,7 @@ test("load_results は空ログの場合に 0 件・パス率 0% を返す", asy
             "}",
             "summary['pass_rate'] = analyze.format_pass_rate(summary['total'], len(fails))",
             "print(json.dumps(summary, ensure_ascii=False))",
-          ].join("; "),
+          ].join("\n"),
         ],
         { cwd: repoRootPath, encoding: "utf8", env },
         (error: Error | null, stdoutValue: string, stderr: string) => {


### PR DESCRIPTION
## Summary
- join the inline Python snippet with newlines in the analyze script test so the dict literal is valid

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f357de791083219a73586e6e80067f