### PR TITLE
Fix run-tests script relative TS path resolution

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -15,16 +15,32 @@ const defaultTargets = [
 ];
 
 const mapArgument = (argument) => {
-  const absolutePath = path.isAbsolute(argument)
-    ? argument
-    : path.resolve(projectRoot, argument);
-  const projectRelativePath = path.relative(projectRoot, absolutePath);
+  const candidatePaths = path.isAbsolute(argument)
+    ? [argument]
+    : [path.resolve(process.cwd(), argument), path.resolve(projectRoot, argument)];
 
-  if (
-    projectRelativePath === "" ||
-    projectRelativePath.startsWith("..") ||
-    path.isAbsolute(projectRelativePath)
-  ) {
+  let matchedAbsolutePath = null;
+  let projectRelativePath = null;
+
+  for (const candidate of candidatePaths) {
+    const relative = path.relative(projectRoot, candidate);
+    if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+      continue;
+    }
+
+    if (fs.existsSync(candidate)) {
+      matchedAbsolutePath = candidate;
+      projectRelativePath = relative;
+      break;
+    }
+
+    if (matchedAbsolutePath === null) {
+      matchedAbsolutePath = candidate;
+      projectRelativePath = relative;
+    }
+  }
+
+  if (matchedAbsolutePath === null || projectRelativePath === null) {
     return argument;
   }
 
@@ -34,9 +50,9 @@ const mapArgument = (argument) => {
     return mapped;
   }
 
-  if (fs.existsSync(absolutePath)) {
+  if (fs.existsSync(matchedAbsolutePath)) {
     try {
-      if (fs.statSync(absolutePath).isDirectory()) {
+      if (fs.statSync(matchedAbsolutePath).isDirectory()) {
         const mappedDirectory = path.join(projectRoot, "dist", projectRelativePath);
         if (fs.existsSync(mappedDirectory)) {
           return mappedDirectory;

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -191,6 +191,36 @@ test("run-tests script normalizes absolute TS targets to dist JS paths", async (
   assert.deepEqual(result.exitCodes, [0]);
 });
 
+test(
+  "run-tests script resolves relative TS targets from current working directory",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["example.test.ts"],
+      cwd: env.pathModule.join(env.repoRootPath, "tests"),
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+    const expectedTarget = env.pathModule.join(
+      env.repoRootPath,
+      "dist",
+      "tests",
+      "example.test.js",
+    );
+    assert.ok(
+      args.includes(expectedTarget),
+      `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
+    );
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
 for (const directoryName of ["frontend", "dist"]) {
   test(
     `run-tests script resolves cwd and default targets from repo root when started from ${directoryName}/`,


### PR DESCRIPTION
## Summary
- add coverage for resolving relative TypeScript targets when run-tests is invoked from the tests directory
- update run-tests path mapping to consider the current working directory before mapping to dist

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f48b85346c83218786ea01f5eafceb