### PR TITLE
Quote workflow step name in required-labels workflow

### DIFF
--- a/workflow-cookbook-main/.github/workflows/required-labels.yml
+++ b/workflow-cookbook-main/.github/workflows/required-labels.yml
@@ -14,7 +14,7 @@ jobs:
   check-labels:
     runs-on: ubuntu-latest
     steps:
-      - name: 検証: type:* と semver:* ラベルの付与
+      - name: "検証: type:* と semver:* ラベルの付与"
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
- quote the GitHub Actions step name containing colon characters so Prettier can parse the workflow

## Testing
- npx --yes prettier@3.3.3 --check workflow-cookbook-main/.github/workflows/required-labels.yml *(fails: npm 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68f3a1438eec83219cb6ddb93bae7e7d