### PR TITLE
Fix run-tests directory mapping from dist

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -23,7 +23,10 @@ const mapArgument = (argument) => {
 
   const candidatePaths = path.isAbsolute(argument)
     ? [argument]
-    : [path.resolve(process.cwd(), argument), path.resolve(projectRoot, argument)];
+    : [
+        path.resolve(projectRoot, argument),
+        path.resolve(process.cwd(), argument),
+      ];
 
   let matchedAbsolutePath = null;
   let projectRelativePath = null;
@@ -98,7 +101,25 @@ const flagsWithValues = new Set([
 
 const cliArguments = process.argv.slice(2);
 const filteredCliArguments = cliArguments.filter((argument) => argument !== "--");
-const mappedArguments = filteredCliArguments.map(mapArgument);
+const mappedArguments = [];
+
+for (let index = 0; index < filteredCliArguments.length; index += 1) {
+  const argument = filteredCliArguments[index];
+  if (argument === undefined) {
+    continue;
+  }
+
+  mappedArguments.push(mapArgument(argument));
+
+  if (flagsWithValues.has(argument)) {
+    const valueArgument = filteredCliArguments[index + 1];
+    if (valueArgument !== undefined) {
+      mappedArguments.push({ value: valueArgument, isTarget: false });
+      index += 1;
+    }
+  }
+}
+
 const extraTargets = mappedArguments.map((entry) => entry.value);
 const hasExplicitTargets = mappedArguments.some((entry) => entry.isTarget);
 

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -182,6 +182,36 @@ test("run-tests script maps CLI directory arguments to dist targets", async () =
   assert.deepEqual(result.exitCodes, [0]);
 });
 
+test(
+  "run-tests script maps CLI directory arguments to dist targets when invoked from dist/",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["tests"],
+      cwd: env.pathModule.join(env.repoRootPath, "dist"),
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+    const expectedTarget = env.pathModule.join(
+      env.repoRootPath,
+      "dist",
+      "tests",
+    );
+    assert.ok(
+      args.includes(expectedTarget),
+      `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
+    );
+
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
 test("run-tests script normalizes absolute TS targets to dist JS paths", async () => {
   const env = await loadEnvironment();
   const absoluteTarget = env.pathModule.resolve(


### PR DESCRIPTION
## Summary
- add coverage to ensure directory CLI arguments resolve to dist targets even when the script runs from the compiled dist directory
- prefer project-root candidate paths and skip mapping flag values so directory targets consistently point into dist without rewriting flag payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4db2400a88321939280ec2151b9b9