### PR TITLE
Add Prettier pragma requirement

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "requirePragma": true
+}


### PR DESCRIPTION
## Summary
- add a Prettier configuration requiring a formatting pragma so the CI check only runs on opted-in files

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f3a44e1180832195af0a3568cb65d0