### PR TITLE
Fix TypeScript build by using dynamic dist import in tests

### DIFF
--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -114,9 +114,13 @@ test("direct dist import exposes stableStringify", async () => {
     return;
   }
 
-  const distModule = (await import("../dist/index.js")) as {
-    stableStringify?: unknown;
-  };
+  const sourceImportMetaUrl = import.meta.url.includes("/dist/tests/")
+    ? new URL("../../tests/categorizer.test.ts", import.meta.url)
+    : import.meta.url;
+
+  const distModule = (await import(
+    new URL("../dist/index.js", sourceImportMetaUrl).href,
+  )) as { stableStringify?: unknown };
   assert.equal(typeof distModule.stableStringify, "function");
 });
 


### PR DESCRIPTION
## Summary
- avoid direct relative import of dist entry in categorizer test so TypeScript compilation passes without prebuilt artifacts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f3c5057df48321b872613407c7acb7