### PR TITLE
Ensure lint covers frontend TypeScript

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,12 @@ export default [
     ignores: ["dist/**"],
   },
   {
-    files: ["src/**/*.ts", "tests/**/*.ts"],
+    files: [
+      "src/**/*.ts",
+      "tests/**/*.ts",
+      "frontend/src/**/*.ts",
+      "frontend/tests/**/*.ts",
+    ],
     languageOptions: {
       parser: tsParser,
       parserOptions: {

--- a/frontend/tests/sw/retry-attempt.types.test.ts
+++ b/frontend/tests/sw/retry-attempt.types.test.ts
@@ -15,4 +15,6 @@ const assertRetryQueueEntryResult = async (store: RefreshQueueStore) => {
   return { promiseResult, syncResult };
 };
 
+void acceptsPromiseReturningValue;
+void acceptsSynchronousValue;
 void assertRetryQueueEntryResult;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bench": "npm run build && node dist/scripts/bench.js",
     "test": "npm run build && node scripts/run-tests.js",
     "prepare": "npm run build",
-    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" \"frontend/src/**/*.ts\" \"frontend/tests/**/*.ts\"",
     "lint:fix": "npm run lint -- --fix"
   },
   "engines": {

--- a/tests/package-metadata.test.ts
+++ b/tests/package-metadata.test.ts
@@ -8,6 +8,13 @@ const dynamicImport = new Function(
 
 const expectedBenchScript = "npm run build && node dist/scripts/bench.js";
 
+const requiredLintGlobs = [
+  "src/**/*.ts",
+  "tests/**/*.ts",
+  "frontend/src/**/*.ts",
+  "frontend/tests/**/*.ts",
+];
+
 test("package.json exposes a TypeScript dev dependency", async () => {
   const { readFile } = (await dynamicImport("node:fs/promises")) as {
     readFile: (path: string | URL, options: "utf8") => Promise<string>;
@@ -62,4 +69,56 @@ test("package.json declares a bench script targeting the compiled bench entry", 
 
   const benchSourceUrl = new URL("../../scripts/bench.ts", import.meta.url);
   await access(benchSourceUrl, constants.R_OK);
+});
+
+test("lint configuration covers frontend TypeScript sources and tests", async () => {
+  const { readFile } = (await dynamicImport("node:fs/promises")) as {
+    readFile: (path: string | URL, options: "utf8") => Promise<string>;
+  };
+
+  const packageJsonUrl = new URL("../../package.json", import.meta.url);
+  const packageJsonContent = await readFile(packageJsonUrl, "utf8");
+  const packageJson = JSON.parse(packageJsonContent) as {
+    scripts?: Record<string, unknown>;
+  };
+
+  assert.ok(
+    packageJson.scripts && typeof packageJson.scripts.lint === "string",
+    "expected package.json to declare a lint script",
+  );
+
+  const lintScript = (packageJson.scripts!.lint as string).trim();
+  for (const glob of requiredLintGlobs) {
+    assert.ok(
+      lintScript.includes(glob),
+      `expected lint script to include the glob ${glob}`,
+    );
+  }
+
+  const configModule = (await dynamicImport(
+    "../../eslint.config.js",
+  )) as { default?: unknown };
+  assert.ok(
+    Array.isArray(configModule.default),
+    "expected eslint.config.js to export an array",
+  );
+
+  const configEntries = configModule.default as Array<{
+    files?: string[];
+  }>;
+  const lintingEntry = configEntries.find(
+    (entry) => Array.isArray(entry.files) && entry.files.length > 0,
+  );
+
+  assert.ok(
+    lintingEntry,
+    "expected eslint.config.js to declare a files list for linting",
+  );
+
+  for (const glob of requiredLintGlobs) {
+    assert.ok(
+      lintingEntry!.files!.includes(glob),
+      `expected eslint.config.js to include the glob ${glob}`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- add a metadata test that ensures frontend directories are linted
- extend lint script and ESLint config to include frontend TypeScript files
- silence unused variable lint errors in the frontend retry attempt type test

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f45ae2a7848321839283e28c4679e8