### PR TITLE
Handle directory targets in run-tests script

### DIFF
--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -14,6 +14,27 @@ type SpawnInvocation = {
   readonly child: FakeChildProcess;
 };
 
+type PathModule = {
+  join: (...segments: string[]) => string;
+  resolve: (...segments: string[]) => string;
+};
+
+type RunScriptEnvironment = {
+  readonly pathModule: PathModule;
+  readonly repoRootPath: string;
+};
+
+type RunScriptOptions = {
+  readonly argv: string[];
+  readonly cwd?: string;
+};
+
+type RunScriptResult = {
+  readonly spawnCalls: SpawnInvocation[];
+  readonly exitCodes: number[];
+  readonly importError: unknown;
+};
+
 const repoRootUrl = import.meta.url.includes("/dist/tests/")
   ? new URL("../..", import.meta.url)
   : new URL("..", import.meta.url);
@@ -25,15 +46,19 @@ const dynamicImport = new Function(
   "return import(specifier);",
 ) as (specifier: string) => Promise<unknown>;
 
-test("run-tests script normalizes absolute TS targets to dist JS paths", async () => {
+const loadEnvironment = async (): Promise<RunScriptEnvironment> => {
   const { fileURLToPath } = (await dynamicImport("node:url")) as {
     fileURLToPath: (specifier: string | URL) => string;
   };
-  const pathModule = (await dynamicImport("node:path")) as {
-    join: (...segments: string[]) => string;
-    resolve: (...segments: string[]) => string;
-  };
+  const pathModule = (await dynamicImport("node:path")) as PathModule;
+  const repoRootPath = pathModule.resolve(fileURLToPath(repoRootUrl));
+  return { pathModule, repoRootPath };
+};
 
+const runScriptWithEnvironment = async (
+  env: RunScriptEnvironment,
+  options: RunScriptOptions,
+): Promise<RunScriptResult> => {
   const spawnCalls: SpawnInvocation[] = [];
   const exitCodes: number[] = [];
   const cleanups: Array<() => void> = [];
@@ -92,24 +117,21 @@ test("run-tests script normalizes absolute TS targets to dist JS paths", async (
     }
   });
 
-  const repoRootPath = pathModule.resolve(fileURLToPath(repoRootUrl));
   const processModule = process as NodeJS.Process & {
     cwd: () => string;
     chdir: (directory: string) => void;
   };
   const originalCwd = processModule.cwd();
-  processModule.chdir(pathModule.join(repoRootPath, "dist"));
+  const targetCwd = options.cwd ?? env.repoRootPath;
+  if (targetCwd !== originalCwd) {
+    processModule.chdir(targetCwd);
+  }
   cleanups.push(() => {
     processModule.chdir(originalCwd);
   });
 
-  const absoluteTarget = pathModule.resolve(
-    repoRootPath,
-    "tests/example.test.ts",
-  );
-
   const originalArgv = process.argv;
-  process.argv = [process.argv[0]!, scriptUrl.pathname, absoluteTarget];
+  process.argv = [process.argv[0]!, scriptUrl.pathname, ...options.argv];
   cleanups.push(() => {
     process.argv = originalArgv;
   });
@@ -135,14 +157,29 @@ test("run-tests script normalizes absolute TS targets to dist JS paths", async (
     }
   }
 
-  assert.equal(importError, undefined);
-  assert.equal(spawnCalls.length, 1);
+  return { spawnCalls, exitCodes, importError };
+};
 
-  const invocation = spawnCalls[0]!;
+test("run-tests script normalizes absolute TS targets to dist JS paths", async () => {
+  const env = await loadEnvironment();
+  const absoluteTarget = env.pathModule.resolve(
+    env.repoRootPath,
+    "tests/example.test.ts",
+  );
+
+  const result = await runScriptWithEnvironment(env, {
+    argv: [absoluteTarget],
+    cwd: env.pathModule.join(env.repoRootPath, "dist"),
+  });
+
+  assert.equal(result.importError, undefined);
+  assert.equal(result.spawnCalls.length, 1);
+
+  const invocation = result.spawnCalls[0]!;
   assert.ok(Array.isArray(invocation.args));
   const args = invocation.args as string[];
-  const expectedTarget = pathModule.join(
-    repoRootPath,
+  const expectedTarget = env.pathModule.join(
+    env.repoRootPath,
     "dist",
     "tests",
     "example.test.js",
@@ -151,128 +188,62 @@ test("run-tests script normalizes absolute TS targets to dist JS paths", async (
     args.includes(expectedTarget),
     `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
   );
-  assert.deepEqual(exitCodes, [0]);
+  assert.deepEqual(result.exitCodes, [0]);
+});
+
+test("run-tests script maps directory arguments to dist targets", async () => {
+  const env = await loadEnvironment();
+
+  const result = await runScriptWithEnvironment(env, {
+    argv: ["--", env.pathModule.join("frontend", "tests", "sw")],
+  });
+
+  assert.equal(result.importError, undefined);
+  assert.equal(result.spawnCalls.length, 1);
+
+  const invocation = result.spawnCalls[0]!;
+  assert.ok(Array.isArray(invocation.args));
+  const args = invocation.args as string[];
+  assert.ok(
+    !args.includes("--"),
+    `expected spawn args to omit "--", received: ${args.join(", ")}`,
+  );
+  const expectedTarget = env.pathModule.join(
+    env.repoRootPath,
+    "dist",
+    "frontend",
+    "tests",
+    "sw",
+  );
+  assert.ok(
+    args.includes(expectedTarget),
+    `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
+  );
+  assert.deepEqual(result.exitCodes, [0]);
 });
 
 test("run-tests script resolves cwd and default targets from repo root", async () => {
-  const { fileURLToPath } = (await dynamicImport("node:url")) as {
-    fileURLToPath: (specifier: string | URL) => string;
-  };
-  const pathModule = (await dynamicImport("node:path")) as {
-    join: (...segments: string[]) => string;
-    resolve: (...segments: string[]) => string;
-  };
+  const env = await loadEnvironment();
 
-  const spawnCalls: SpawnInvocation[] = [];
-  const exitCodes: number[] = [];
-  const cleanups: Array<() => void> = [];
-  let importError: unknown;
-
-  const globalOverride = globalThis as {
-    __CAT32_TEST_SPAWN__?: (
-      command: unknown,
-      args: unknown,
-      options: unknown,
-    ) => FakeChildProcess;
-  };
-
-  const spawnOverride = (
-    command: unknown,
-    args: unknown,
-    options: unknown,
-  ): FakeChildProcess => {
-    const listeners = new Map<string, Array<(...listenerArgs: unknown[]) => void>>();
-    const child: FakeChildProcess = {
-      on: (event, listener) => {
-        const current = listeners.get(event) ?? [];
-        current.push(listener);
-        listeners.set(event, current);
-        return child;
-      },
-      emit: (event, ...listenerArgs) => {
-        const registered = listeners.get(event);
-        if (registered) {
-          for (const listener of registered) {
-            listener(...listenerArgs);
-          }
-        }
-        return child;
-      },
-      kill: () => true,
-    };
-
-    spawnCalls.push({
-      command,
-      args: Array.isArray(args) ? [...args] : [],
-      options,
-      child,
-    });
-
-    return child;
-  };
-
-  const previousSpawnOverride = globalOverride.__CAT32_TEST_SPAWN__;
-  globalOverride.__CAT32_TEST_SPAWN__ = spawnOverride;
-  cleanups.push(() => {
-    if (previousSpawnOverride === undefined) {
-      delete globalOverride.__CAT32_TEST_SPAWN__;
-    } else {
-      globalOverride.__CAT32_TEST_SPAWN__ = previousSpawnOverride;
-    }
+  const result = await runScriptWithEnvironment(env, {
+    argv: [],
+    cwd: env.pathModule.join(env.repoRootPath, "frontend"),
   });
 
-  const repoRootPath = pathModule.resolve(fileURLToPath(repoRootUrl));
-  const processModule = process as NodeJS.Process & {
-    cwd: () => string;
-    chdir: (directory: string) => void;
-  };
-  const originalCwd = processModule.cwd();
-  processModule.chdir(pathModule.join(repoRootPath, "frontend"));
-  cleanups.push(() => {
-    processModule.chdir(originalCwd);
-  });
+  assert.equal(result.importError, undefined);
+  assert.equal(result.spawnCalls.length, 1);
 
-  const originalArgv = process.argv;
-  process.argv = [process.argv[0]!, scriptUrl.pathname];
-  cleanups.push(() => {
-    process.argv = originalArgv;
-  });
-
-  const originalExit = process.exit;
-  (process as { exit: (code?: number) => never }).exit = ((code?: number) => {
-    exitCodes.push(code ?? 0);
-    return undefined as never;
-  }) as typeof originalExit;
-  cleanups.push(() => {
-    (process as { exit: typeof originalExit }).exit = originalExit;
-  });
-
-  try {
-    await import(`${scriptUrl.href}?t=${Date.now()}`);
-    const invocation = spawnCalls[0];
-    invocation?.child.emit("exit", 0, null);
-  } catch (error) {
-    importError = error;
-  } finally {
-    while (cleanups.length > 0) {
-      cleanups.pop()?.();
-    }
-  }
-
-  assert.equal(importError, undefined);
-  assert.equal(spawnCalls.length, 1);
-
-  const invocation = spawnCalls[0]!;
+  const invocation = result.spawnCalls[0]!;
   assert.equal(
     (invocation.options as { cwd?: unknown } | undefined)?.cwd,
-    repoRootPath,
+    env.repoRootPath,
   );
 
   assert.ok(Array.isArray(invocation.args));
   const args = invocation.args as string[];
-  const defaultTarget = pathModule.join(repoRootPath, "dist", "tests");
-  const frontendTarget = pathModule.join(
-    repoRootPath,
+  const defaultTarget = env.pathModule.join(env.repoRootPath, "dist", "tests");
+  const frontendTarget = env.pathModule.join(
+    env.repoRootPath,
     "dist",
     "frontend",
     "tests",
@@ -287,5 +258,5 @@ test("run-tests script resolves cwd and default targets from repo root", async (
     `expected spawn args to include ${frontendTarget}, received: ${args.join(", ")}`,
   );
 
-  assert.deepEqual(exitCodes, [0]);
+  assert.deepEqual(result.exitCodes, [0]);
 });


### PR DESCRIPTION
## Summary
- add reusable harness for the run-tests script tests and cover directory arguments
- expand run-tests script argument mapping to convert existing directories into dist paths and ignore the `--` separator

## Testing
- npm test -- tests/run-tests-script.test.ts
- npm run build && node scripts/run-tests.js -- frontend/tests/sw

------
https://chatgpt.com/codex/tasks/task_e_68f47b26b7048321bf729fd9348b250e