### PR TITLE
Fix JSON reporter runner absolute path handling

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -7,15 +7,20 @@ const DESTINATION_PREFIX = '--test-reporter-destination=';
 const DEFAULT_DESTINATION = 'logs/test.jsonl';
 const DEFAULT_TARGETS = ['dist/tests', 'dist/frontend/tests'];
 
-const normalizeTarget = (target) => {
+const mapTargetArgument = (target) => {
   if (!target.endsWith('.ts')) {
     return target;
   }
 
-  const tsExtensionLength = path.extname(target).length;
+  const absolute = path.isAbsolute(target) ? target : path.resolve(target);
+  const relativePath = path.relative(process.cwd(), absolute);
+  const normalizedRelative = path.normalize(relativePath);
+
+  const tsExtensionLength = path.extname(normalizedRelative).length;
   const withoutExtension = tsExtensionLength > 0
-    ? target.slice(0, -tsExtensionLength)
-    : target;
+    ? normalizedRelative.slice(0, -tsExtensionLength)
+    : normalizedRelative;
+
   return path.join('dist', `${withoutExtension}.js`);
 };
 
@@ -37,7 +42,7 @@ const prepareRunnerOptions = (
       return;
     }
 
-    const normalized = normalizeTarget(candidate);
+    const normalized = mapTargetArgument(candidate);
 
     if (seenTargets.has(normalized)) {
       return;
@@ -63,7 +68,7 @@ const prepareRunnerOptions = (
       continue;
     }
 
-    const normalized = normalizeTarget(argument);
+    const normalized = mapTargetArgument(argument);
 
     if (existsSync(argument)) {
       addTarget(normalized);
@@ -83,7 +88,7 @@ const prepareRunnerOptions = (
       continue;
     }
 
-    const normalized = normalizeTarget(candidate);
+    const normalized = mapTargetArgument(candidate);
 
     if (!existsSync(normalized)) {
       continue;
@@ -100,7 +105,7 @@ const prepareRunnerOptions = (
   const targets = explicitTargets.length > 0 ? explicitTargets : resolvedDefaults;
 
   if (targets.length === 0 && defaultTargets.length > 0) {
-    const fallbackCandidate = normalizeTarget(defaultTargets[0]);
+    const fallbackCandidate = mapTargetArgument(defaultTargets[0]);
     if (fallbackCandidate && !seenTargets.has(fallbackCandidate)) {
       targets.push(fallbackCandidate);
       seenTargets.add(fallbackCandidate);

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,9 @@ jobs:
           npm -v
           pwd
           echo "::endgroup::"
-
           export NODE_OPTIONS="--enable-source-maps --trace-uncaught --unhandled-rejections=strict --trace-warnings"
-
           set +e
-          node scripts/build.js 2>&1 | tee logs/build.log
+          npm run build 2>&1 | tee logs/build.log
           build_status=${PIPESTATUS[0]}
           set -e
 

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -114,6 +114,107 @@ test("JSON reporter runner uses dist target when invoked with TS input", async (
   assert.deepEqual(exitCodes, [0]);
 });
 
+test("JSON reporter runner maps absolute TS targets into dist", async () => {
+  const { createRequire } = (await dynamicImport("node:module")) as {
+    createRequire: (specifier: string | URL) => (id: string) => unknown;
+  };
+  const require = createRequire(import.meta.url);
+  const fsModule = require("node:fs") as {
+    existsSync: (value: unknown) => boolean;
+  };
+
+  const cleanups: Array<() => void> = [];
+  const spawnCalls: SpawnCall[] = [];
+  const exitCodes: number[] = [];
+  let thrown: unknown;
+
+  const { resolve } = (await dynamicImport("node:path")) as {
+    resolve: (...segments: string[]) => string;
+  };
+  const absoluteTarget = resolve("tests/example.test.ts");
+  const knownPaths = new Set([
+    absoluteTarget,
+    "dist/tests/example.test.js",
+  ]);
+  const originalExistsSync = fsModule.existsSync;
+  (fsModule as { existsSync: (value: unknown) => boolean }).existsSync = (
+    candidate,
+  ) => typeof candidate === "string" && knownPaths.has(candidate);
+  cleanups.push(() => {
+    (fsModule as { existsSync: (value: unknown) => boolean }).existsSync =
+      originalExistsSync;
+  });
+
+  const originalArgv = process.argv;
+  process.argv = [
+    process.argv[0]!,
+    "./--test-reporter=json",
+    absoluteTarget,
+  ];
+  cleanups.push(() => {
+    process.argv = originalArgv;
+  });
+
+  const originalExit = process.exit;
+  (process as { exit: (code?: number) => never }).exit = (
+    (code?: number) => {
+      exitCodes.push(code ?? 0);
+      return undefined as never;
+    }
+  ) as typeof originalExit;
+  cleanups.push(() => {
+    (process as { exit: typeof originalExit }).exit = originalExit;
+  });
+
+  const spawnOverride = (
+    command: unknown,
+    args: unknown,
+    options: unknown,
+  ) => {
+    const child = {
+      killed: false,
+      kill: () => {
+        child.killed = true;
+        return true;
+      },
+      once: (event: unknown, listener: unknown) => {
+        if (event === "exit" && typeof listener === "function") {
+          queueMicrotask(() => {
+            (listener as (code: number, signal: string | null) => void)(0, null);
+          });
+        }
+        return child;
+      },
+    };
+    spawnCalls.push({ command, args, options });
+    return child;
+  };
+  (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride }).__CAT32_TEST_SPAWN__ =
+    spawnOverride;
+  cleanups.push(() => {
+    delete (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride })
+      .__CAT32_TEST_SPAWN__;
+  });
+
+  try {
+    await import(`${runnerUrl.href}?t=${Date.now()}`);
+  } catch (error) {
+    thrown = error;
+  } finally {
+    while (cleanups.length) {
+      cleanups.pop()?.();
+    }
+  }
+
+  assert.equal(thrown, undefined);
+  assert.equal(spawnCalls.length, 1);
+  const invocation = spawnCalls[0]!;
+  assert.ok(Array.isArray(invocation.args));
+  const args = invocation.args as ReadonlyArray<string>;
+  assert.ok(args.includes("dist/tests/example.test.js"));
+  assert.deepEqual(exitCodes, [0]);
+});
+
 test("prepareRunnerOptions prefers CLI targets when present", async () => {
   type PrepareRunnerOptions = (
     argv: readonly string[],


### PR DESCRIPTION
## Summary
- add a regression test covering absolute TypeScript targets for the JSON reporter runner
- normalize target mapping in the JSON reporter runner to always emit dist-relative .js paths
- tweak the test workflow so the typecheck job advertises the build step expected by workflow tests

## Testing
- npm run build
- node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f39782cbb0832190884b0d57a7257e