### PR TITLE
Add concurrency cancellation to workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '0 18 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   security-events: write
   actions: read

--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -1,5 +1,9 @@
 name: pr-gate
 on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -5,6 +5,10 @@ on:
     types: [completed]
   schedule:
     - cron: "0 3 * * *"   # 毎日3:00 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   reflect:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update_release_draft:
     name: Update release draft

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary
- ensure all workflows cancel in-progress runs when a new execution starts
- align concurrency groups across workflows to use the workflow name plus pull request number or ref

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3d5dffa6c8321ae2419e19bdff843