### PR TITLE
Forward test runner flags to JSON reporter

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -7,7 +7,41 @@ const DESTINATION_PREFIX = '--test-reporter-destination=';
 const DEFAULT_DESTINATION = 'logs/test.jsonl';
 const DEFAULT_TARGETS = ['dist/tests', 'dist/frontend/tests'];
 
-const resolveTargets = () => {
+const mapTargetArgument = (argument) => {
+  if (!argument.endsWith('.ts')) {
+    return argument;
+  }
+
+  const withoutExtension = argument.slice(0, -3);
+  return path.join('dist', `${withoutExtension}.js`);
+};
+
+const parseCliArguments = () => {
+  const passthroughArgs = [];
+  const targetArgs = [];
+
+  for (const argument of process.argv.slice(2)) {
+    if (!argument) {
+      continue;
+    }
+
+    if (argument.startsWith('--')) {
+      passthroughArgs.push(argument);
+      continue;
+    }
+
+    if (fs.existsSync(argument)) {
+      targetArgs.push(mapTargetArgument(argument));
+      continue;
+    }
+
+    passthroughArgs.push(argument);
+  }
+
+  return { passthroughArgs, targetArgs };
+};
+
+const resolveTargets = (explicitTargets) => {
   const targets = [];
   for (const candidate of DEFAULT_TARGETS) {
     if (fs.existsSync(candidate)) {
@@ -15,15 +49,13 @@ const resolveTargets = () => {
     }
   }
 
-  for (const argument of process.argv.slice(2)) {
-    if (!argument || argument.startsWith('--')) {
+  for (const target of explicitTargets) {
+    if (!target) {
       continue;
     }
-    if (!fs.existsSync(argument)) {
-      continue;
-    }
-    if (!targets.includes(argument)) {
-      targets.push(argument);
+
+    if (!targets.includes(target)) {
+      targets.push(target);
     }
   }
 
@@ -59,18 +91,22 @@ const destination = resolveDestination();
 const resolvedDestination = path.resolve(destination);
 fs.mkdirSync(path.dirname(resolvedDestination), { recursive: true });
 
-const targets = resolveTargets();
+const { passthroughArgs, targetArgs } = parseCliArguments();
+const targets = resolveTargets(targetArgs);
 const reporterSpecifier = pathToFileURL(path.resolve('reporters/json/index.js')).href;
 const args = [
   '--test',
   `--test-reporter=${reporterSpecifier}`,
   `--test-reporter-destination=${resolvedDestination}`,
-  ...targets
+  ...targets,
+  ...passthroughArgs
 ];
 
 const childEnv = { ...process.env };
 delete childEnv.NODE_TEST_CONTEXT;
-const child = spawn(process.execPath, args, { stdio: 'inherit', env: childEnv });
+const spawnOverride = globalThis.__CAT32_TEST_SPAWN__;
+const spawnFunction = typeof spawnOverride === 'function' ? spawnOverride : spawn;
+const child = spawnFunction(process.execPath, args, { stdio: 'inherit', env: childEnv });
 for (const signal of ['SIGINT', 'SIGTERM', 'SIGQUIT']) {
   process.on(signal, () => {
     if (!child.killed) {

--- a/tests/json-reporter-runner-flags.test.ts
+++ b/tests/json-reporter-runner-flags.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type Signal = "SIGINT" | "SIGTERM" | "SIGQUIT";
+
+type Listener = (...args: unknown[]) => void;
+
+const createMockChildProcess = () => {
+  const onceListeners = new Map<string, Listener[]>();
+
+  const child = {
+    killed: false,
+    once(event: string, listener: Listener) {
+      const listeners = onceListeners.get(event) ?? [];
+      listeners.push(listener);
+      onceListeners.set(event, listeners);
+      return child;
+    },
+    kill(_signal?: unknown) {
+      child.killed = true;
+      return true;
+    },
+  };
+
+  return {
+    child,
+    emit(event: string, ...args: unknown[]) {
+      const listeners = onceListeners.get(event);
+      if (!listeners) {
+        return;
+      }
+
+      onceListeners.delete(event);
+      for (const listener of listeners) {
+        listener(...args);
+      }
+    },
+  };
+};
+
+const repoRootUrl = import.meta.url.includes("/dist/tests/")
+  ? new URL("../..", import.meta.url)
+  : new URL("..", import.meta.url);
+
+test("JSON reporter runner forwards CLI flags to spawned process", async () => {
+  const spawnCalls: Array<{
+    command: string;
+    args: string[];
+  }> = [];
+
+  const globalOverride = globalThis as {
+    __CAT32_TEST_SPAWN__?: (
+      command: string,
+      args: readonly string[],
+      options?: unknown,
+    ) => unknown;
+  };
+
+  const originalSpawnOverride = globalOverride.__CAT32_TEST_SPAWN__;
+
+  globalOverride.__CAT32_TEST_SPAWN__ = (
+    command: string,
+    args: readonly string[],
+    _options?: unknown,
+  ) => {
+    spawnCalls.push({ command, args: [...args] });
+
+    const child = createMockChildProcess();
+    queueMicrotask(() => {
+      child.emit("exit", 0, null);
+    });
+
+    return child.child;
+  };
+
+  const nodeProcess = process as unknown as {
+    argv: string[];
+    execPath: string;
+    pid: number;
+    env: Record<string, string | undefined>;
+    exit: (code?: number) => never;
+    kill: (pid: number, signal: string) => void;
+    on: (event: string, listener: Listener) => void;
+    listeners: (event: string) => Listener[];
+    removeListener: (event: string, listener: Listener) => void;
+  };
+
+  const runnerUrl = new URL("./--test-reporter=json", repoRootUrl);
+  const runnerPath = decodeURIComponent(runnerUrl.pathname);
+  const originalArgv = nodeProcess.argv;
+  const trackedSignals: Signal[] = ["SIGINT", "SIGTERM", "SIGQUIT"];
+  const previousListeners = new Map<Signal, Set<Listener>>();
+
+  for (const signal of trackedSignals) {
+    previousListeners.set(signal, new Set(nodeProcess.listeners(signal)));
+  }
+
+  const originalExit = nodeProcess.exit;
+  const exitCalls: Array<number | undefined> = [];
+  nodeProcess.exit = ((code?: number) => {
+    exitCalls.push(code);
+    return undefined as never;
+  }) as (code?: number) => never;
+
+  nodeProcess.argv = [
+    nodeProcess.execPath,
+    runnerPath,
+    "--test-name-pattern",
+    "foo",
+  ];
+
+  try {
+    await import(`${runnerUrl.href}?${Date.now()}`);
+  } finally {
+    nodeProcess.argv = originalArgv;
+    nodeProcess.exit = originalExit;
+    globalOverride.__CAT32_TEST_SPAWN__ = originalSpawnOverride;
+
+    for (const signal of trackedSignals) {
+      const before = previousListeners.get(signal) ?? new Set();
+      for (const listener of nodeProcess.listeners(signal)) {
+        if (!before.has(listener)) {
+          nodeProcess.removeListener(signal, listener);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(exitCalls.at(-1), 0);
+  assert.equal(spawnCalls.length, 1);
+
+  const forwardedArgs = spawnCalls[0]!.args.slice(-2);
+  assert.deepEqual(forwardedArgs, ["--test-name-pattern", "foo"]);
+});


### PR DESCRIPTION
## Summary
- forward extra CLI flags from the JSON reporter runner to the child process while mapping explicit targets
- allow tests to inject a spawn override so the runner can be verified without launching node
- add a regression test that asserts --test-name-pattern is preserved when invoking the JSON reporter runner

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f36fc9b5548321be075e1520452138