### PR TITLE
Fix Prettier formatting for Birdseye metadata

### DIFF
--- a/docs/birdseye/caps/src.serialize.ts.json
+++ b/docs/birdseye/caps/src.serialize.ts.json
@@ -3,6 +3,12 @@
   "role": "utility",
   "summary": "Stable stringify, normalization helpers, and canonical key helpers shared across Cat32 APIs.",
   "deps_out": [],
-  "deps_in": ["src/categorizer.ts", "src/index.ts", "tests/categorizer.test.ts"],
-  "tests": ["tests/categorizer.test.ts"]
+  "deps_in": [
+    "src/categorizer.ts",
+    "src/index.ts",
+    "tests/categorizer.test.ts"
+  ],
+  "tests": [
+    "tests/categorizer.test.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- expand array literals in docs/birdseye/caps/src.serialize.ts.json to align with Prettier formatting expectations

## Testing
- npx --yes prettier@3.3.3 --check . *(fails: npm 403 Forbidden fetching prettier)*

------
https://chatgpt.com/codex/tasks/task_e_68f3a872f0e883219509d0d779e04233