### PR TITLE
Ensure run-tests reporter destination flag requires a value

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -107,18 +107,26 @@ const cliArguments = process.argv.slice(2);
 const filteredCliArguments = cliArguments.filter((argument) => argument !== "--");
 const mappedArguments = [];
 let pendingValueFlag = null;
-
 let expectValueForFlag = false;
 
 for (const argument of filteredCliArguments) {
   if (expectValueForFlag) {
     mappedArguments.push({ value: argument, isTarget: false });
     expectValueForFlag = false;
+    pendingValueFlag = null;
     continue;
   }
 
   const mapped = mapArgument(argument);
   mappedArguments.push(mapped);
+
+  if (
+    typeof mapped.value === "string" &&
+    flagsWithValues.has(mapped.value)
+  ) {
+    expectValueForFlag = true;
+    pendingValueFlag = mapped.value;
+  }
 }
 
 if (pendingValueFlag !== null) {

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -439,6 +439,26 @@ test(
 );
 
 test(
+  "run-tests script rejects reporter destination flag without value",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["--test-reporter-destination"],
+    });
+
+    assert.equal(result.spawnCalls.length, 0);
+    assert.deepEqual(result.exitCodes, []);
+
+    assert.ok(result.importError instanceof RangeError);
+    assert.equal(
+      (result.importError as RangeError).message,
+      "Missing value for --test-reporter-destination",
+    );
+  },
+);
+
+test(
   "run-tests script preserves flag values for Node preload options",
   async () => {
     const env = await loadEnvironment();


### PR DESCRIPTION
## Summary
- add a regression test that covers invoking the run-tests script with a value-less --test-reporter-destination flag
- update the run-tests argument handling to track value-required flags and throw when a value is missing

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f4f647a13c83218b8fcdc721c0e1ea