### PR TITLE
Normalize run-tests arguments for absolute paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ npx deterministic-32 "user:123" --salt=proj --namespace=v1
 echo '{"id":1,"k":"v"}' | npx deterministic-32 --salt=proj
 # Output: one JSON per line (same shape as assign())
 ```
-- 出力は既定で 1 行 1 JSON の **NDJSON**（末尾改行あり）。`--json` を付けない場合も、`--json` / `--json=compact` を指定した場合も同じ形式です。
-- `--json=pretty` / `--pretty` / `--json --pretty` はインデント 2 の複数行 JSON を返し、各レコードが複数行になるため NDJSON ではありません。
+- 出力は既定で 1 行 1 JSON の **NDJSON**（末尾改行あり）。NDJSON はデフォルト/compact モードのみ利用でき、`--json` を付けない場合も、`--json` / `--json=compact` を指定した場合も同じ形式です。
+- `--json=pretty` / `--pretty` / `--json --pretty` は複数行の整形 JSON（インデント 2）を返し、各レコードが複数行になるため NDJSON ではありません。
 
 ## Determinism
 - Canonical key = **normalize(NFKC)** ∘ **stable stringify (key-sorted, cycle-check)**.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -10,7 +10,9 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
   {"index":7,"label":"H","hash":"1a2b3c4d","key":"...canonical..."}
   ```
   - `--json` を付けない場合も、`--json` / `--json=compact` を指定した場合も compact JSON（1 行 1 JSON、末尾改行あり）の NDJSON を維持する。
-  - `--json=pretty` / `--pretty` / `--json --pretty` はインデント 2 の複数行 JSON を返し、各レコードが複数行になるため NDJSON ではない。
+  - NDJSON (1 行 1 JSON オブジェクト) になるのは compact/既定モードのみ。
+  - `--json=pretty` / `--pretty` / `--json --pretty` は複数行の整形 JSON（インデント 2）を返し、各レコードが複数行になるため NDJSON ではない。
+  - 整形モードでは 1 レコードが複数行の JSON になる。
 - `--normalize` には Unicode 正規化モードとして `nfkc`（既定）、`nfkd`、`nfc`、`none` の 4 種類を指定できる。
 - 終了コード:
 - `0` … 成功

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type FakeChildProcess = {
+  on: (event: string, listener: (...args: unknown[]) => void) => FakeChildProcess;
+  emit: (event: string, ...args: unknown[]) => FakeChildProcess;
+  kill: () => boolean;
+};
+
+type SpawnInvocation = {
+  readonly command: unknown;
+  readonly args: unknown[];
+  readonly options: unknown;
+  readonly child: FakeChildProcess;
+};
+
+const repoRootUrl = import.meta.url.includes("/dist/tests/")
+  ? new URL("../..", import.meta.url)
+  : new URL("..", import.meta.url);
+
+const scriptUrl = new URL("scripts/run-tests.js", repoRootUrl);
+
+const dynamicImport = new Function(
+  "specifier",
+  "return import(specifier);",
+) as (specifier: string) => Promise<unknown>;
+
+test("run-tests script normalizes absolute TS targets to dist JS paths", async () => {
+  const { fileURLToPath } = (await dynamicImport("node:url")) as {
+    fileURLToPath: (specifier: string | URL) => string;
+  };
+  const pathModule = (await dynamicImport("node:path")) as {
+    join: (...segments: string[]) => string;
+    resolve: (...segments: string[]) => string;
+  };
+
+  const spawnCalls: SpawnInvocation[] = [];
+  const exitCodes: number[] = [];
+  const cleanups: Array<() => void> = [];
+  let importError: unknown;
+
+  const globalOverride = globalThis as {
+    __CAT32_TEST_SPAWN__?: (
+      command: unknown,
+      args: unknown,
+      options: unknown,
+    ) => FakeChildProcess;
+  };
+
+  const spawnOverride = (
+    command: unknown,
+    args: unknown,
+    options: unknown,
+  ): FakeChildProcess => {
+    const listeners = new Map<string, Array<(...listenerArgs: unknown[]) => void>>();
+    const child: FakeChildProcess = {
+      on: (event, listener) => {
+        const current = listeners.get(event) ?? [];
+        current.push(listener);
+        listeners.set(event, current);
+        return child;
+      },
+      emit: (event, ...listenerArgs) => {
+        const registered = listeners.get(event);
+        if (registered) {
+          for (const listener of registered) {
+            listener(...listenerArgs);
+          }
+        }
+        return child;
+      },
+      kill: () => true,
+    };
+
+    spawnCalls.push({
+      command,
+      args: Array.isArray(args) ? [...args] : [],
+      options,
+      child,
+    });
+
+    return child;
+  };
+
+  const previousSpawnOverride = globalOverride.__CAT32_TEST_SPAWN__;
+  globalOverride.__CAT32_TEST_SPAWN__ = spawnOverride;
+  cleanups.push(() => {
+    if (previousSpawnOverride === undefined) {
+      delete globalOverride.__CAT32_TEST_SPAWN__;
+    } else {
+      globalOverride.__CAT32_TEST_SPAWN__ = previousSpawnOverride;
+    }
+  });
+
+  const repoRootPath = pathModule.resolve(fileURLToPath(repoRootUrl));
+  const absoluteTarget = pathModule.resolve(repoRootPath, "tests/example.test.ts");
+
+  const originalArgv = process.argv;
+  process.argv = [process.argv[0]!, scriptUrl.pathname, absoluteTarget];
+  cleanups.push(() => {
+    process.argv = originalArgv;
+  });
+
+  const originalExit = process.exit;
+  (process as { exit: (code?: number) => never }).exit = ((code?: number) => {
+    exitCodes.push(code ?? 0);
+    return undefined as never;
+  }) as typeof originalExit;
+  cleanups.push(() => {
+    (process as { exit: typeof originalExit }).exit = originalExit;
+  });
+
+  try {
+    await import(`${scriptUrl.href}?t=${Date.now()}`);
+    const invocation = spawnCalls[0];
+    invocation?.child.emit("exit", 0, null);
+  } catch (error) {
+    importError = error;
+  } finally {
+    while (cleanups.length > 0) {
+      cleanups.pop()?.();
+    }
+  }
+
+  assert.equal(importError, undefined);
+  assert.equal(spawnCalls.length, 1);
+
+  const invocation = spawnCalls[0]!;
+  assert.ok(Array.isArray(invocation.args));
+  const args = invocation.args as string[];
+  const expectedTarget = pathModule.join("dist", "tests", "example.test.js");
+  assert.ok(
+    args.includes(expectedTarget),
+    `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
+  );
+  assert.deepEqual(exitCodes, [0]);
+});


### PR DESCRIPTION
## Summary
- adjust scripts/run-tests.js to normalize absolute .ts arguments relative to the project root before mapping into dist and to support spawn overrides for testing
- add a node:test covering scripts/run-tests.js to assert absolute TypeScript inputs are converted to dist JavaScript paths when spawning the child process
- document in README and docs/CLI.md that NDJSON output is limited to default/compact modes and that pretty output emits multi-line JSON

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f45ae386d48321a3446fb87260b456