### PR TITLE
Ensure JSON reporter runner prefers CLI targets

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -16,11 +16,28 @@ const mapTargetArgument = (argument) => {
   return path.join('dist', `${withoutExtension}.js`);
 };
 
-const parseCliArguments = () => {
+const prepareRunnerOptions = (
+  argv = process.argv,
+  {
+    existsSync = fs.existsSync,
+    defaultTargets = DEFAULT_TARGETS,
+  } = {},
+) => {
   const passthroughArgs = [];
-  const targetArgs = [];
+  const explicitTargets = [];
+  const resolvedDefaults = [];
+  const seenTargets = new Set();
 
-  for (const argument of process.argv.slice(2)) {
+  const addTarget = (candidate) => {
+    if (!candidate || seenTargets.has(candidate)) {
+      return;
+    }
+
+    seenTargets.add(candidate);
+    explicitTargets.push(candidate);
+  };
+
+  for (const argument of argv.slice(2)) {
     if (!argument) {
       continue;
     }
@@ -30,50 +47,44 @@ const parseCliArguments = () => {
       continue;
     }
 
-    if (fs.existsSync(argument)) {
-      targetArgs.push(mapTargetArgument(argument));
+    const mapped = mapTargetArgument(argument);
+    if (mapped !== argument && existsSync(mapped)) {
+      addTarget(mapped);
+      continue;
+    }
+
+    if (existsSync(argument)) {
+      addTarget(argument);
       continue;
     }
 
     passthroughArgs.push(argument);
   }
 
-  return { passthroughArgs, targetArgs };
-};
-
-const resolveTargets = (explicitTargets) => {
-  const targets = [];
-  for (const candidate of DEFAULT_TARGETS) {
-    if (fs.existsSync(candidate)) {
-      targets.push(candidate);
-    }
-  }
-
-  for (const target of explicitTargets) {
-    if (!target) {
+  for (const candidate of defaultTargets) {
+    if (!candidate) {
       continue;
     }
-    let candidate = argument;
-    if (candidate.endsWith('.ts')) {
-      const tsExtensionLength = path.extname(candidate).length;
-      const withoutExtension = tsExtensionLength > 0
-        ? candidate.slice(0, -tsExtensionLength)
-        : candidate;
-      candidate = `${path.join('dist', withoutExtension)}.js`;
-    }
-    if (!fs.existsSync(candidate)) {
+
+    if (!existsSync(candidate) || seenTargets.has(candidate)) {
       continue;
     }
-    if (!targets.includes(candidate)) {
-      targets.push(candidate);
+
+    seenTargets.add(candidate);
+    resolvedDefaults.push(candidate);
+  }
+
+  const targets = explicitTargets.length > 0 ? explicitTargets : resolvedDefaults;
+
+  if (targets.length === 0 && defaultTargets.length > 0) {
+    const fallback = defaultTargets[0];
+    if (fallback && !seenTargets.has(fallback)) {
+      targets.push(fallback);
+      seenTargets.add(fallback);
     }
   }
 
-  if (targets.length === 0) {
-    targets.push(DEFAULT_TARGETS[0]);
-  }
-
-  return targets;
+  return { passthroughArgs, targets };
 };
 
 const resolveDestination = () => {
@@ -97,46 +108,53 @@ const resolveDestination = () => {
   return DEFAULT_DESTINATION;
 };
 
-const destination = resolveDestination();
-const resolvedDestination = path.resolve(destination);
-fs.mkdirSync(path.dirname(resolvedDestination), { recursive: true });
+export { prepareRunnerOptions };
 
-const { passthroughArgs, targetArgs } = parseCliArguments();
-const targets = resolveTargets(targetArgs);
-const reporterSpecifier = pathToFileURL(path.resolve('reporters/json/index.js')).href;
-const args = [
-  '--test',
-  `--test-reporter=${reporterSpecifier}`,
-  `--test-reporter-destination=${resolvedDestination}`,
-  ...targets,
-  ...passthroughArgs
-];
+const runJsonReporter = async () => {
+  const destination = resolveDestination();
+  const resolvedDestination = path.resolve(destination);
+  fs.mkdirSync(path.dirname(resolvedDestination), { recursive: true });
 
-const childEnv = { ...process.env };
-delete childEnv.NODE_TEST_CONTEXT;
-const spawnOverride = globalThis.__CAT32_TEST_SPAWN__;
-const spawnFunction = typeof spawnOverride === 'function' ? spawnOverride : spawn;
-const child = spawnFunction(process.execPath, args, { stdio: 'inherit', env: childEnv });
-for (const signal of ['SIGINT', 'SIGTERM', 'SIGQUIT']) {
-  process.on(signal, () => {
-    if (!child.killed) {
-      child.kill(signal);
-    }
+  const { passthroughArgs, targets } = prepareRunnerOptions();
+  const reporterSpecifier = pathToFileURL(path.resolve('reporters/json/index.js')).href;
+  const args = [
+    '--test',
+    `--test-reporter=${reporterSpecifier}`,
+    `--test-reporter-destination=${resolvedDestination}`,
+    ...targets,
+    ...passthroughArgs
+  ];
+
+  const childEnv = { ...process.env };
+  delete childEnv.NODE_TEST_CONTEXT;
+  const spawnOverride = globalThis.__CAT32_TEST_SPAWN__;
+  const spawnFunction = typeof spawnOverride === 'function' ? spawnOverride : spawn;
+  const child = spawnFunction(process.execPath, args, { stdio: 'inherit', env: childEnv });
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGQUIT']) {
+    process.on(signal, () => {
+      if (!child.killed) {
+        child.kill(signal);
+      }
+    });
+  }
+
+  const exitResult = await new Promise((resolve) => {
+    child.once('error', (error) => {
+      console.error(error);
+      resolve({ code: 1, signal: null });
+    });
+    child.once('exit', (code, signal) => {
+      resolve({ code, signal });
+    });
   });
-}
 
-const exitResult = await new Promise((resolve) => {
-  child.once('error', (error) => {
-    console.error(error);
-    resolve({ code: 1, signal: null });
-  });
-  child.once('exit', (code, signal) => {
-    resolve({ code, signal });
-  });
-});
+  if (exitResult.signal) {
+    process.kill(process.pid, exitResult.signal);
+  } else {
+    process.exit(exitResult.code ?? 1);
+  }
+};
 
-if (exitResult.signal) {
-  process.kill(process.pid, exitResult.signal);
-} else {
-  process.exit(exitResult.code ?? 1);
+if (process.env.__CAT32_SKIP_JSON_REPORTER_RUN__ !== '1') {
+  await runJsonReporter();
 }


### PR DESCRIPTION
## Summary
- export `prepareRunnerOptions` from the JSON reporter runner so tests can assert its behavior without spawning the runner
- ensure CLI-specified targets are validated and preferred before falling back to default discovery
- add test coverage confirming the new target-selection behavior

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f3815ffb908321b47c3d9266584074