### PR TITLE
Ensure JSON reporter runner spawns from project root

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -308,7 +308,11 @@ const runJsonReporter = async () => {
   delete childEnv.NODE_TEST_CONTEXT;
   const spawnOverride = globalThis.__CAT32_TEST_SPAWN__;
   const spawnFunction = typeof spawnOverride === 'function' ? spawnOverride : spawn;
-  const child = spawnFunction(process.execPath, args, { stdio: 'inherit', env: childEnv });
+  const child = spawnFunction(process.execPath, args, {
+    stdio: 'inherit',
+    env: childEnv,
+    cwd: projectRoot,
+  });
   for (const signal of ['SIGINT', 'SIGTERM', 'SIGQUIT']) {
     process.on(signal, () => {
       if (!child.killed) {

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -202,6 +202,7 @@ test(
     const pathModule = require("node:path") as {
       resolve: (...segments: string[]) => string;
       dirname: (value: string) => string;
+      isAbsolute: (value: string) => boolean;
     };
     const { fileURLToPath } = (await dynamicImport("node:url")) as {
       fileURLToPath: (url: string | URL) => string;
@@ -318,6 +319,21 @@ test(
     assert.equal(destinationArgs[0], expectedDestinationArg);
     const expectedDirectory = pathModule.dirname(expectedDefaultDestination);
     assert.ok(mkdirCalls.includes(expectedDirectory));
+    const targetArgs = args.filter(
+      (value) => typeof value === "string" && !value.startsWith("--") && value !== "--test",
+    );
+    const hasAbsoluteTargets =
+      targetArgs.length > 0 && targetArgs.every((value) => pathModule.isAbsolute(value));
+    const options = invocation.options as { cwd?: unknown };
+    const usesProjectRootCwd =
+      options !== null &&
+      typeof options === "object" &&
+      typeof options.cwd === "string" &&
+      pathModule.resolve(options.cwd) === pathModule.resolve(projectRoot);
+    assert.ok(
+      hasAbsoluteTargets || usesProjectRootCwd,
+      "runner should spawn with absolute targets or project root cwd",
+    );
     assert.deepEqual(exitCodes, [0]);
   },
 );


### PR DESCRIPTION
## Summary
- ensure the JSON reporter runner spawns the child process with the project root as its working directory so relative dist targets resolve correctly
- extend the subdirectory runner test to assert that spawned targets are absolute or executed from the project root

## Testing
- npm run build && node --test dist/tests

------
https://chatgpt.com/codex/tasks/task_e_68f3fe063e6883218a3b037e4d34ff71