### PR TITLE
Improve CI diagnostics for failing tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,39 @@ jobs:
 
           echo "build_status=${build_status} test_status=${test_status}"
           exit $(( build_status != 0 ? build_status : test_status ))
-      - name: Upload logs
+      - name: Summarize failing tests
+        if: failure()
+        run: |
+          node -e "
+          const fs=require('fs');
+          const p='logs/test.jsonl';
+          if(!fs.existsSync(p)){ console.log('logs/test.jsonl not found'); process.exit(0); }
+          const lines=fs.readFileSync(p,'utf8').trim().split(/\r?\n/);
+          const fails=[];
+          for(const L of lines){
+            try{
+              const o=JSON.parse(L);
+              if(o.type==='test' && o.data?.details?.error){
+                const e=o.data.details.error;
+                fails.push({
+                  file:o.data.file, name:o.data.name,
+                  message:e.message||String(e),
+                  stack:(e.stack||'').split('\n').slice(0,15).join('\n')
+                });
+              }
+            }catch{}
+          }
+          console.log('\nFailing tests:', fails.length);
+          for(const f of fails){
+            console.log(`\n--- ${f.file} :: ${f.name}\n${f.message}\n${f.stack}`);
+          }"
+      - name: Re-run tests in spec reporter (non-blocking)
+        if: failure()
+        continue-on-error: true
+        run: node --test dist/tests --test-reporter=spec
+      - name: Upload CI logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-logs
+          name: ci-logs
           path: logs/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 npm-debug.log*
 .DS_Store
+
+# stray from test runner
+--test-reporter=json
+--test-reporter-destination=logs


### PR DESCRIPTION
## Summary
- add a workflow step to summarize failing tests and re-run the suite with the spec reporter on failure
- rename the uploaded logs artifact for clarity
- ignore stray CLI flag artifacts created by the test runner

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f38674f19083219bacfdbdc79d939d