### PR TITLE
Add lint coverage tests for frontend globs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
     files: [
       "src/**/*.ts",
       "tests/**/*.ts",
+      "frontend/**/*.ts",
       "frontend/src/**/*.ts",
       "frontend/tests/**/*.ts",
     ],

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bench": "npm run build && node dist/scripts/bench.js",
     "test": "npm run build && node scripts/run-tests.js",
     "prepare": "npm run build",
-    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" \"frontend/src/**/*.ts\" \"frontend/tests/**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" \"frontend/**/*.ts\" \"frontend/src/**/*.ts\" \"frontend/tests/**/*.ts\"",
     "lint:fix": "npm run lint -- --fix"
   },
   "engines": {

--- a/tests/package-metadata.test.ts
+++ b/tests/package-metadata.test.ts
@@ -11,6 +11,7 @@ const expectedBenchScript = "npm run build && node dist/scripts/bench.js";
 const requiredLintGlobs = [
   "src/**/*.ts",
   "tests/**/*.ts",
+  "frontend/**/*.ts",
   "frontend/src/**/*.ts",
   "frontend/tests/**/*.ts",
 ];


### PR DESCRIPTION
## Summary
- extend the package metadata test to require frontend lint coverage globs
- update the lint script and ESLint config to include frontend source and test trees

## Testing
- npm test -- tests/package-metadata.test.ts
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f464fe24508321ae8ffd15bb04bec1