### PR TITLE
docs: clarify CLI JSON output modes

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -9,10 +9,8 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
   ```json
   {"index":7,"label":"H","hash":"1a2b3c4d","key":"...canonical..."}
   ```
-  - `--json` を付けない場合も、`--json` / `--json=compact` を指定した場合も compact JSON（1 行 1 JSON、末尾改行あり）の NDJSON を維持する。
-  - NDJSON (1 行 1 JSON オブジェクト) になるのは compact/既定モードのみ。
-  - `--json=pretty` / `--pretty` / `--json --pretty` は複数行の整形 JSON（インデント 2）を返し、各レコードが複数行になるため NDJSON ではない。
-  - 整形モードでは 1 レコードが複数行の JSON になる。
+  - `--json` を付けない場合、`--json` または `--json=compact` を指定した場合はいずれも compact JSON（1 行 1 JSON、末尾改行あり）の NDJSON を返す。NDJSON を選べるのはこの既定/compact モードのみ。
+  - `--json=pretty` / `--pretty` / `--json --pretty` は 2 スペースで整形した複数行の JSON を返し、各レコードが複数行になるため NDJSON ではない。
 - `--normalize` には Unicode 正規化モードとして `nfkc`（既定）、`nfkd`、`nfc`、`none` の 4 種類を指定できる。
 - 終了コード:
 - `0` … 成功


### PR DESCRIPTION
## Summary
- reorganize the CLI output format description to remove redundant NDJSON bullets
- clarify how compact and pretty JSON modes affect NDJSON compatibility

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f4b022002c8321a855ab7f6a367e11