### PR TITLE
docs: document nfkd normalization option

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,7 +1,7 @@
 # CLI 仕様
 
 ```
-$ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfc|none --json[=compact|pretty] --pretty]
+$ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|nfc|none --json[=compact|pretty] --pretty]
 ```
 
 - `<key>` が無い場合は **stdin** を読み取る。
@@ -19,11 +19,12 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfc|n
   - `--json=compact`/既定モードのみ **NDJSON**（1行1 JSON オブジェクト、末尾改行あり）の制約が掛かる。
   - `--json=pretty` または `--pretty` はインデント2の複数行 JSON を出力し、複雑なキーでも可読性を優先して確認できる。
   - `--json=pretty` と `--pretty` は同じ整形結果になる。
-  - `--json` と `--pretty` を同時指定した場合も整形出力（インデント2）。
-  - 整形モードは複数行の整形 JSON を返し、NDJSON ではない点に注意。
-  - 終了コード:
-  - `0` … 成功
-  - `2` … 循環/labels長不正/override不正など仕様違反
+- `--json` と `--pretty` を同時指定した場合も整形出力（インデント2）。
+- 整形モードは複数行の整形 JSON を返し、NDJSON ではない点に注意。
+- `--normalize` には `nfkc`（既定）、`nfkd`、`nfc`、`none` を指定できる。
+- 終了コード:
+- `0` … 成功
+- `2` … 循環/labels長不正/override不正など仕様違反
   - `1` … その他の例外
 
 ## 出力例

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -35,7 +35,7 @@ tests/
 - Node <18 互換は非目標（必要なら polyfill）。
 
 ## 6. CLI（cli.ts）
-- 引数: `--salt=... --namespace=... --normalize=nfkc|nfc|none`
+- 引数: `--salt=... --namespace=... --normalize=nfkc|nfkd|nfc|none`
 - 入力: 引数 `<key>` がなければ **stdin** を読む。
 - 出力: 既定/`compact` モードは **NDJSON**（1 行 1 JSON）で `Assignment` を出力。
 - 整形モード（`--json=pretty`/`--pretty`/`--json --pretty`）は複数行の整形 JSON を返し、NDJSON とは異なる。


### PR DESCRIPTION
## Summary
- document nfkd as a supported value for the --normalize flag in the CLI usage guide
- align the design documentation with the CLI implementation by listing nfkd among the allowed normalization strategies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3d8fa5cd08321b3dd41accf76797b