### PR TITLE
Refactor build command into standalone script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "deterministic-32": "dist/cli.js"
   },
   "scripts": {
-    "build": "node -e \"const {spawnSync}=require('node:child_process');const fs=require('node:fs');const path=require('node:path');const tscPath=require.resolve('typescript/bin/tsc');const result=spawnSync(process.execPath,[tscPath,'-p','tsconfig.json'],{stdio:'inherit'});if((result.status ?? 1)!==0){process.exit(result.status ?? 1);}const dist=path.resolve('dist');const srcRoot=path.join(dist,'src');if(fs.existsSync(srcRoot)){fs.cpSync(srcRoot,dist,{recursive:true,filter:(source)=>{if(source===srcRoot){return true;}const stat=fs.statSync(source);if(stat.isDirectory()){return true;}return source.endsWith('.js')||source.endsWith('.d.ts');}});}const reporterSrc=path.resolve('reporters/json');const reporterDest=path.resolve('node_modules/json');fs.rmSync(reporterDest,{recursive:true,force:true});fs.mkdirSync(reporterDest,{recursive:true});for(const filename of ['index.js','package.json']){fs.copyFileSync(path.join(reporterSrc,filename),path.join(reporterDest,filename));}\"",
+    "build": "node scripts/build.js",
     "bench": "npm run build && node dist/scripts/bench.js",
     "test": "npm run build && node scripts/run-tests.js",
     "prepare": "npm run build",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,79 @@
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+
+function getForwardedArgs() {
+  return process.argv.slice(2);
+}
+
+function runTypeScriptBuild() {
+  const tscPath = resolve('node_modules', 'typescript', 'bin', 'tsc');
+  const forwardedArgs = getForwardedArgs();
+  const tscArgs = ['-p', 'tsconfig.json', ...forwardedArgs];
+  const result = spawnSync(process.execPath, [tscPath, ...tscArgs], {
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const exitCode = result.status ?? 1;
+  if (exitCode !== 0) {
+    process.exit(exitCode);
+  }
+}
+
+function shouldCopy(source, srcRoot) {
+  if (source === srcRoot) {
+    return true;
+  }
+
+  const stats = statSync(source);
+  if (stats.isDirectory()) {
+    return true;
+  }
+
+  return source.endsWith('.js') || source.endsWith('.d.ts');
+}
+
+function copyCompiledSources() {
+  const dist = resolve('dist');
+  const srcRoot = join(dist, 'src');
+
+  if (!existsSync(srcRoot)) {
+    return;
+  }
+
+  cpSync(srcRoot, dist, {
+    recursive: true,
+    filter: (source) => shouldCopy(source, srcRoot),
+  });
+}
+
+function installJsonReporter() {
+  const reporterSrc = resolve('reporters', 'json');
+  const reporterDest = resolve('node_modules', 'json');
+
+  rmSync(reporterDest, { recursive: true, force: true });
+  mkdirSync(reporterDest, { recursive: true });
+
+  for (const filename of ['index.js', 'package.json']) {
+    copyFileSync(join(reporterSrc, filename), join(reporterDest, filename));
+  }
+}
+
+function main() {
+  runTypeScriptBuild();
+  copyCompiledSources();
+  installJsonReporter();
+}
+
+main();


### PR DESCRIPTION
## Summary
- replace the one-line npm build command with a dedicated scripts/build.js module
- keep the TypeScript compilation, dist copy, and JSON reporter installation steps readable while forwarding CLI overrides

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f363b7192c83218239d2450721c1d4