### PR TITLE
Ensure reporter destination flags preserve default run-tests targets

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -102,21 +102,24 @@ const flagsWithValues = new Set([
 const cliArguments = process.argv.slice(2);
 const filteredCliArguments = cliArguments.filter((argument) => argument !== "--");
 const mappedArguments = [];
-let expectValueForFlag = false;
 
-for (const argument of filteredCliArguments) {
-  if (expectValueForFlag) {
+for (let index = 0; index < filteredCliArguments.length; index += 1) {
+  const argument = filteredCliArguments[index];
+
+  if (flagsWithValues.has(argument)) {
     mappedArguments.push({ value: argument, isTarget: false });
-    expectValueForFlag = false;
+
+    const valueArgument = filteredCliArguments[index + 1];
+    if (valueArgument !== undefined) {
+      mappedArguments.push({ value: valueArgument, isTarget: false });
+      index += 1;
+    }
+
     continue;
   }
 
   const mapped = mapArgument(argument);
   mappedArguments.push(mapped);
-
-  if (!mapped.isTarget && flagsWithValues.has(argument)) {
-    expectValueForFlag = true;
-  }
 }
 
 const flagArguments = [];

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -363,6 +363,44 @@ test(
 );
 
 test(
+  "run-tests script retains default targets when CLI provides reporter destination",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["--test-reporter-destination", "tests/output.jsonl"],
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+
+    const defaultTargets = [
+      env.pathModule.join(env.repoRootPath, "dist", "tests"),
+      env.pathModule.join(env.repoRootPath, "dist", "frontend", "tests"),
+    ];
+    for (const defaultTarget of defaultTargets) {
+      assert.ok(
+        args.includes(defaultTarget),
+        `expected spawn args to include ${defaultTarget}, received: ${args.join(", ")}`,
+      );
+    }
+
+    const reporterDestinationIndex = args.indexOf("--test-reporter-destination");
+    assert.ok(
+      reporterDestinationIndex !== -1,
+      `expected spawn args to include --test-reporter-destination, received: ${args.join(", ")}`,
+    );
+    assert.equal(args[reporterDestinationIndex + 1], "tests/output.jsonl");
+
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
+test(
   "run-tests script positions value-less flags before default targets",
   async () => {
     const env = await loadEnvironment();


### PR DESCRIPTION
## Summary
- add a regression test ensuring the reporter destination flag keeps default run targets
- update the run-tests script to pass value arguments for required flags straight through to Node

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4e16b31b8832185c4c0c41a65fa6e