### PR TITLE
Add coverage for JSON reporter target resolution from script directory

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -36,7 +36,12 @@ const mapTargetArgument = (
       ? normalizedRelative.slice(0, -extension.length)
       : normalizedRelative;
 
-    return path.join('dist', `${withoutExtension}.js`);
+    const normalizedSegments = withoutExtension
+      .split(path.sep)
+      .filter((segment) => segment && segment !== '.' && segment !== '..');
+    const distPath = path.join('dist', ...normalizedSegments);
+
+    return `${distPath}.js`;
   }
 
   const inDistAlready =


### PR DESCRIPTION
## Summary
- add a regression test ensuring prepareRunnerOptions resolves TypeScript targets to dist paths when invoked from the tests directory
- update the JSON reporter runner target mapping to normalize parent directory segments before producing dist paths

## Testing
- npm run build
- node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f3d2559f7883219328bc15c330af66