### PR TITLE
Improve build error diagnostics

### DIFF
--- a/tests/build-artifacts.test.ts
+++ b/tests/build-artifacts.test.ts
@@ -45,9 +45,9 @@ const runBuild = async (
       getNpmExecutable(),
       ["run", "build", ...args],
       { cwd: repoRootPath, env },
-      (error) => {
+      (error, stdout, stderr) => {
         if (error) {
-          reject(error);
+          reject(Object.assign(error ?? {}, { stdout, stderr }));
           return;
         }
         resolve();
@@ -170,6 +170,33 @@ runTest("build respects CLI overrides when npm metadata is unavailable", {}, asy
     }
 
     assert.ok(failure, "expected custom project compilation to fail");
+
+    assert.ok(
+      failure && typeof failure === "object",
+      "expected build failure to expose output",
+    );
+
+    const { stderr, stdout } = failure as {
+      stderr?: unknown;
+      stdout?: unknown;
+    };
+
+    const output =
+      typeof stderr === "string" && stderr.length > 0
+        ? stderr
+        : typeof stdout === "string"
+          ? stdout
+          : undefined;
+
+    if (typeof output !== "string") {
+      throw new Error("expected failure output to be a string");
+    }
+
+    const includesFailurePrefix = /\[build] failed:/.test(output);
+    assert.ok(
+      includesFailurePrefix,
+      "expected failure output to include build failure prefix",
+    );
   } finally {
     await rm(tempTsconfigUrl, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add structured error handling to scripts/build.js so build failures emit a consistent message
- surface build output in build-artifacts.test and assert the failure prefix is printed when TypeScript compilation fails

## Testing
- npm run build
- node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f3783523888321828a4fb5bdecfa0f