### PR TITLE
Ensure run-tests rejects missing reporter destinations

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -123,6 +123,14 @@ const filteredCliArguments = cliArguments.filter((argument) => argument !== "--"
 const mappedArguments = [];
 let pendingValueFlag = null;
 
+const ensurePendingFlagConsumed = (pendingFlag) => {
+  if (pendingFlag === null) {
+    return;
+  }
+
+  throwMissingFlagValueError(pendingFlag);
+};
+
 for (const argument of filteredCliArguments) {
   if (pendingValueFlag !== null) {
     mappedArguments.push({ value: argument, isTarget: false });
@@ -143,14 +151,11 @@ for (const argument of filteredCliArguments) {
     typeof mapped.value === "string" &&
     flagsWithValues.has(mapped.value)
   ) {
-    expectValueForFlag = true;
     pendingValueFlag = mapped.value;
   }
 }
 
-if (pendingValueFlag !== null) {
-  throwMissingFlagValueError(pendingValueFlag);
-}
+ensurePendingFlagConsumed(pendingValueFlag);
 
 const flagArguments = [];
 const targetArguments = [];

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -192,6 +192,27 @@ test(
 );
 
 test(
+  "run-tests script reports missing reporter destination before consuming targets",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["tests", "--test-reporter-destination"],
+    });
+
+    assert.equal(result.spawnCalls.length, 0);
+    assert.equal(result.exitCodes.length, 0);
+    assert.equal(result.exitCode, 2);
+    assert.ok(
+      result.importError instanceof RangeError ||
+        result.exitCodes.includes(2) ||
+        result.exitCode === 2,
+      "expected missing reporter destination to trigger RangeError or exit code 2",
+    );
+  },
+);
+
+test(
   "run-tests script rejects --test-reporter-destination without a value",
   async () => {
     const env = await loadEnvironment();


### PR DESCRIPTION
## Summary
- add a regression test to confirm the script throws before consuming targets when --test-reporter-destination lacks a value
- guard the CLI argument processing loop against pending value flags so the reporter destination option cannot consume targets

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f5153c42788321a82c5da0866af89b