### PR TITLE
Ensure run-tests script resolves repo root cwd

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -3,12 +3,15 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
 
-const defaultTargets = ["dist/tests", "dist/frontend/tests"];
-
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = scriptDirectory.endsWith(`${path.sep}dist${path.sep}scripts`)
   ? path.resolve(scriptDirectory, "..", "..")
   : path.resolve(scriptDirectory, "..");
+
+const defaultTargets = [
+  path.join(projectRoot, "dist", "tests"),
+  path.join(projectRoot, "dist", "frontend", "tests"),
+];
 
 const mapArgument = (argument) => {
   if (!argument.endsWith(".ts")) {
@@ -28,7 +31,7 @@ const mapArgument = (argument) => {
   }
 
   const withoutExtension = projectRelativePath.slice(0, -3);
-  const mapped = path.join("dist", `${withoutExtension}.js`);
+  const mapped = path.join(projectRoot, "dist", `${withoutExtension}.js`);
   return mapped;
 };
 
@@ -47,6 +50,7 @@ const child = spawnImplementation(
   process.execPath,
   ["--test", ...defaultTargets, ...extraTargets],
   {
+    cwd: projectRoot,
     stdio: "inherit",
   },
 );

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -141,10 +141,151 @@ test("run-tests script normalizes absolute TS targets to dist JS paths", async (
   const invocation = spawnCalls[0]!;
   assert.ok(Array.isArray(invocation.args));
   const args = invocation.args as string[];
-  const expectedTarget = pathModule.join("dist", "tests", "example.test.js");
+  const expectedTarget = pathModule.join(
+    repoRootPath,
+    "dist",
+    "tests",
+    "example.test.js",
+  );
   assert.ok(
     args.includes(expectedTarget),
     `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
   );
+  assert.deepEqual(exitCodes, [0]);
+});
+
+test("run-tests script resolves cwd and default targets from repo root", async () => {
+  const { fileURLToPath } = (await dynamicImport("node:url")) as {
+    fileURLToPath: (specifier: string | URL) => string;
+  };
+  const pathModule = (await dynamicImport("node:path")) as {
+    join: (...segments: string[]) => string;
+    resolve: (...segments: string[]) => string;
+  };
+
+  const spawnCalls: SpawnInvocation[] = [];
+  const exitCodes: number[] = [];
+  const cleanups: Array<() => void> = [];
+  let importError: unknown;
+
+  const globalOverride = globalThis as {
+    __CAT32_TEST_SPAWN__?: (
+      command: unknown,
+      args: unknown,
+      options: unknown,
+    ) => FakeChildProcess;
+  };
+
+  const spawnOverride = (
+    command: unknown,
+    args: unknown,
+    options: unknown,
+  ): FakeChildProcess => {
+    const listeners = new Map<string, Array<(...listenerArgs: unknown[]) => void>>();
+    const child: FakeChildProcess = {
+      on: (event, listener) => {
+        const current = listeners.get(event) ?? [];
+        current.push(listener);
+        listeners.set(event, current);
+        return child;
+      },
+      emit: (event, ...listenerArgs) => {
+        const registered = listeners.get(event);
+        if (registered) {
+          for (const listener of registered) {
+            listener(...listenerArgs);
+          }
+        }
+        return child;
+      },
+      kill: () => true,
+    };
+
+    spawnCalls.push({
+      command,
+      args: Array.isArray(args) ? [...args] : [],
+      options,
+      child,
+    });
+
+    return child;
+  };
+
+  const previousSpawnOverride = globalOverride.__CAT32_TEST_SPAWN__;
+  globalOverride.__CAT32_TEST_SPAWN__ = spawnOverride;
+  cleanups.push(() => {
+    if (previousSpawnOverride === undefined) {
+      delete globalOverride.__CAT32_TEST_SPAWN__;
+    } else {
+      globalOverride.__CAT32_TEST_SPAWN__ = previousSpawnOverride;
+    }
+  });
+
+  const repoRootPath = pathModule.resolve(fileURLToPath(repoRootUrl));
+  const processModule = process as NodeJS.Process & {
+    cwd: () => string;
+    chdir: (directory: string) => void;
+  };
+  const originalCwd = processModule.cwd();
+  processModule.chdir(pathModule.join(repoRootPath, "frontend"));
+  cleanups.push(() => {
+    processModule.chdir(originalCwd);
+  });
+
+  const originalArgv = process.argv;
+  process.argv = [process.argv[0]!, scriptUrl.pathname];
+  cleanups.push(() => {
+    process.argv = originalArgv;
+  });
+
+  const originalExit = process.exit;
+  (process as { exit: (code?: number) => never }).exit = ((code?: number) => {
+    exitCodes.push(code ?? 0);
+    return undefined as never;
+  }) as typeof originalExit;
+  cleanups.push(() => {
+    (process as { exit: typeof originalExit }).exit = originalExit;
+  });
+
+  try {
+    await import(`${scriptUrl.href}?t=${Date.now()}`);
+    const invocation = spawnCalls[0];
+    invocation?.child.emit("exit", 0, null);
+  } catch (error) {
+    importError = error;
+  } finally {
+    while (cleanups.length > 0) {
+      cleanups.pop()?.();
+    }
+  }
+
+  assert.equal(importError, undefined);
+  assert.equal(spawnCalls.length, 1);
+
+  const invocation = spawnCalls[0]!;
+  assert.equal(
+    (invocation.options as { cwd?: unknown } | undefined)?.cwd,
+    repoRootPath,
+  );
+
+  assert.ok(Array.isArray(invocation.args));
+  const args = invocation.args as string[];
+  const defaultTarget = pathModule.join(repoRootPath, "dist", "tests");
+  const frontendTarget = pathModule.join(
+    repoRootPath,
+    "dist",
+    "frontend",
+    "tests",
+  );
+
+  assert.ok(
+    args.includes(defaultTarget),
+    `expected spawn args to include ${defaultTarget}, received: ${args.join(", ")}`,
+  );
+  assert.ok(
+    args.includes(frontendTarget),
+    `expected spawn args to include ${frontendTarget}, received: ${args.join(", ")}`,
+  );
+
   assert.deepEqual(exitCodes, [0]);
 });


### PR DESCRIPTION
## Summary
- add regression coverage verifying run-tests forwards repo-root cwd and targets after changing process.cwd
- make run-tests always resolve default targets to absolute repo-root paths and set spawn cwd

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f477e790b88321bbb863c9b175f8c8