### PR TITLE
Ensure JSON reporter resolves destination from project root

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -261,21 +261,28 @@ const resolveDestination = (override) => {
     if (!entry.name.startsWith(DESTINATION_PREFIX)) {
       continue;
     }
-    let suffix = entry.name.slice(DESTINATION_PREFIX.length);
+
+    const entrySuffix = entry.name.slice(DESTINATION_PREFIX.length);
+    let suffix = entrySuffix;
     let current = entry.isDirectory()
-      ? path.join(projectRoot, entry.name)
+      ? path.resolve(projectRoot, entry.name)
       : null;
+
     while (current) {
       const contents = fs.readdirSync(current, { withFileTypes: true });
       const next = contents.find((item) => item.isDirectory());
+
       if (!next) {
         break;
       }
+
       suffix = path.join(suffix, next.name);
       current = path.join(current, next.name);
     }
+
     return ensureAbsoluteDestination(suffix || DEFAULT_DESTINATION);
   }
+
   return ensureAbsoluteDestination(DEFAULT_DESTINATION);
 };
 

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -29,6 +29,34 @@ type PrepareRunnerOptions = (
   destinationOverride: string | null;
 };
 
+const loadResolveDestination = async (
+  token: string,
+): Promise<(override: string | null) => string> => {
+  const processWithEnv = process as typeof process & {
+    env: Record<string, string | undefined> & {
+      __CAT32_SKIP_JSON_REPORTER_RUN__?: string;
+    };
+  };
+  const previousSkip = processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__;
+  processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__ = "1";
+
+  try {
+    const moduleExports = (await import(
+      `${runnerUrl.href}?${token}=${Date.now()}`,
+    )) as { resolveDestination?: (override: string | null) => string };
+    if (typeof moduleExports.resolveDestination !== "function") {
+      throw new Error("resolveDestination not loaded");
+    }
+    return moduleExports.resolveDestination;
+  } finally {
+    if (previousSkip === undefined) {
+      delete processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__;
+    } else {
+      processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__ = previousSkip;
+    }
+  }
+};
+
 test("JSON reporter runner uses dist target when invoked with TS input", async () => {
   const { createRequire } = (await dynamicImport("node:module")) as {
     createRequire: (specifier: string | URL) => (id: string) => unknown;
@@ -180,41 +208,14 @@ test(
     };
 
     const projectRoot = fileURLToPath(repoRootUrl);
-    const processWithEnv = process as typeof process & {
-      env: Record<string, string | undefined> & {
-        __CAT32_SKIP_JSON_REPORTER_RUN__?: string;
-      };
-    };
-    const previousSkip = processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__;
-    processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__ = "1";
-
-    let resolveDestination: (override: string | null) => string;
-    try {
-      const moduleExports = (await import(
-        `${runnerUrl.href}?destination=${Date.now()}`,
-      )) as { resolveDestination: (override: string | null) => string };
-      resolveDestination = moduleExports.resolveDestination;
-    } finally {
-      if (previousSkip === undefined) {
-        delete processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__;
-      } else {
-        processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__ = previousSkip;
-      }
-    }
-
-    if (!resolveDestination) {
-      throw new Error("resolveDestination not loaded");
-    }
-    const activeResolveDestination = resolveDestination;
+    const activeResolveDestination = await loadResolveDestination("destination");
 
     const expectedDefaultDestination = activeResolveDestination(null);
     assert.equal(
       expectedDefaultDestination,
       pathModule.resolve(projectRoot, "logs/test.jsonl"),
     );
-    const expectedOverrideDestination = activeResolveDestination(
-      "tmp/out.jsonl",
-    );
+    const expectedOverrideDestination = activeResolveDestination("tmp/out.jsonl");
     assert.equal(
       expectedOverrideDestination,
       pathModule.resolve(projectRoot, "tmp/out.jsonl"),
@@ -316,6 +317,141 @@ test(
     const expectedDestinationArg = `--test-reporter-destination=${expectedDefaultDestination}`;
     assert.equal(destinationArgs[0], expectedDestinationArg);
     const expectedDirectory = pathModule.dirname(expectedDefaultDestination);
+    assert.ok(mkdirCalls.includes(expectedDirectory));
+    assert.deepEqual(exitCodes, [0]);
+  },
+);
+
+test(
+  "JSON reporter runner uses CLI override destination from project root when invoked in subdirectory",
+  async () => {
+    const { createRequire } = (await dynamicImport("node:module")) as {
+      createRequire: (specifier: string | URL) => (id: string) => unknown;
+    };
+    const require = createRequire(import.meta.url);
+    const fsModule = require("node:fs") as {
+      mkdirSync: (path: unknown, options?: unknown) => unknown;
+    };
+    const pathModule = require("node:path") as {
+      resolve: (...segments: string[]) => string;
+      dirname: (value: string) => string;
+    };
+    const { fileURLToPath } = (await dynamicImport("node:url")) as {
+      fileURLToPath: (url: string | URL) => string;
+    };
+
+    const projectRoot = fileURLToPath(repoRootUrl);
+    const activeResolveDestination = await loadResolveDestination(
+      "cli-destination",
+    );
+
+    const expectedOverrideDestination = activeResolveDestination("tmp/cli-out.jsonl");
+    assert.equal(
+      expectedOverrideDestination,
+      pathModule.resolve(projectRoot, "tmp/cli-out.jsonl"),
+    );
+
+    const cleanups: Array<() => void> = [];
+    const mkdirCalls: string[] = [];
+    const spawnCalls: SpawnCall[] = [];
+    const exitCodes: number[] = [];
+    let thrown: unknown;
+
+    const originalMkdirSync = fsModule.mkdirSync;
+    (fsModule as {
+      mkdirSync: (path: string, options?: { recursive?: boolean }) => void;
+    }).mkdirSync = (directory) => {
+      mkdirCalls.push(directory);
+    };
+    cleanups.push(() => {
+      (fsModule as {
+        mkdirSync: (path: string, options?: { recursive?: boolean }) => void;
+      }).mkdirSync = originalMkdirSync;
+    });
+
+    const processWithCwd = process as typeof process & {
+      cwd: () => string;
+      chdir: (directory: string) => void;
+    };
+    const originalCwd = processWithCwd.cwd();
+    const testsDirectory = fileURLToPath(new URL("./tests/", repoRootUrl));
+    processWithCwd.chdir(testsDirectory);
+    cleanups.push(() => {
+      processWithCwd.chdir(originalCwd);
+    });
+
+    const originalArgv = process.argv;
+    process.argv = [
+      process.argv[0]!,
+      "./--test-reporter=json",
+      "--test-reporter-destination",
+      "tmp/cli-out.jsonl",
+    ];
+    cleanups.push(() => {
+      process.argv = originalArgv;
+    });
+
+    const originalExit = process.exit;
+    (process as { exit: (code?: number) => never }).exit = ((code?: number) => {
+      exitCodes.push(code ?? 0);
+      return undefined as never;
+    }) as typeof originalExit;
+    cleanups.push(() => {
+      (process as { exit: typeof originalExit }).exit = originalExit;
+    });
+
+    const spawnOverride = (
+      command: unknown,
+      args: unknown,
+      options: unknown,
+    ) => {
+      const child = {
+        killed: false,
+        kill: () => {
+          child.killed = true;
+          return true;
+        },
+        once: (event: unknown, listener: unknown) => {
+          if (event === "exit" && typeof listener === "function") {
+            queueMicrotask(() => {
+              (listener as (code: number, signal: string | null) => void)(0, null);
+            });
+          }
+          return child;
+        },
+      };
+      spawnCalls.push({ command, args, options });
+      return child;
+    };
+    (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride }).__CAT32_TEST_SPAWN__ =
+      spawnOverride;
+    cleanups.push(() => {
+      delete (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride })
+        .__CAT32_TEST_SPAWN__;
+    });
+
+    try {
+      await import(`${runnerUrl.href}?cli-run=${Date.now()}`);
+    } catch (error) {
+      thrown = error;
+    } finally {
+      while (cleanups.length) {
+        cleanups.pop()?.();
+      }
+    }
+
+    assert.equal(thrown, undefined);
+    assert.equal(spawnCalls.length, 1);
+    const invocation = spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as ReadonlyArray<string>;
+    const destinationArgs = args.filter((value) =>
+      value.startsWith("--test-reporter-destination="),
+    );
+    assert.equal(destinationArgs.length, 1);
+    const expectedDestinationArg = `--test-reporter-destination=${expectedOverrideDestination}`;
+    assert.equal(destinationArgs[0], expectedDestinationArg);
+    const expectedDirectory = pathModule.dirname(expectedOverrideDestination);
     assert.ok(mkdirCalls.includes(expectedDirectory));
     assert.deepEqual(exitCodes, [0]);
   },


### PR DESCRIPTION
## Summary
- ensure the JSON reporter resolves destination prefixes relative to the project root
- add regression coverage to verify default and CLI override destinations when running from subdirectories

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f3f962aed883218fc581bbda8f04dc