### PR TITLE
Fix JSON reporter target resolution in nested directories

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -50,7 +50,40 @@ const mapTargetArgument = (
     return target;
   }
 
-  const absolute = path.isAbsolute(target) ? target : path.resolve(target);
+  const safeExists = (candidate) =>
+    typeof candidate === 'string' && existsSync(candidate);
+
+  const resolveAbsoluteCandidate = (candidate) => {
+    if (path.isAbsolute(candidate)) {
+      return path.normalize(candidate);
+    }
+
+    const resolvedFromCwd = path.resolve(candidate);
+
+    const relativeFromCwd = path.relative(projectRoot, resolvedFromCwd);
+    const isWithinProjectFromCwd =
+      relativeFromCwd &&
+      relativeFromCwd !== '..' &&
+      !relativeFromCwd.startsWith(`..${path.sep}`);
+    const candidateExtension = path.extname(candidate);
+
+    if (
+      safeExists(resolvedFromCwd) ||
+      (candidateExtension && isWithinProjectFromCwd)
+    ) {
+      return path.normalize(resolvedFromCwd);
+    }
+
+    const resolvedFromProject = path.resolve(projectRoot, candidate);
+
+    if (safeExists(resolvedFromProject)) {
+      return path.normalize(resolvedFromProject);
+    }
+
+    return path.normalize(resolvedFromProject);
+  };
+
+  const absolute = resolveAbsoluteCandidate(target);
   const relativePathFromProject = path.relative(projectRoot, absolute);
   const normalizedRelative = path.normalize(relativePathFromProject);
   const extension = path.extname(normalizedRelative);
@@ -130,33 +163,54 @@ const prepareRunnerOptions = (
       return null;
     }
 
