### PR TITLE
Prevent missing reporter destination flag from consuming default targets

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -102,6 +102,7 @@ const flagsWithValues = new Set([
 const cliArguments = process.argv.slice(2);
 const filteredCliArguments = cliArguments.filter((argument) => argument !== "--");
 const mappedArguments = [];
+let pendingValueFlag = null;
 
 for (let index = 0; index < filteredCliArguments.length; index += 1) {
   const argument = filteredCliArguments[index];
@@ -113,19 +114,19 @@ for (let index = 0; index < filteredCliArguments.length; index += 1) {
     if (valueArgument !== undefined) {
       mappedArguments.push({ value: valueArgument, isTarget: false });
       index += 1;
+    } else {
+      pendingValueFlag = argument;
     }
 
     continue;
   }
 
-  if (flagsWithValues.has(argument)) {
-    mappedArguments.push({ value: argument, isTarget: false });
-    expectValueForFlag = true;
-    continue;
-  }
-
   const mapped = mapArgument(argument);
   mappedArguments.push(mapped);
+}
+
+if (pendingValueFlag !== null) {
+  throw new RangeError(`Missing value for ${pendingValueFlag}`);
 }
 
 const flagArguments = [];

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -439,6 +439,26 @@ test(
 );
 
 test(
+  "run-tests script rejects reporter destination without value",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["--test-reporter-destination"],
+    });
+
+    const hasRangeError = result.importError instanceof RangeError;
+    const hasExitCodeTwo = result.exitCodes.includes(2);
+
+    assert.ok(
+      hasRangeError || hasExitCodeTwo,
+      "expected RangeError import or exit code 2 when reporter destination value is missing",
+    );
+    assert.equal(result.spawnCalls.length, 0);
+  },
+);
+
+test(
   "run-tests script positions value-less flags before default targets",
   async () => {
     const env = await loadEnvironment();


### PR DESCRIPTION
## Summary
- add a regression test that fails when `--test-reporter-destination` lacks a value
- throw a RangeError after argument parsing if a reporter flag is missing its value so Node does not treat default targets as the flag payload

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f4f06b7f548321ac5a888735ed8025