### PR TITLE
Add RangeError guard for missing reporter destination values

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -332,8 +332,10 @@ const prepareRunnerOptions = (
     addResolvedTarget(resolvedTarget, resolvedDefaults);
   }
 
-  if (pendingOption === '--test-reporter-destination') {
-    throw new RangeError('Missing value for --test-reporter-destination');
+  if (pendingOption) {
+    if (pendingOption === '--test-reporter-destination') {
+      throw new RangeError(`Missing value for ${pendingOption}`);
+    }
   }
 
   const targets = explicitTargets.length > 0 ? explicitTargets : resolvedDefaults;


### PR DESCRIPTION
## Summary
- add a shared helper for loading prepareRunnerOptions in the JSON reporter tests
- cover the --test-reporter-destination flag without a value when it terminates argv
- ensure the JSON reporter runner surfaces a RangeError when the destination flag is missing a value

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f451bcf13083218ddd16126e0d797b