+    const candidateExists = (value) => {
+      if (!value || typeof value !== 'string') {
+        return false;
+      }
+
+      const queue = path.isAbsolute(value)
+        ? [path.normalize(value)]
+        : [
+            path.normalize(value),
+            path.normalize(path.resolve(value)),
+            path.normalize(path.resolve(projectRoot, value)),
+          ];
+      const seen = new Set();
+
+      for (const entry of queue) {
+        if (!entry || seen.has(entry)) {
+          continue;
+        }
+
+        seen.add(entry);
+
+        if (existsSync(entry)) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+
     const normalized = mapTargetArgument(candidate, {
       existsSync,
       mapDirectoriesToDist: true,
     });
 
     if (normalized && normalized !== candidate) {
-      const normalizedAbsolute = path.resolve(projectRoot, normalized);
-      const candidateAbsolute = path.resolve(candidate);
-
-      if (
-        existsSync(normalized) ||
-        existsSync(normalizedAbsolute) ||
-        existsSync(candidate) ||
-        existsSync(candidateAbsolute)
-      ) {
+      if (candidateExists(normalized) || candidateExists(candidate)) {
         return normalized;
       }
     }
 
-    if (existsSync(candidate)) {
+    if (candidateExists(candidate)) {
       return candidate;
     }
 
-    const absoluteCandidate = path.resolve(candidate);
+    const absoluteCandidate = mapTargetArgument(candidate, { existsSync });
 
-    if (existsSync(absoluteCandidate)) {
-      return absoluteCandidate;
+    if (absoluteCandidate && path.isAbsolute(absoluteCandidate)) {
+      return candidateExists(absoluteCandidate) ? absoluteCandidate : null;
     }
 
     return null;

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -162,6 +162,134 @@ test("JSON reporter runner uses dist target when invoked with TS input", async (
 });
 
 test(
+  "JSON reporter runner maps default targets from nested directory to dist",
+  async () => {
+    const { createRequire } = (await dynamicImport("node:module")) as {
+      createRequire: (specifier: string | URL) => (id: string) => unknown;
+    };
+    const require = createRequire(import.meta.url);
+    const fsModule = require("node:fs") as {
+      mkdirSync: (path: unknown, options?: unknown) => unknown;
+      mkdtempSync: (prefix: string) => string;
+      rmdirSync: (path: string) => void;
+    };
+    const pathModule = require("node:path") as {
+      join: (...segments: string[]) => string;
+      resolve: (...segments: string[]) => string;
+      dirname: (value: string) => string;
+    };
+    const { fileURLToPath } = (await dynamicImport("node:url")) as {
+      fileURLToPath: (url: string | URL) => string;
+    };
+
+    const projectRoot = fileURLToPath(repoRootUrl);
+    const cleanups: Array<() => void> = [];
+    const spawnCalls: SpawnCall[] = [];
+    const mkdirCalls: string[] = [];
+    const exitCodes: number[] = [];
+    let thrown: unknown;
+
+    const originalMkdirSync = fsModule.mkdirSync;
+    (fsModule as {
+      mkdirSync: (path: string, options?: { recursive?: boolean }) => void;
+    }).mkdirSync = (directory) => {
+      mkdirCalls.push(directory);
+    };
+    cleanups.push(() => {
+      (fsModule as {
+        mkdirSync: (path: string, options?: { recursive?: boolean }) => void;
+      }).mkdirSync = originalMkdirSync;
+    });
+
+    const processWithCwd = process as typeof process & {
+      cwd: () => string;
+      chdir: (directory: string) => void;
+    };
+    const originalCwd = processWithCwd.cwd();
+    const testsDirectory = fileURLToPath(new URL("./tests/", repoRootUrl));
+    const temporaryDirectory = fsModule.mkdtempSync(
+      pathModule.join(testsDirectory, "json-runner-"),
+    );
+    processWithCwd.chdir(temporaryDirectory);
+    cleanups.push(() => {
+      processWithCwd.chdir(originalCwd);
+      fsModule.rmdirSync(temporaryDirectory);
+    });
+
+    const originalArgv = process.argv;
+    process.argv = [process.argv[0]!, "./--test-reporter=json"];
+    cleanups.push(() => {
+      process.argv = originalArgv;
+    });
+
+    const originalExit = process.exit;
+    (process as { exit: (code?: number) => never }).exit = ((code?: number) => {
+      exitCodes.push(code ?? 0);
+      return undefined as never;
+    }) as typeof originalExit;
+    cleanups.push(() => {
+      (process as { exit: typeof originalExit }).exit = originalExit;
+    });
+
+    const spawnOverride = (
+      command: unknown,
+      args: unknown,
+      options: unknown,
+    ) => {
+      const child = {
+        killed: false,
+        kill: () => {
+          child.killed = true;
+          return true;
+        },
+        once: (event: unknown, listener: unknown) => {
+          if (event === "exit" && typeof listener === "function") {
+            queueMicrotask(() => {
+              (listener as (code: number, signal: string | null) => void)(0, null);
+            });
+          }
+          return child;
+        },
+      };
+      spawnCalls.push({ command, args, options });
+      return child;
+    };
+    (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride }).__CAT32_TEST_SPAWN__ =
+      spawnOverride;
+    cleanups.push(() => {
+      delete (globalThis as { __CAT32_TEST_SPAWN__?: typeof spawnOverride })
+        .__CAT32_TEST_SPAWN__;
+    });
+
+    try {
+      await import(`${runnerUrl.href}?nested=${Date.now()}`);
+    } catch (error) {
+      thrown = error;
+    } finally {
+      while (cleanups.length) {
+        cleanups.pop()?.();
+      }
+    }
+
+    assert.equal(thrown, undefined);
+    assert.equal(spawnCalls.length, 1);
+    const invocation = spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as ReadonlyArray<string>;
+    const normalizedTargets = args
+      .filter((value) => typeof value === "string" && !value.startsWith("--"))
+      .map((value) => value.replace(/\\+/g, "/"));
+    assert.ok(normalizedTargets.includes("dist/tests"));
+    assert.ok(normalizedTargets.includes("dist/frontend/tests"));
+    const expectedDirectory = pathModule.dirname(
+      pathModule.resolve(projectRoot, "logs/test.jsonl"),
+    );
+    assert.ok(mkdirCalls.includes(expectedDirectory));
+    assert.deepEqual(exitCodes, [0]);
+  },
+);
+
+test(
   "JSON reporter runner resolves destination from project root when invoked in subdirectory",
   async () => {
     const { createRequire } = (await dynamicImport("node:module")) as {


### PR DESCRIPTION
## Summary
- add coverage for invoking the JSON reporter runner from a nested directory and validate default dist targets
- resolve JSON reporter target arguments relative to the project root while preserving TypeScript to dist mapping

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f3f962278483219901c457579324e2