### PR TITLE
Fix run-tests directory argument mapping

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -10,7 +10,9 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
   {"index":7,"label":"H","hash":"1a2b3c4d","key":"...canonical..."}
   ```
   - `--json` を付けない場合、`--json` または `--json=compact` を指定した場合はいずれも compact JSON（1 行 1 JSON、末尾改行あり）の NDJSON を返す。NDJSON を選べるのはこの既定/compact モードのみ。
-  - `--json=pretty` / `--pretty` / `--json --pretty` は 2 スペースで整形した複数行の JSON を返し、各レコードが複数行になるため NDJSON ではない。
+- `--json=pretty` / `--pretty` / `--json --pretty` は 2 スペースで整形した複数行の JSON を返し、各レコードが複数行になるため NDJSON ではない。
+- 整形モードでは 1 レコードが複数行の JSON になるため、compact/既定モードとは出力の構造が異なる。
+- NDJSON (1 行 1 JSON オブジェクト) になるのは compact/既定モードのみ。
 - `--normalize` には Unicode 正規化モードとして `nfkc`（既定）、`nfkd`、`nfc`、`none` の 4 種類を指定できる。
 - 終了コード:
 - `0` … 成功

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -52,7 +52,7 @@ const mapArgument = (argument) => {
 
   if (fs.existsSync(matchedAbsolutePath)) {
     try {
-      if (fs.statSync(absolutePath).isDirectory()) {
+      if (fs.statSync(matchedAbsolutePath).isDirectory()) {
         if (
           projectRelativePath === "dist" ||
           projectRelativePath.startsWith(`dist${path.sep}`)

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -160,6 +160,28 @@ const runScriptWithEnvironment = async (
   return { spawnCalls, exitCodes, importError };
 };
 
+test("run-tests script maps CLI directory arguments to dist targets", async () => {
+  const env = await loadEnvironment();
+
+  const result = await runScriptWithEnvironment(env, {
+    argv: ["tests"],
+  });
+
+  assert.equal(result.importError, undefined);
+  assert.equal(result.spawnCalls.length, 1);
+
+  const invocation = result.spawnCalls[0]!;
+  assert.ok(Array.isArray(invocation.args));
+  const args = invocation.args as string[];
+  const expectedTarget = env.pathModule.join(env.repoRootPath, "dist", "tests");
+  assert.ok(
+    args.includes(expectedTarget),
+    `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
+  );
+
+  assert.deepEqual(result.exitCodes, [0]);
+});
+
 test("run-tests script normalizes absolute TS targets to dist JS paths", async () => {
   const env = await loadEnvironment();
   const absoluteTarget = env.pathModule.resolve(


### PR DESCRIPTION
## Summary
- run-tests.js がディレクトリ引数を dist/<path> に正しく写像するよう修正
- run-tests スクリプト向けのモックテストを追加し、ディレクトリ指定時の引数を検証
- CLI ドキュメントに整形モードと NDJSON モードの違いを追記

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f4c1de42ec8321a6f7a64c244a49cd