### PR TITLE
Fix Prettier formatting for serialize capability metadata

### DIFF
--- a/docs/birdseye/caps/src.serialize.ts.json
+++ b/docs/birdseye/caps/src.serialize.ts.json
@@ -3,12 +3,6 @@
   "role": "utility",
   "summary": "Stable stringify, normalization helpers, and canonical key helpers shared across Cat32 APIs.",
   "deps_out": [],
-  "deps_in": [
-    "src/categorizer.ts",
-    "src/index.ts",
-    "tests/categorizer.test.ts"
-  ],
-  "tests": [
-    "tests/categorizer.test.ts"
-  ]
+  "deps_in": ["src/categorizer.ts", "src/index.ts", "tests/categorizer.test.ts"],
+  "tests": ["tests/categorizer.test.ts"]
 }


### PR DESCRIPTION
## Summary
- format the birdseye serialize capability metadata JSON to match Prettier 3 expectations

## Testing
- npx --yes prettier@3.3.3 --check docs/birdseye/caps/src.serialize.ts.json *(fails: npm 403 fetching https://registry.npmjs.org/prettier)*

------
https://chatgpt.com/codex/tasks/task_e_68f3aa9279f88321812bfc0f03eb19bc