### PR TITLE
docs: document nfkd normalization option

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -7,7 +7,7 @@ export interface CategorizerOptions {
   salt?: string;
   namespace?: string;
   labels?: string[];            // length === 32
-  normalize?: NormalizeMode;    // default "nfkc"
+  normalize?: NormalizeMode;    // default "nfkc"; accepts "none" | "nfc" | "nfkc" | "nfkd"
   overrides?: Record<string, number | string>;  // use Cat32.assign(...).key or stableStringify(...) for keys
 }
 
@@ -29,7 +29,7 @@ export class Cat32 {
 }
 ```
 
-`normalize` には Unicode 正規化モードとして `"none" | "nfc" | "nfkc" | "nfkd"` の 4 種類を指定できます（CLI の `--normalize` も同じ値を受け付けます）。
+`normalize` には Unicode 正規化モードとして `"none" | "nfc" | "nfkc" | "nfkd"` の 4 種類を指定できます（CLI の `--normalize` も同じ値を受け付けます）。既定値は `"nfkc"` です。
 
 ### 例
 ```ts


### PR DESCRIPTION
## Summary
- note the four Unicode normalization modes exposed by NormalizeMode in the API docs
- clarify the default normalize option value in the TypeScript snippet

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f3e31fef5483218b0731d507a92c8b