### PR TITLE
Extend run-tests flag handling for module registration options

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -104,6 +104,13 @@ const flagsWithValues = new Set([
   "--test-reporter-destination",
   "-r",
   "-i",
+  "--conditions",
+  "--eval",
+  "--experimental-specifier-resolution",
+  "--input-type",
+  "--print",
+  "--test-concurrency",
+  "--test-timeout",
 ]);
 
 const cliArguments = process.argv.slice(2);

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -346,6 +346,49 @@ test(
   },
 );
 
+test(
+  "run-tests script keeps module registration flag values separate from default targets",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["--require", "tests/register.js"],
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+
+    const flagIndex = args.indexOf("--require");
+    assert.ok(
+      flagIndex !== -1,
+      `expected spawn args to include --require, received: ${args.join(", ")}`,
+    );
+    assert.equal(args[flagIndex + 1], "tests/register.js");
+
+    const defaultTargets = [
+      env.pathModule.join(env.repoRootPath, "dist", "tests"),
+      env.pathModule.join(env.repoRootPath, "dist", "frontend", "tests"),
+    ];
+    for (const defaultTarget of defaultTargets) {
+      const targetIndex = args.indexOf(defaultTarget);
+      assert.ok(
+        targetIndex !== -1,
+        `expected spawn args to include ${defaultTarget}, received: ${args.join(", ")}`,
+      );
+      assert.ok(
+        targetIndex > flagIndex,
+        `expected ${defaultTarget} to appear after --require, received: ${args.join(", ")}`,
+      );
+    }
+
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
 const moduleRegistrationFlagCases: ReadonlyArray<{
   readonly flag: string;
   readonly description: string;


### PR DESCRIPTION
## Summary
- add a regression test ensuring run-tests keeps module registration flag values and default targets
- extend the flag tracking set in run-tests to cover additional value-required Node flags

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f50ce08ae88321be41e6f3c8566a80