### PR TITLE
Fix json reporter target mapping against cwd

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const DESTINATION_PREFIX = '--test-reporter-destination=';
 const DEFAULT_DESTINATION = 'logs/test.jsonl';
@@ -16,6 +16,8 @@ const OPTIONS_EXPECTING_VALUE = new Set([
   '--test-reporter-destination',
 ]);
 
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+
 const mapTargetArgument = (
   target,
   { existsSync = fs.existsSync, mapDirectoriesToDist = false } = {},
@@ -25,8 +27,8 @@ const mapTargetArgument = (
   }
 
   const absolute = path.isAbsolute(target) ? target : path.resolve(target);
-  const relativePath = path.relative(process.cwd(), absolute);
-  const normalizedRelative = path.normalize(relativePath);
+  const relativePathFromScript = path.relative(scriptDirectory, absolute);
+  const normalizedRelative = path.normalize(relativePathFromScript);
   const extension = path.extname(normalizedRelative);
 
   if (extension === '.ts') {

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -114,6 +114,117 @@ test("JSON reporter runner uses dist target when invoked with TS input", async (
   assert.deepEqual(exitCodes, [0]);
 });
 
+test("JSON reporter runner resolves TS targets when invoked from tests directory", async () => {
+  const { createRequire } = (await dynamicImport("node:module")) as {
+    createRequire: (specifier: string | URL) => (id: string) => unknown;
+  };
+  const require = createRequire(import.meta.url);
+  const fsModule = require("node:fs") as {
+    existsSync: (value: unknown) => boolean;
+  };
+
+  const cleanups: Array<() => void> = [];
+  const spawnCalls: SpawnCall[] = [];
+  const exitCodes: number[] = [];
+  let thrown: unknown;
+
+  const knownPaths = new Set([
+    "categorizer.test.ts",
+    "dist/tests/categorizer.test.js",
+  ]);
+  const originalExistsSync = fsModule.existsSync;
+  (fsModule as { existsSync: (value: unknown) => boolean }).existsSync = (
+    candidate,
+  ) => typeof candidate === "string" && knownPaths.has(candidate);
+  cleanups.push(() => {
+    (fsModule as { existsSync: (value: unknown) => boolean }).existsSync =
+      originalExistsSync;
+  });
+
+  const { fileURLToPath } = (await dynamicImport("node:url")) as {
+    fileURLToPath: (url: string | URL) => string;
+  };
+  const testsDirectory = fileURLToPath(new URL("./tests/", repoRootUrl));
+  const processWithCwd = process as typeof process & {
+    cwd: () => string;
+    chdir: (directory: string) => void;
+  };
+  const originalCwd = processWithCwd.cwd();
+  processWithCwd.chdir(testsDirectory);
+  cleanups.push(() => {
+    processWithCwd.chdir(originalCwd);
+  });
+
+  const originalArgv = process.argv;
+  process.argv = [
+    process.argv[0]!,
+    "./--test-reporter=json",
+    "categorizer.test.ts",
+  ];
+  cleanups.push(() => {
+    process.argv = originalArgv;
+  });
+
+  const originalExit = process.exit;
+  (process as { exit: (code?: number) => never }).exit = (
+    (code?: number) => {
+      exitCodes.push(code ?? 0);
+      return undefined as never;
+    }
+  ) as typeof originalExit;
+  cleanups.push(() => {
+    (process as { exit: typeof originalExit }).exit = originalExit;
+  });
+
+  const spawnOverride = (
+    command: unknown,
+    args: unknown,
+    options: unknown,
+  ) => {
+    const child = {
+      killed: false,
+      kill: () => {
+        child.killed = true;
+        return true;
+      },
+      once: (event: unknown, listener: unknown) => {
+        if (event === "exit" && typeof listener === "function") {
+          queueMicrotask(() => {
+            (listener as (code: number, signal: string | null) => void)(0, null);
+          });
+        }
+        return child;
+      },
+    };
+    spawnCalls.push({ command, args, options });
+    return child;
+  };
+  (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride }).__CAT32_TEST_SPAWN__ =
+    spawnOverride;
+  cleanups.push(() => {
+    delete (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride })
+      .__CAT32_TEST_SPAWN__;
+  });
+
+  try {
+    await import(`${runnerUrl.href}?t=${Date.now()}`);
+  } catch (error) {
+    thrown = error;
+  } finally {
+    while (cleanups.length) {
+      cleanups.pop()?.();
+    }
+  }
+
+  assert.equal(thrown, undefined);
+  assert.equal(spawnCalls.length, 1);
+  const invocation = spawnCalls[0]!;
+  assert.ok(Array.isArray(invocation.args));
+  const args = invocation.args as ReadonlyArray<string>;
+  assert.ok(args.includes("dist/tests/categorizer.test.js"));
+  assert.deepEqual(exitCodes, [0]);
+});
+
 test("JSON reporter runner maps directory targets into dist", async () => {
   const { createRequire } = (await dynamicImport("node:module")) as {
     createRequire: (specifier: string | URL) => (id: string) => unknown;


### PR DESCRIPTION
## Summary
- add a regression test ensuring the JSON reporter runner resolves TypeScript targets correctly when invoked from the tests directory
- update the reporter runner to derive relative target paths from its own directory so the dist mapping no longer depends on the current working directory

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f3cdbffc4483219df8861fdab03fe5