### PR TITLE
Handle directory targets for JSON reporter

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -7,21 +7,42 @@ const DESTINATION_PREFIX = '--test-reporter-destination=';
 const DEFAULT_DESTINATION = 'logs/test.jsonl';
 const DEFAULT_TARGETS = ['dist/tests', 'dist/frontend/tests'];
 
-const mapTargetArgument = (target) => {
-  if (!target.endsWith('.ts')) {
+const mapTargetArgument = (
+  target,
+  { existsSync = fs.existsSync } = {},
+) => {
+  if (!target) {
     return target;
   }
 
   const absolute = path.isAbsolute(target) ? target : path.resolve(target);
   const relativePath = path.relative(process.cwd(), absolute);
   const normalizedRelative = path.normalize(relativePath);
+  const extension = path.extname(normalizedRelative);
 
-  const tsExtensionLength = path.extname(normalizedRelative).length;
-  const withoutExtension = tsExtensionLength > 0
-    ? normalizedRelative.slice(0, -tsExtensionLength)
-    : normalizedRelative;
+  if (extension === '.ts') {
+    const withoutExtension = extension.length > 0
+      ? normalizedRelative.slice(0, -extension.length)
+      : normalizedRelative;
 
-  return path.join('dist', `${withoutExtension}.js`);
+    return path.join('dist', `${withoutExtension}.js`);
+  }
+
+  const inDistAlready =
+    normalizedRelative === 'dist' ||
+    normalizedRelative.startsWith(`dist${path.sep}`);
+
+  if (inDistAlready) {
+    return target;
+  }
+
+  const distCandidate = path.join('dist', normalizedRelative);
+
+  if (existsSync(distCandidate)) {
+    return distCandidate;
+  }
+
+  return target;
 };
 
 const prepareRunnerOptions = (
@@ -42,7 +63,7 @@ const prepareRunnerOptions = (
       return;
     }
 
-    const normalized = mapTargetArgument(candidate);
+    const normalized = mapTargetArgument(candidate, { existsSync });
 
     if (seenTargets.has(normalized)) {
       return;
@@ -68,7 +89,7 @@ const prepareRunnerOptions = (
       continue;
     }
 
-    const normalized = mapTargetArgument(argument);
+    const normalized = mapTargetArgument(argument, { existsSync });
 
     if (existsSync(argument)) {
       addTarget(normalized);
@@ -88,7 +109,7 @@ const prepareRunnerOptions = (
       continue;
     }
 
-    const normalized = mapTargetArgument(candidate);
+    const normalized = mapTargetArgument(candidate, { existsSync });
 
     if (!existsSync(normalized)) {
       continue;
@@ -105,7 +126,7 @@ const prepareRunnerOptions = (
   const targets = explicitTargets.length > 0 ? explicitTargets : resolvedDefaults;
 
   if (targets.length === 0 && defaultTargets.length > 0) {
-    const fallbackCandidate = mapTargetArgument(defaultTargets[0]);
+    const fallbackCandidate = mapTargetArgument(defaultTargets[0], { existsSync });
     if (fallbackCandidate && !seenTargets.has(fallbackCandidate)) {
       targets.push(fallbackCandidate);
       seenTargets.add(fallbackCandidate);

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -114,6 +114,96 @@ test("JSON reporter runner uses dist target when invoked with TS input", async (
   assert.deepEqual(exitCodes, [0]);
 });
 
+test("JSON reporter runner maps directory targets into dist", async () => {
+  const { createRequire } = (await dynamicImport("node:module")) as {
+    createRequire: (specifier: string | URL) => (id: string) => unknown;
+  };
+  const require = createRequire(import.meta.url);
+  const fsModule = require("node:fs") as {
+    existsSync: (value: unknown) => boolean;
+  };
+
+  const cleanups: Array<() => void> = [];
+  const spawnCalls: SpawnCall[] = [];
+  const exitCodes: number[] = [];
+  let thrown: unknown;
+
+  const knownPaths = new Set(["dist/tests"]);
+  const originalExistsSync = fsModule.existsSync;
+  (fsModule as { existsSync: (value: unknown) => boolean }).existsSync = (
+    candidate,
+  ) => typeof candidate === "string" && knownPaths.has(candidate);
+  cleanups.push(() => {
+    (fsModule as { existsSync: (value: unknown) => boolean }).existsSync =
+      originalExistsSync;
+  });
+
+  const originalArgv = process.argv;
+  process.argv = [process.argv[0]!, "./--test-reporter=json", "tests"];
+  cleanups.push(() => {
+    process.argv = originalArgv;
+  });
+
+  const originalExit = process.exit;
+  (process as { exit: (code?: number) => never }).exit = (
+    (code?: number) => {
+      exitCodes.push(code ?? 0);
+      return undefined as never;
+    }
+  ) as typeof originalExit;
+  cleanups.push(() => {
+    (process as { exit: typeof originalExit }).exit = originalExit;
+  });
+
+  const spawnOverride = (
+    command: unknown,
+    args: unknown,
+    options: unknown,
+  ) => {
+    const child = {
+      killed: false,
+      kill: () => {
+        child.killed = true;
+        return true;
+      },
+      once: (event: unknown, listener: unknown) => {
+        if (event === "exit" && typeof listener === "function") {
+          queueMicrotask(() => {
+            (listener as (code: number, signal: string | null) => void)(0, null);
+          });
+        }
+        return child;
+      },
+    };
+    spawnCalls.push({ command, args, options });
+    return child;
+  };
+  (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride }).__CAT32_TEST_SPAWN__ =
+    spawnOverride;
+  cleanups.push(() => {
+    delete (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride })
+      .__CAT32_TEST_SPAWN__;
+  });
+
+  try {
+    await import(`${runnerUrl.href}?t=${Date.now()}`);
+  } catch (error) {
+    thrown = error;
+  } finally {
+    while (cleanups.length) {
+      cleanups.pop()?.();
+    }
+  }
+
+  assert.equal(thrown, undefined);
+  assert.equal(spawnCalls.length, 1);
+  const invocation = spawnCalls[0]!;
+  assert.ok(Array.isArray(invocation.args));
+  const args = invocation.args as ReadonlyArray<string>;
+  assert.ok(args.includes("dist/tests"));
+  assert.deepEqual(exitCodes, [0]);
+});
+
 test("JSON reporter runner maps absolute TS targets into dist", async () => {
   const { createRequire } = (await dynamicImport("node:module")) as {
     createRequire: (specifier: string | URL) => (id: string) => unknown;


### PR DESCRIPTION
## Summary
- add a regression test ensuring directory targets are mapped into the dist tree
- extend the JSON reporter runner target mapping to redirect directory inputs into dist after verifying their compiled counterpart exists

## Testing
- npm test *(fails: typecheck job runs lint before building)*

------
https://chatgpt.com/codex/tasks/task_e_68f3bc278adc83219e80086382e8b8f5