### PR TITLE
Prevent JSON reporter CLI flags from being parsed as targets

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -6,6 +6,15 @@ import { pathToFileURL } from 'node:url';
 const DESTINATION_PREFIX = '--test-reporter-destination=';
 const DEFAULT_DESTINATION = 'logs/test.jsonl';
 const DEFAULT_TARGETS = ['dist/tests', 'dist/frontend/tests'];
+const OPTIONS_EXPECTING_VALUE = new Set([
+  '--import',
+  '--loader',
+  '--require',
+  '--test-ignore',
+  '--test-name-pattern',
+  '--test-reporter',
+  '--test-reporter-destination',
+]);
 
 const mapTargetArgument = (target) => {
   if (!target.endsWith('.ts')) {
@@ -36,6 +45,7 @@ const prepareRunnerOptions = (
   const resolvedDefaults = [];
   const seenTargets = new Set();
   let destinationOverride = null;
+  let pendingOption = null;
 
   const addTarget = (candidate) => {
     if (!candidate) {
@@ -57,6 +67,12 @@ const prepareRunnerOptions = (
       continue;
     }
 
+    if (pendingOption) {
+      passthroughArgs.push(argument);
+      pendingOption = null;
+      continue;
+    }
+
     if (argument.startsWith(DESTINATION_PREFIX)) {
       const candidateDestination = argument.slice(DESTINATION_PREFIX.length);
       destinationOverride = candidateDestination || null;
@@ -65,6 +81,13 @@ const prepareRunnerOptions = (
 
     if (argument.startsWith('--')) {
       passthroughArgs.push(argument);
+      const assignmentIndex = argument.indexOf('=');
+      if (assignmentIndex === -1) {
+        const optionName = argument;
+        if (OPTIONS_EXPECTING_VALUE.has(optionName)) {
+          pendingOption = optionName;
+        }
+      }
       continue;
     }
 

--- a/tests/json-reporter-runner-flags.test.ts
+++ b/tests/json-reporter-runner-flags.test.ts
@@ -132,3 +132,97 @@ test("JSON reporter runner forwards CLI flags to spawned process", async () => {
   const forwardedArgs = spawnCalls[0]!.args.slice(-2);
   assert.deepEqual(forwardedArgs, ["--test-name-pattern", "foo"]);
 });
+
+test("JSON reporter runner does not treat CLI flag values as targets", async () => {
+  const spawnCalls: Array<{
+    command: string;
+    args: string[];
+  }> = [];
+
+  const globalOverride = globalThis as {
+    __CAT32_TEST_SPAWN__?: (
+      command: string,
+      args: readonly string[],
+      options?: unknown,
+    ) => unknown;
+  };
+
+  const originalSpawnOverride = globalOverride.__CAT32_TEST_SPAWN__;
+
+  globalOverride.__CAT32_TEST_SPAWN__ = (
+    command: string,
+    args: readonly string[],
+    _options?: unknown,
+  ) => {
+    spawnCalls.push({ command, args: [...args] });
+
+    const child = createMockChildProcess();
+    queueMicrotask(() => {
+      child.emit("exit", 0, null);
+    });
+
+    return child.child;
+  };
+
+  const nodeProcess = process as unknown as {
+    argv: string[];
+    execPath: string;
+    pid: number;
+    env: Record<string, string | undefined>;
+    exit: (code?: number) => never;
+    kill: (pid: number, signal: string) => void;
+    on: (event: string, listener: Listener) => void;
+    listeners: (event: string) => Listener[];
+    removeListener: (event: string, listener: Listener) => void;
+  };
+
+  const runnerUrl = new URL("./--test-reporter=json", repoRootUrl);
+  const runnerPath = decodeURIComponent(runnerUrl.pathname);
+  const originalArgv = nodeProcess.argv;
+  const trackedSignals: Signal[] = ["SIGINT", "SIGTERM", "SIGQUIT"];
+  const previousListeners = new Map<Signal, Set<Listener>>();
+
+  for (const signal of trackedSignals) {
+    previousListeners.set(signal, new Set(nodeProcess.listeners(signal)));
+  }
+
+  const originalExit = nodeProcess.exit;
+  const exitCalls: Array<number | undefined> = [];
+  nodeProcess.exit = ((code?: number) => {
+    exitCalls.push(code);
+    return undefined as never;
+  }) as (code?: number) => never;
+
+  nodeProcess.argv = [
+    nodeProcess.execPath,
+    runnerPath,
+    "--test-name-pattern",
+    "dist",
+  ];
+
+  try {
+    await import(`${runnerUrl.href}?${Date.now()}`);
+  } finally {
+    nodeProcess.argv = originalArgv;
+    nodeProcess.exit = originalExit;
+    globalOverride.__CAT32_TEST_SPAWN__ = originalSpawnOverride;
+
+    for (const signal of trackedSignals) {
+      const before = previousListeners.get(signal) ?? new Set();
+      for (const listener of nodeProcess.listeners(signal)) {
+        if (!before.has(listener)) {
+          nodeProcess.removeListener(signal, listener);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(exitCalls.at(-1), 0);
+  assert.equal(spawnCalls.length, 1);
+
+  const forwardedArgs = spawnCalls[0]!.args;
+  const flagIndex = forwardedArgs.indexOf("--test-name-pattern");
+  assert.ok(flagIndex !== -1);
+  assert.equal(forwardedArgs[flagIndex + 1], "dist");
+  assert.equal(forwardedArgs.slice(0, flagIndex).indexOf("dist"), -1);
+});


### PR DESCRIPTION
## Summary
- add a regression test ensuring --test-name-pattern values stay out of runner targets
- track CLI options that expect a following value so prepareRunnerOptions preserves those tokens in passthroughArgs

## Testing
- node --test dist/tests/json-reporter-runner-flags.test.js dist/tests/json-reporter-runner.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f3bc2656a483219cf46caa46efb29f