### PR TITLE
Refine lint glob expectations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,12 @@ export default [
     ignores: ["dist/**"],
   },
   {
-    files: ["src/**/*.ts", "tests/**/*.ts"],
+    files: [
+      "src/**/*.ts",
+      "tests/**/*.ts",
+      "frontend/src/**/*.ts",
+      "frontend/tests/**/*.ts",
+    ],
     languageOptions: {
       parser: tsParser,
       parserOptions: {

--- a/frontend/tests/sw/retry-attempt.types.test.ts
+++ b/frontend/tests/sw/retry-attempt.types.test.ts
@@ -15,4 +15,6 @@ const assertRetryQueueEntryResult = async (store: RefreshQueueStore) => {
   return { promiseResult, syncResult };
 };
 
+void acceptsPromiseReturningValue;
+void acceptsSynchronousValue;
 void assertRetryQueueEntryResult;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bench": "npm run build && node dist/scripts/bench.js",
     "test": "npm run build && node scripts/run-tests.js",
     "prepare": "npm run build",
-    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" \"frontend/src/**/*.ts\" \"frontend/tests/**/*.ts\"",
     "lint:fix": "npm run lint -- --fix"
   },
   "engines": {

--- a/tests/package-metadata.test.ts
+++ b/tests/package-metadata.test.ts
@@ -7,6 +7,14 @@ const dynamicImport = new Function(
 ) as (specifier: string) => Promise<unknown>;
 
 const expectedBenchScript = "npm run build && node dist/scripts/bench.js";
+const requiredLintGlobs = [
+  "src/**/*.ts",
+  "tests/**/*.ts",
+  "frontend/src/**/*.ts",
+  "frontend/tests/**/*.ts",
+];
+
+const expectedLintGlobs = requiredLintGlobs.map((glob) => `"${glob}"`);
 
 test("package.json exposes a TypeScript dev dependency", async () => {
   const { readFile } = (await dynamicImport("node:fs/promises")) as {
@@ -62,4 +70,51 @@ test("package.json declares a bench script targeting the compiled bench entry", 
 
   const benchSourceUrl = new URL("../../scripts/bench.ts", import.meta.url);
   await access(benchSourceUrl, constants.R_OK);
+});
+
+test("package.json lint script includes frontend TypeScript sources", async () => {
+  const { readFile } = (await dynamicImport("node:fs/promises")) as {
+    readFile: (path: string | URL, options: "utf8") => Promise<string>;
+  };
+
+  const packageJsonUrl = new URL("../../package.json", import.meta.url);
+  const packageJsonContent = await readFile(packageJsonUrl, "utf8");
+  const packageJson = JSON.parse(packageJsonContent) as {
+    scripts?: Record<string, unknown>;
+  };
+
+  assert.ok(
+    packageJson.scripts && typeof packageJson.scripts.lint === "string",
+    "expected package.json to declare a lint script",
+  );
+
+  const lintScript = (packageJson.scripts!.lint as string).trim();
+  for (const glob of expectedLintGlobs) {
+    assert.ok(
+      lintScript.includes(glob),
+      `expected lint script to include ${glob}`,
+    );
+  }
+});
+
+test("eslint config covers frontend TypeScript sources", async () => {
+  const configModule = (await dynamicImport("../../eslint.config.js")) as {
+    default: unknown;
+  };
+
+  const config = configModule.default;
+  assert.ok(Array.isArray(config), "expected eslint config to be an array");
+
+  const typedConfig = config as Array<{ files?: unknown }>;
+  const lintingEntry = typedConfig.find((entry) => Array.isArray(entry.files));
+
+  assert.ok(lintingEntry, "expected eslint config to define file globs");
+
+  const files = lintingEntry!.files as unknown[];
+  for (const glob of requiredLintGlobs) {
+    assert.ok(
+      files.includes(glob),
+      `expected eslint config to include ${glob}`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- derive lint script glob expectations from the shared required glob list used for the ESLint config assertions
- reuse the shared glob list when verifying the ESLint config to avoid duplication

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f45c8b25a88321a0b5ee6da10c1b96