### PR TITLE
Support custom JSON reporter destination flag

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -4,6 +4,7 @@ import { spawn } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 const DESTINATION_PREFIX = '--test-reporter-destination=';
+const DESTINATION_FLAG = '--test-reporter-destination';
 const DEFAULT_DESTINATION = 'logs/test.jsonl';
 const DEFAULT_TARGETS = ['dist/tests', 'dist/frontend/tests'];
 
@@ -19,9 +20,29 @@ const mapTargetArgument = (argument) => {
 const parseCliArguments = () => {
   const passthroughArgs = [];
   const targetArgs = [];
+  let reporterDestination;
 
-  for (const argument of process.argv.slice(2)) {
+  const argv = process.argv.slice(2);
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
     if (!argument) {
+      continue;
+    }
+
+    if (argument === DESTINATION_FLAG) {
+      const candidate = argv[index + 1];
+      if (typeof candidate === 'string' && candidate.length > 0) {
+        reporterDestination = candidate;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (argument.startsWith(DESTINATION_PREFIX)) {
+      const suffix = argument.slice(DESTINATION_PREFIX.length);
+      if (suffix.length > 0) {
+        reporterDestination = suffix;
+      }
       continue;
     }
 
@@ -38,7 +59,7 @@ const parseCliArguments = () => {
     passthroughArgs.push(argument);
   }
 
-  return { passthroughArgs, targetArgs };
+  return { passthroughArgs, targetArgs, reporterDestination };
 };
 
 const resolveTargets = (explicitTargets) => {
@@ -53,7 +74,7 @@ const resolveTargets = (explicitTargets) => {
     if (!target) {
       continue;
     }
-    let candidate = argument;
+    let candidate = target;
     if (candidate.endsWith('.ts')) {
       const tsExtensionLength = path.extname(candidate).length;
       const withoutExtension = tsExtensionLength > 0
@@ -76,7 +97,10 @@ const resolveTargets = (explicitTargets) => {
   return targets;
 };
 
-const resolveDestination = () => {
+const resolveDestination = (explicitDestination) => {
+  if (explicitDestination) {
+    return explicitDestination;
+  }
   for (const entry of fs.readdirSync('.', { withFileTypes: true })) {
     if (!entry.name.startsWith(DESTINATION_PREFIX)) {
       continue;
@@ -97,17 +121,16 @@ const resolveDestination = () => {
   return DEFAULT_DESTINATION;
 };
 
-const destination = resolveDestination();
-const resolvedDestination = path.resolve(destination);
-fs.mkdirSync(path.dirname(resolvedDestination), { recursive: true });
+const { passthroughArgs, targetArgs, reporterDestination } = parseCliArguments();
+const destination = resolveDestination(reporterDestination);
+fs.mkdirSync(path.dirname(destination), { recursive: true });
 
-const { passthroughArgs, targetArgs } = parseCliArguments();
 const targets = resolveTargets(targetArgs);
 const reporterSpecifier = pathToFileURL(path.resolve('reporters/json/index.js')).href;
 const args = [
   '--test',
   `--test-reporter=${reporterSpecifier}`,
-  `--test-reporter-destination=${resolvedDestination}`,
+  `--test-reporter-destination=${destination}`,
   ...targets,
   ...passthroughArgs
 ];

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -122,3 +122,113 @@ test("JSON reporter runner expands TS targets to dist JS paths", async () => {
     }
   }
 });
+
+test("JSON reporter runner respects --test-reporter-destination", async () => {
+  const { createRequire } = (await dynamicImport("node:module")) as {
+    createRequire: (specifier: string | URL) => (id: string) => unknown;
+  };
+  const require = createRequire(import.meta.url);
+  const fsModule = require("node:fs") as {
+    existsSync: (value: unknown) => boolean;
+    mkdirSync: (directory: unknown, options?: unknown) => unknown;
+  };
+  const processWithSignals = process as typeof process & {
+    listeners: (signal: (typeof SIGNALS)[number]) => Array<(...args: unknown[]) => void>;
+    removeListener: (
+      signal: (typeof SIGNALS)[number],
+      listener: (...args: unknown[]) => void,
+    ) => void;
+  };
+
+  const cleanups: Array<() => void> = [];
+  const exitCodes: number[] = [];
+  const spawnCalls: Array<ReadonlyArray<unknown>> = [];
+  const mkdirCalls: Array<[unknown, unknown?]> = [];
+
+  const globalOverride = globalThis as { __CAT32_TEST_SPAWN__?: SpawnFunction };
+  const originalSpawnOverride = globalOverride.__CAT32_TEST_SPAWN__;
+  globalOverride.__CAT32_TEST_SPAWN__ = ((...args) => {
+    spawnCalls.push(args);
+    return createMockChild();
+  }) as SpawnFunction;
+  cleanups.push(() => {
+    if (originalSpawnOverride === undefined) {
+      delete globalOverride.__CAT32_TEST_SPAWN__;
+    } else {
+      globalOverride.__CAT32_TEST_SPAWN__ = originalSpawnOverride;
+    }
+  });
+
+  const originalArgv = process.argv;
+  process.argv = [
+    process.argv[0]!,
+    "./--test-reporter=json",
+    "--test-reporter-destination",
+    "tmp/out.jsonl",
+    "tests/categorizer.test.ts",
+  ];
+  cleanups.push(() => (process.argv = originalArgv));
+
+  const baseline = new Map(
+    SIGNALS.map((signal) => [signal, new Set(processWithSignals.listeners(signal))]),
+  );
+  cleanups.push(() => {
+    for (const signal of SIGNALS) {
+      const known = baseline.get(signal)!;
+      for (const listener of processWithSignals.listeners(signal)) {
+        if (!known.has(listener)) {
+          processWithSignals.removeListener(signal, listener);
+        }
+      }
+    }
+  });
+
+  const originalExit = process.exit;
+  (process as { exit: (code?: number) => never }).exit = ((code?: number) => {
+    exitCodes.push(code ?? 0);
+    return undefined as never;
+  }) as typeof originalExit;
+  cleanups.push(() => {
+    (process as { exit: typeof originalExit }).exit = originalExit;
+  });
+
+  const knownPaths = new Set([
+    "dist/tests",
+    "tests/categorizer.test.ts",
+    "dist/tests/categorizer.test.js",
+  ]);
+  const originalExistsSync = fsModule.existsSync;
+  (fsModule as { existsSync: (value: unknown) => boolean }).existsSync = (candidate) =>
+    typeof candidate === "string" && knownPaths.has(candidate);
+  cleanups.push(() => {
+    (fsModule as { existsSync: (value: unknown) => boolean }).existsSync = originalExistsSync;
+  });
+
+  const originalMkdirSync = fsModule.mkdirSync;
+  (fsModule as {
+    mkdirSync: (directory: unknown, options?: unknown) => unknown;
+  }).mkdirSync = (directory, options) => {
+    mkdirCalls.push([directory, options]);
+    return undefined;
+  };
+  cleanups.push(() => {
+    (fsModule as {
+      mkdirSync: (directory: unknown, options?: unknown) => unknown;
+    }).mkdirSync = originalMkdirSync;
+  });
+
+  try {
+    await import(`${runnerUrl.href}?test=${Date.now()}`);
+    assert.equal(spawnCalls.length, 1);
+    const spawnArgs = spawnCalls[0]![1] as ReadonlyArray<string>;
+    assert.ok(Array.isArray(spawnArgs));
+    assert.ok(spawnArgs.includes("dist/tests/categorizer.test.js"));
+    assert.ok(spawnArgs.includes("--test-reporter-destination=tmp/out.jsonl"));
+    assert.deepEqual(mkdirCalls, [["tmp", { recursive: true }]]);
+    assert.deepEqual(exitCodes, [0]);
+  } finally {
+    while (cleanups.length) {
+      cleanups.pop()?.();
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add coverage to the JSON reporter runner to assert the destination flag drives mkdir and spawn arguments
- parse --test-reporter-destination (both =value and split value forms) and use the requested path for directory creation and child arguments

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f3857c2ec08321935dee3ea960e10e