### PR TITLE
docs: clarify CLI JSON 出力モード

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -9,18 +9,9 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
   ```json
   {"index":7,"label":"H","hash":"1a2b3c4d","key":"...canonical..."}
   ```
-  - `--json` を付けない場合は従来通り **compact JSON**。`--json=compact` で明示指定できる。
-  - `--json` 単体でも compact JSON（1行1JSON）を維持する。
-  - `compact` モード（既定/`--json[=compact]`）のみ **NDJSON**（1行1 JSON オブジェクト、末尾改行あり）として出力される。
-  - `--json=pretty` または `--pretty` はインデント2の複数行 JSON を出力し、1レコードが複数行になる。
-  - `--json=pretty` と `--pretty` は同じ整形結果になり、整形モードでは 1 レコードが複数行の JSON になる。
-  - `--json` と `--pretty` を同時指定した場合も整形出力（インデント2、複数行 JSON）となる。
-  - NDJSON (1 行 1 JSON オブジェクト) になるのは compact/既定モード（`--json` を指定しない / `--json` / `--json=compact`）のみ。
-  - `--json=compact`/既定モードのみ **NDJSON**（1行1 JSON オブジェクト、末尾改行あり）の制約が掛かる。
-  - `--json=pretty` または `--pretty` はインデント2の複数行 JSON を出力し、複雑なキーでも可読性を優先して確認できる。
-  - `--json=pretty` と `--pretty` は同じ整形結果になる。
-- `--json` と `--pretty` を同時指定した場合も整形出力（インデント2）。
-- 整形モードは複数行の整形 JSON を返し、NDJSON ではない点に注意。
+  - 既定（`--json` を指定しない）および `--json[=compact]` は compact JSON を 1 行 1 レコードで出力し、末尾改行付きの NDJSON を維持する。
+  - `--json=pretty` と `--pretty` は同義で、インデント 2 の複数行 JSON を返す。`--json` と併用しても整形出力になり、NDJSON にはならない。
+- 整形モードは複数行 JSON（非 NDJSON）となる点に注意。
 - `--normalize` には Unicode 正規化モードとして `nfkc`（既定）、`nfkd`、`nfc`、`none` の 4 種類を指定できる。
 - 終了コード:
 - `0` … 成功


### PR DESCRIPTION
## Summary
- docs/CLI.md の出力形式セクションで compact/pretty モードの説明を統合し、重複を排除
- 整形モードが NDJSON ではない点と compact モードが既定動作である点を明示

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f45665d9f4832192e9c86bd3a90a17