### PR TITLE
Fix run-tests option parsing for flag values

### DIFF
--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -192,6 +192,44 @@ test("run-tests script normalizes absolute TS targets to dist JS paths", async (
 });
 
 test(
+  "run-tests script preserves flag values for known option arguments",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["--", "--test-name-pattern", "frontend/tests"],
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+
+    const flagIndex = args.indexOf("--test-name-pattern");
+    assert.ok(
+      flagIndex !== -1,
+      `expected spawn args to include --test-name-pattern, received: ${args.join(", ")}`,
+    );
+    assert.equal(args[flagIndex + 1], "frontend/tests");
+
+    const defaultTargets = [
+      env.pathModule.join(env.repoRootPath, "dist", "tests"),
+      env.pathModule.join(env.repoRootPath, "dist", "frontend", "tests"),
+    ];
+    for (const defaultTarget of defaultTargets) {
+      assert.ok(
+        args.includes(defaultTarget),
+        `expected spawn args to include ${defaultTarget}, received: ${args.join(", ")}`,
+      );
+    }
+
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
+test(
   "run-tests script omits default targets when CLI specifies TS target",
   async () => {
     const env = await loadEnvironment();


### PR DESCRIPTION
## Summary
- ensure the run-tests script treats known flag values as options and avoids remapping them into dist paths
- add a regression test confirming --test-name-pattern values remain unchanged while default targets are still passed through

## Testing
- npm run build
- node scripts/run-tests.js -- --test-name-pattern frontend/tests

------
https://chatgpt.com/codex/tasks/task_e_68f4c165ad2c83219a3eaad1711239d9