### PR TITLE
Ensure run-tests preserves flag values

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -111,12 +111,14 @@ for (const argument of filteredCliArguments) {
     continue;
   }
 
+  if (flagsWithValues.has(argument)) {
+    mappedArguments.push({ value: argument, isTarget: false });
+    expectValueForFlag = true;
+    continue;
+  }
+
   const mapped = mapArgument(argument);
   mappedArguments.push(mapped);
-
-  if (!mapped.isTarget && flagsWithValues.has(argument)) {
-    expectValueForFlag = true;
-  }
 }
 
 const flagArguments = [];

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -282,6 +282,44 @@ test(
 );
 
 test(
+  "run-tests script retains default targets when flag values resemble test directories",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["--test-name-pattern", "frontend/tests"],
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+
+    const flagIndex = args.indexOf("--test-name-pattern");
+    assert.ok(
+      flagIndex !== -1,
+      `expected spawn args to include --test-name-pattern, received: ${args.join(", ")}`,
+    );
+    assert.equal(args[flagIndex + 1], "frontend/tests");
+
+    const defaultTargets = [
+      env.pathModule.join(env.repoRootPath, "dist", "tests"),
+      env.pathModule.join(env.repoRootPath, "dist", "frontend", "tests"),
+    ];
+    for (const defaultTarget of defaultTargets) {
+      assert.ok(
+        args.includes(defaultTarget),
+        `expected spawn args to include ${defaultTarget}, received: ${args.join(", ")}`,
+      );
+    }
+
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
+test(
   "run-tests script omits default targets when CLI specifies TS target",
   async () => {
     const env = await loadEnvironment();


### PR DESCRIPTION
## Summary
- add coverage ensuring --test-name-pattern frontend/tests keeps default targets and value
- update run-tests argument parser to skip mapping values for flags requiring separate tokens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4e16b4d008321b5671d724eceb81c