### PR TITLE
Fix JSON reporter dist target resolution in frontend cwd

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -46,38 +46,48 @@ const mapTargetArgument = (
   target,
   { existsSync = fs.existsSync, mapDirectoriesToDist = false } = {},
 ) => {
-  if (!target) {
+  if (!target || typeof target !== 'string') {
     return target;
   }
 
+  const normalizedTarget = path.normalize(target);
+  const preferProjectAbsolute =
+    !path.isAbsolute(target) &&
+    (normalizedTarget === 'dist' || normalizedTarget.startsWith(`dist${path.sep}`));
+
   const absoluteFromCwd = path.isAbsolute(target)
-    ? target
-    : path.resolve(target);
+    ? path.normalize(target)
+    : path.normalize(path.resolve(target));
   const absoluteFromProject = path.isAbsolute(target)
-    ? target
-    : path.resolve(projectRoot, target);
+    ? path.normalize(target)
+    : path.normalize(path.resolve(projectRoot, target));
 
   const absolute = (() => {
     if (path.isAbsolute(target)) {
-      return target;
+      return absoluteFromProject;
     }
 
     const existsFromCwd = existsSync(absoluteFromCwd);
     const existsFromProject = existsSync(absoluteFromProject);
-    const currentDirectory = process.cwd();
-    const cwdContainsCandidate = absoluteFromCwd.startsWith(`${currentDirectory}${path.sep}`) ||
-      absoluteFromCwd === currentDirectory;
-
-    if (existsFromCwd && !existsFromProject) {
-      return absoluteFromCwd;
-    }
+    const currentDirectory = path.normalize(process.cwd());
+    const cwdContainsCandidate =
+      absoluteFromCwd === currentDirectory ||
+      absoluteFromCwd.startsWith(`${currentDirectory}${path.sep}`);
 
     if (existsFromProject && !existsFromCwd) {
       return absoluteFromProject;
     }
 
-    if (existsFromCwd && existsFromProject) {
+    if (existsFromCwd && !existsFromProject) {
+      return absoluteFromCwd;
+    }
+
+    if (existsFromProject && existsFromCwd) {
       return cwdContainsCandidate ? absoluteFromCwd : absoluteFromProject;
+    }
+
+    if (preferProjectAbsolute) {
+      return absoluteFromProject;
     }
 
     if (cwdContainsCandidate) {
@@ -171,23 +181,25 @@ const prepareRunnerOptions = (
         return false;
       }
 
-      const queue = path.isAbsolute(value)
-        ? [path.normalize(value)]
-        : [
-            path.normalize(value),
-            path.normalize(path.resolve(value)),
-            path.normalize(path.resolve(projectRoot, value)),
-          ];
-      const seen = new Set();
+      const normalizedValue = path.normalize(value);
+      const candidates = new Set();
 
-      for (const entry of queue) {
-        if (!entry || seen.has(entry)) {
-          continue;
-        }
+      const projectAbsolute = path.normalize(
+        path.isAbsolute(normalizedValue)
+          ? normalizedValue
+          : path.resolve(projectRoot, normalizedValue),
+      );
+      candidates.add(projectAbsolute);
 
-        seen.add(entry);
+      if (path.isAbsolute(normalizedValue)) {
+        candidates.add(normalizedValue);
+      } else {
+        candidates.add(normalizedValue);
+        candidates.add(path.normalize(path.resolve(normalizedValue)));
+      }
 
-        if (existsSync(entry)) {
+      for (const entry of candidates) {
+        if (entry && existsSync(entry)) {
           return true;
         }
       }

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -1102,3 +1102,55 @@ test(
     }
   },
 );
+
+test(
+  "prepareRunnerOptions keeps default dist targets when existsSync only reports dist entries from frontend directory",
+  async () => {
+    const processWithEnv = process as typeof process & {
+      env: Record<string, string | undefined> & {
+        __CAT32_SKIP_JSON_REPORTER_RUN__?: string;
+      };
+    };
+    const previousEnv = processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__;
+    processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__ = "1";
+
+    const processWithCwd = process as typeof process & {
+      cwd: () => string;
+      chdir: (directory: string) => void;
+    };
+    const originalCwd = processWithCwd.cwd();
+
+    try {
+      const moduleExports = (await import(
+        `${runnerUrl.href}?frontend-relative=${Date.now()}`,
+      )) as { prepareRunnerOptions: PrepareRunnerOptions };
+
+      const { prepareRunnerOptions } = moduleExports;
+      assert.equal(typeof prepareRunnerOptions, "function");
+
+      const { fileURLToPath } = (await dynamicImport("node:url")) as {
+        fileURLToPath: (url: string | URL) => string;
+      };
+
+      const frontendDirectory = fileURLToPath(new URL("./frontend/", repoRootUrl));
+      processWithCwd.chdir(frontendDirectory);
+
+      const relativeDistEntries = new Set(["dist/tests", "dist/frontend/tests"]);
+
+      const result = prepareRunnerOptions(["node", "script"], {
+        existsSync: (candidate) =>
+          typeof candidate === "string" && relativeDistEntries.has(candidate),
+      });
+
+      assert.deepEqual(result.targets, ["dist/tests", "dist/frontend/tests"]);
+    } finally {
+      processWithCwd.chdir(originalCwd);
+
+      if (previousEnv === undefined) {
+        delete processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__;
+      } else {
+        processWithEnv.env.__CAT32_SKIP_JSON_REPORTER_RUN__ = previousEnv;
+      }
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- add a regression test for prepareRunnerOptions to ensure default dist targets are preserved when cwd is frontend and existsSync only reports dist paths
- update the JSON reporter runner target normalization to prefer project-root absolute paths for dist entries and to canonicalize candidate existence checks

## Testing
- npm run build
- node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f4030c624c8321899529981e7ee83d