### PR TITLE
docs: document nfkd normalize mode

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # API: TypeScript
 
 ```ts
-export type NormalizeMode = "none" | "nfc" | "nfkc";
+export type NormalizeMode = "none" | "nfc" | "nfkc" | "nfkd";
 
 export interface CategorizerOptions {
   salt?: string;
@@ -28,6 +28,8 @@ export class Cat32 {
   labelOf(input: unknown): string;
 }
 ```
+
+`normalize` には Unicode 正規化モードとして `"none" | "nfc" | "nfkc" | "nfkd"` の 4 種類を指定できます（CLI の `--normalize` も同じ値を受け付けます）。
 
 ### 例
 ```ts


### PR DESCRIPTION
## Summary
- document the nfkd Unicode normalization mode in the TypeScript API docs and note the four supported options shared with the CLI

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f3d8fa8cbc8321b5ff8bfa0a6b2868