### PR TITLE
docs: document nfkd normalization mode

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,7 +21,7 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
   - `--json=pretty` と `--pretty` は同じ整形結果になる。
 - `--json` と `--pretty` を同時指定した場合も整形出力（インデント2）。
 - 整形モードは複数行の整形 JSON を返し、NDJSON ではない点に注意。
-- `--normalize` には `nfkc`（既定）、`nfkd`、`nfc`、`none` を指定できる。
+- `--normalize` には Unicode 正規化モードとして `nfkc`（既定）、`nfkd`、`nfc`、`none` の 4 種類を指定できる。
 - 終了コード:
 - `0` … 成功
 - `2` … 循環/labels長不正/override不正など仕様違反

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -36,6 +36,7 @@ tests/
 
 ## 6. CLI（cli.ts）
 - 引数: `--salt=... --namespace=... --normalize=nfkc|nfkd|nfc|none`
+- 正規化モード: `nfkc`（既定）、`nfkd`、`nfc`、`none` の 4 種類を許可。
 - 入力: 引数 `<key>` がなければ **stdin** を読む。
 - 出力: 既定/`compact` モードは **NDJSON**（1 行 1 JSON）で `Assignment` を出力。
 - 整形モード（`--json=pretty`/`--pretty`/`--json --pretty`）は複数行の整形 JSON を返し、NDJSON とは異なる。


### PR DESCRIPTION
## Summary
- clarify the CLI synopsis to enumerate all four supported --normalize modes
- update the CLI section in the design document to mention the nfkd normalization option

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f3e31fc078832190a3b25955267aee