### PR TITLE
Fix CI artifact collisions for test logs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           fi
       - uses: actions/upload-artifact@v4
         if: always()
-        with: { name: test-logs, path: workflow-cookbook/logs/* }
+        with: { name: 'test-logs-${{ github.job }}', path: workflow-cookbook/logs/* }
 
   typecheck:
     runs-on: ubuntu-24.04
@@ -60,7 +60,7 @@ jobs:
           fi
       - uses: actions/upload-artifact@v4
         if: always()
-        with: { name: test-logs, path: workflow-cookbook/logs/* }
+        with: { name: 'test-logs-${{ github.job }}', path: workflow-cookbook/logs/* }
 
   unit:
     runs-on: ubuntu-24.04
@@ -141,7 +141,7 @@ jobs:
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v4
-        with: { name: test-logs, path: workflow-cookbook/logs/* }
+        with: { name: 'test-logs-${{ github.job }}', path: workflow-cookbook/logs/* }
 
   build:
     needs: [lint, typecheck, unit]
@@ -173,7 +173,7 @@ jobs:
           if-no-files-found: ignore
       - uses: actions/upload-artifact@v4
         if: always()
-        with: { name: test-logs, path: workflow-cookbook/logs/* }
+        with: { name: 'test-logs-${{ github.job }}', path: workflow-cookbook/logs/* }
 
   e2e:
     needs: [build]
@@ -197,28 +197,37 @@ jobs:
           fi
       - uses: actions/upload-artifact@v4
         if: always()
-        with: { name: test-logs, path: workflow-cookbook/logs/* }
+        with: { name: 'test-logs-${{ github.job }}', path: workflow-cookbook/logs/* }
 
   report:
     needs: [lint, typecheck, unit, build, e2e]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@v4
-        with: { name: test-logs, path: . }
+        with:
+          pattern: test-logs-*
+          path: workflow-cookbook/artifacts
       - name: Summarize & STRICT gate (optional)
         run: |
           set -Eeuo pipefail
           # 可能性のあるファイル名に対応
-          src=""
-          [ -f test.jsonl ] && src="test.jsonl"
-          [ -z "$src" ] && [ -f logs/test.jsonl ] && src="logs/test.jsonl"
-          if [ -z "$src" ]; then src=$(ls -1 **/test.jsonl | head -n1 || true); fi
-          if [ -z "$src" ]; then echo "No JSONL found"; exit 0; fi
+          mapfile -d '' files < <(find workflow-cookbook/artifacts -name 'test.jsonl' -print0)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No JSONL found"
+            exit 0
+          fi
+
+          mkdir -p workflow-cookbook/logs
+          combined="workflow-cookbook/logs/combined.jsonl"
+          : > "$combined"
+          for f in "${files[@]}"; do
+            cat "$f" >> "$combined"
+          done
 
           echo "=== CI Summary (raw JSONL) ==="
-          cat "$src" || true
+          cat "$combined" || true
 
-          fails=$(grep -c '"status":"fail"' "$src" || true)
+          fails=$(grep -c '"status":"fail"' "$combined" || true)
           echo "Fail count: $fails"
 
           if [ "${CI_STRICT:-}" = "true" ] && [ "$fails" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- give each job-specific log upload a unique artifact name to avoid conflicts
- download all per-job log artifacts and combine them before generating the summary

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f39e22046c8321b33fe813a593a04d