### PR TITLE
Fix JSON reporter destination resolution from subdirectories

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -240,17 +240,31 @@ const prepareRunnerOptions = (
   return { passthroughArgs, targets, destinationOverride };
 };
 
-const resolveDestination = (override) => {
-  if (override) {
-    return override;
+const ensureAbsoluteDestination = (candidate) => {
+  if (!candidate) {
+    return path.resolve(projectRoot, DEFAULT_DESTINATION);
   }
 
-  for (const entry of fs.readdirSync('.', { withFileTypes: true })) {
+  if (path.isAbsolute(candidate)) {
+    return candidate;
+  }
+
+  return path.resolve(projectRoot, candidate);
+};
+
+const resolveDestination = (override) => {
+  if (override) {
+    return ensureAbsoluteDestination(override);
+  }
+
+  for (const entry of fs.readdirSync(projectRoot, { withFileTypes: true })) {
     if (!entry.name.startsWith(DESTINATION_PREFIX)) {
       continue;
     }
     let suffix = entry.name.slice(DESTINATION_PREFIX.length);
-    let current = entry.isDirectory() ? entry.name : null;
+    let current = entry.isDirectory()
+      ? path.join(projectRoot, entry.name)
+      : null;
     while (current) {
       const contents = fs.readdirSync(current, { withFileTypes: true });
       const next = contents.find((item) => item.isDirectory());
@@ -260,24 +274,25 @@ const resolveDestination = (override) => {
       suffix = path.join(suffix, next.name);
       current = path.join(current, next.name);
     }
-    return suffix || DEFAULT_DESTINATION;
+    return ensureAbsoluteDestination(suffix || DEFAULT_DESTINATION);
   }
-  return DEFAULT_DESTINATION;
+  return ensureAbsoluteDestination(DEFAULT_DESTINATION);
 };
 
-export { prepareRunnerOptions };
+export { prepareRunnerOptions, resolveDestination };
 
 const runJsonReporter = async () => {
   const { passthroughArgs, targets, destinationOverride } = prepareRunnerOptions();
   const destination = resolveDestination(destinationOverride);
-  const resolvedDestination = path.resolve(destination);
-  fs.mkdirSync(path.dirname(resolvedDestination), { recursive: true });
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
 
-  const reporterSpecifier = pathToFileURL(path.resolve('reporters/json/index.js')).href;
+  const reporterSpecifier = pathToFileURL(
+    path.resolve(projectRoot, 'reporters/json/index.js'),
+  ).href;
   const args = [
     '--test',
     `--test-reporter=${reporterSpecifier}`,
-    `--test-reporter-destination=${resolvedDestination}`,
+    `--test-reporter-destination=${destination}`,
     ...targets,
     ...passthroughArgs
   ];

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -161,6 +161,166 @@ test("JSON reporter runner uses dist target when invoked with TS input", async (
   assert.deepEqual(exitCodes, [0]);
 });
 
+test(
+  "JSON reporter runner resolves destination from project root when invoked in subdirectory",
+  async () => {
+    const { createRequire } = (await dynamicImport("node:module")) as {
+      createRequire: (specifier: string | URL) => (id: string) => unknown;
+    };
+    const require = createRequire(import.meta.url);
+    const fsModule = require("node:fs") as {
+      mkdirSync: (path: unknown, options?: unknown) => unknown;
+    };
+    const pathModule = require("node:path") as {
+      resolve: (...segments: string[]) => string;
+      dirname: (value: string) => string;
+    };
+    const { fileURLToPath } = (await dynamicImport("node:url")) as {
+      fileURLToPath: (url: string | URL) => string;
+    };
+
+    const projectRoot = fileURLToPath(repoRootUrl);
+    const processWithEnv = process as typeof process & {
+      env: Record<string, string | undefined> & {
+        __CAT32_SKIP_JSON_REPORTER_RUN__?: string;
+      };
+    };
+    const previousSkip = processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__;
+    processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__ = "1";
+
+    let resolveDestination: (override: string | null) => string;
+    try {
+      const moduleExports = (await import(
+        `${runnerUrl.href}?destination=${Date.now()}`,
+      )) as { resolveDestination: (override: string | null) => string };
+      resolveDestination = moduleExports.resolveDestination;
+    } finally {
+      if (previousSkip === undefined) {
+        delete processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__;
+      } else {
+        processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__ = previousSkip;
+      }
+    }
+
+    if (!resolveDestination) {
+      throw new Error("resolveDestination not loaded");
+    }
+    const activeResolveDestination = resolveDestination;
+
+    const expectedDefaultDestination = activeResolveDestination(null);
+    assert.equal(
+      expectedDefaultDestination,
+      pathModule.resolve(projectRoot, "logs/test.jsonl"),
+    );
+    const expectedOverrideDestination = activeResolveDestination(
+      "tmp/out.jsonl",
+    );
+    assert.equal(
+      expectedOverrideDestination,
+      pathModule.resolve(projectRoot, "tmp/out.jsonl"),
+    );
+
+    const cleanups: Array<() => void> = [];
+    const mkdirCalls: string[] = [];
+    const spawnCalls: SpawnCall[] = [];
+    const exitCodes: number[] = [];
+    let thrown: unknown;
+
+    const originalMkdirSync = fsModule.mkdirSync;
+    (fsModule as {
+      mkdirSync: (path: string, options?: { recursive?: boolean }) => void;
+    }).mkdirSync = (directory) => {
+      mkdirCalls.push(directory);
+    };
+    cleanups.push(() => {
+      (fsModule as {
+        mkdirSync: (path: string, options?: { recursive?: boolean }) => void;
+      }).mkdirSync = originalMkdirSync;
+    });
+
+    const processWithCwd = process as typeof process & {
+      cwd: () => string;
+      chdir: (directory: string) => void;
+    };
+    const originalCwd = processWithCwd.cwd();
+    const testsDirectory = fileURLToPath(new URL("./tests/", repoRootUrl));
+    processWithCwd.chdir(testsDirectory);
+    cleanups.push(() => {
+      processWithCwd.chdir(originalCwd);
+    });
+
+    const originalArgv = process.argv;
+    process.argv = [process.argv[0]!, "./--test-reporter=json"];
+    cleanups.push(() => {
+      process.argv = originalArgv;
+    });
+
+    const originalExit = process.exit;
+    (process as { exit: (code?: number) => never }).exit = ((code?: number) => {
+      exitCodes.push(code ?? 0);
+      return undefined as never;
+    }) as typeof originalExit;
+    cleanups.push(() => {
+      (process as { exit: typeof originalExit }).exit = originalExit;
+    });
+
+    const spawnOverride = (
+      command: unknown,
+      args: unknown,
+      options: unknown,
+    ) => {
+      const child = {
+        killed: false,
+        kill: () => {
+          child.killed = true;
+          return true;
+        },
+        once: (event: unknown, listener: unknown) => {
+          if (event === "exit" && typeof listener === "function") {
+            queueMicrotask(() => {
+              (listener as (code: number, signal: string | null) => void)(0, null);
+            });
+          }
+          return child;
+        },
+      };
+      spawnCalls.push({ command, args, options });
+      return child;
+    };
+    (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride }).__CAT32_TEST_SPAWN__ =
+      spawnOverride;
+    cleanups.push(() => {
+      delete (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride })
+        .__CAT32_TEST_SPAWN__;
+    });
+
+    try {
+      await import(`${runnerUrl.href}?subdir=${Date.now()}`);
+    } catch (error) {
+      thrown = error;
+    } finally {
+      while (cleanups.length) {
+        cleanups.pop()?.();
+      }
+    }
+
+    assert.equal(thrown, undefined);
+    assert.equal(spawnCalls.length, 1);
+    const invocation = spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as ReadonlyArray<string>;
+    const destinationArgs = args.filter((value) =>
+      value.startsWith("--test-reporter-destination="),
+    );
+    assert.equal(destinationArgs.length, 1);
+    const expectedDestinationArg = `--test-reporter-destination=${expectedDefaultDestination}`;
+    assert.equal(destinationArgs[0], expectedDestinationArg);
+    const expectedDirectory = pathModule.dirname(expectedDefaultDestination);
+    assert.ok(mkdirCalls.includes(expectedDirectory));
+    assert.deepEqual(exitCodes, [0]);
+  },
+);
+
 test("JSON reporter runner resolves TS targets when invoked from tests directory", async () => {
   const { createRequire } = (await dynamicImport("node:module")) as {
     createRequire: (specifier: string | URL) => (id: string) => unknown;


### PR DESCRIPTION
## Summary
- ensure the JSON reporter resolves destination paths relative to the project root and exports the helper for tests
- update the reporter runner to reuse the project root when spawning the reporter process
- add a regression test that verifies destination resolution and mkdir/spawn arguments when the runner is invoked from a subdirectory

## Testing
- npm test -- tests/json-reporter-runner.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f3f4a4517c8321b45a0f3b9ff513a5