### PR TITLE
Handle module preload flags in run-tests

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -94,13 +94,14 @@ const mapArgument = (argument) => {
 };
 
 const flagsWithValues = new Set([
-  "--test-name-pattern",
-  "--test-reporter",
-  "--test-reporter-destination",
-  "--require",
+  "--env-file",
   "--import",
   "--loader",
   "--experimental-loader",
+  "--require",
+  "--test-name-pattern",
+  "--test-reporter",
+  "--test-reporter-destination",
   "-r",
   "-i",
 ]);

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -319,13 +319,20 @@ test(
   },
 );
 
-test(
-  "run-tests script preserves flag values for module registration options",
-  async () => {
+const moduleRegistrationFlagCases: ReadonlyArray<{
+  readonly flag: string;
+  readonly description: string;
+}> = [
+  { flag: "--require", description: "module registration flag --require" },
+  { flag: "--import", description: "module registration flag --import" },
+];
+
+for (const { flag, description } of moduleRegistrationFlagCases) {
+  test(`run-tests script preserves ${description}`, async () => {
     const env = await loadEnvironment();
 
     const result = await runScriptWithEnvironment(env, {
-      argv: ["--require", "tests/register.js"],
+      argv: [flag, "tests/register.js"],
     });
 
     assert.equal(result.importError, undefined);
@@ -335,10 +342,10 @@ test(
     assert.ok(Array.isArray(invocation.args));
     const args = invocation.args as string[];
 
-    const flagIndex = args.indexOf("--require");
+    const flagIndex = args.indexOf(flag);
     assert.ok(
       flagIndex !== -1,
-      `expected spawn args to include --require, received: ${args.join(", ")}`,
+      `expected spawn args to include ${flag}, received: ${args.join(", ")}`,
     );
     assert.equal(args[flagIndex + 1], "tests/register.js");
 
@@ -354,8 +361,8 @@ test(
     }
 
     assert.deepEqual(result.exitCodes, [0]);
-  },
-);
+  });
+}
 
 test(
   "run-tests script omits default targets when CLI specifies TS target",


### PR DESCRIPTION
## Summary
- add run-tests script coverage for module registration flags to ensure default targets remain
- extend the run-tests flag whitelist to cover module preload and env file options

## Testing
- npm run build
- node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f4faffed5083218878b4f036940cb5