### PR TITLE
Ensure JSON reporter runner preserves flag value tokens

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -90,6 +90,9 @@ const prepareRunnerOptions = (
 
     if (pendingOption) {
       passthroughArgs.push(argument);
+      if (pendingOption === '--test-reporter-destination') {
+        destinationOverride = argument || null;
+      }
       pendingOption = null;
       continue;
     }
@@ -103,11 +106,17 @@ const prepareRunnerOptions = (
     if (argument.startsWith('--')) {
       passthroughArgs.push(argument);
       const assignmentIndex = argument.indexOf('=');
+      const optionName = assignmentIndex === -1
+        ? argument
+        : argument.slice(0, assignmentIndex);
+
       if (assignmentIndex === -1) {
-        const optionName = argument;
         if (OPTIONS_EXPECTING_VALUE.has(optionName)) {
           pendingOption = optionName;
         }
+      } else if (optionName === '--test-reporter-destination') {
+        const value = argument.slice(assignmentIndex + 1);
+        destinationOverride = value || null;
       }
       continue;
     }

--- a/tests/json-reporter-runner-flags.test.ts
+++ b/tests/json-reporter-runner-flags.test.ts
@@ -133,6 +133,96 @@ test("JSON reporter runner forwards CLI flags to spawned process", async () => {
   assert.deepEqual(forwardedArgs, ["--test-name-pattern", "foo"]);
 });
 
+test("JSON reporter runner forwards flag values that require separate tokens", async () => {
+  const spawnCalls: Array<{
+    command: string;
+    args: string[];
+  }> = [];
+  const globalOverride = globalThis as {
+    __CAT32_TEST_SPAWN__?: (
+      command: string,
+      args: readonly string[],
+      options?: unknown,
+    ) => unknown;
+  };
+
+  const originalSpawnOverride = globalOverride.__CAT32_TEST_SPAWN__;
+
+  globalOverride.__CAT32_TEST_SPAWN__ = (
+    command: string,
+    args: readonly string[],
+    _options?: unknown,
+  ) => {
+    spawnCalls.push({ command, args: [...args] });
+
+    const child = createMockChildProcess();
+    queueMicrotask(() => {
+      child.emit("exit", 0, null);
+    });
+
+    return child.child;
+  };
+
+  const nodeProcess = process as unknown as {
+    argv: string[];
+    execPath: string;
+    pid: number;
+    env: Record<string, string | undefined>;
+    exit: (code?: number) => never;
+    kill: (pid: number, signal: string) => void;
+    on: (event: string, listener: Listener) => void;
+    listeners: (event: string) => Listener[];
+    removeListener: (event: string, listener: Listener) => void;
+  };
+
+  const runnerUrl = new URL("./--test-reporter=json", repoRootUrl);
+  const runnerPath = decodeURIComponent(runnerUrl.pathname);
+  const originalArgv = nodeProcess.argv;
+  const trackedSignals: Signal[] = ["SIGINT", "SIGTERM", "SIGQUIT"];
+  const previousListeners = new Map<Signal, Set<Listener>>();
+
+  for (const signal of trackedSignals) {
+    previousListeners.set(signal, new Set(nodeProcess.listeners(signal)));
+  }
+
+  const originalExit = nodeProcess.exit;
+  const exitCalls: Array<number | undefined> = [];
+  nodeProcess.exit = ((code?: number) => {
+    exitCalls.push(code);
+    return undefined as never;
+  }) as (code?: number) => never;
+
+  nodeProcess.argv = [
+    nodeProcess.execPath,
+    runnerPath,
+    "--import",
+    "./scripts/register.js",
+  ];
+
+  try {
+    await import(`${runnerUrl.href}?${Date.now()}`);
+  } finally {
+    nodeProcess.argv = originalArgv;
+    nodeProcess.exit = originalExit;
+    globalOverride.__CAT32_TEST_SPAWN__ = originalSpawnOverride;
+
+    for (const signal of trackedSignals) {
+      const before = previousListeners.get(signal) ?? new Set();
+      for (const listener of nodeProcess.listeners(signal)) {
+        if (!before.has(listener)) {
+          nodeProcess.removeListener(signal, listener);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(exitCalls.at(-1), 0);
+  assert.equal(spawnCalls.length, 1);
+
+  const forwardedArgs = spawnCalls[0]!.args.slice(-2);
+  assert.deepEqual(forwardedArgs, ["--import", "./scripts/register.js"]);
+});
+
 test("JSON reporter runner does not treat CLI flag values as targets", async () => {
   const spawnCalls: Array<{
     command: string;


### PR DESCRIPTION
## Summary
- add coverage that verifies the JSON reporter runner forwards separate flag values such as `--import ./scripts/register.js`
- ensure `prepareRunnerOptions` keeps flag value tokens in the passthrough list and applies destination overrides when provided separately

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f3c1a7fa708321bf110a79cf2626ca