### PR TITLE
Fix run-tests extension mapping

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -62,10 +62,22 @@ const mapArgument = (argument) => {
     return { value: argument, isTarget: false };
   }
 
-  if (projectRelativePath.endsWith(".ts")) {
-    const withoutExtension = projectRelativePath.slice(0, -3);
-    const mapped = path.join(projectRoot, "dist", `${withoutExtension}.js`);
-    return { value: mapped, isTarget: true };
+  const tsExtensionMappings = [
+    [".cts", ".cjs"],
+    [".mts", ".mjs"],
+    [".ts", ".js"],
+  ];
+
+  for (const [extension, replacement] of tsExtensionMappings) {
+    if (projectRelativePath.endsWith(extension)) {
+      const withoutExtension = projectRelativePath.slice(0, -extension.length);
+      const mapped = path.join(
+        projectRoot,
+        "dist",
+        `${withoutExtension}${replacement}`,
+      );
+      return { value: mapped, isTarget: true };
+    }
   }
 
   if (matchedPathExists) {

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -316,6 +316,74 @@ test("run-tests script normalizes absolute TS targets to dist JS paths", async (
 });
 
 test(
+  "run-tests script normalizes absolute MTS targets to dist MJS paths",
+  async () => {
+    const env = await loadEnvironment();
+    const absoluteTarget = env.pathModule.resolve(
+      env.repoRootPath,
+      "tests/example.test.mts",
+    );
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: [absoluteTarget],
+      cwd: env.pathModule.join(env.repoRootPath, "dist"),
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+    const expectedTarget = env.pathModule.join(
+      env.repoRootPath,
+      "dist",
+      "tests",
+      "example.test.mjs",
+    );
+    assert.ok(
+      args.includes(expectedTarget),
+      `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
+    );
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
+test(
+  "run-tests script normalizes absolute CTS targets to dist CJS paths",
+  async () => {
+    const env = await loadEnvironment();
+    const absoluteTarget = env.pathModule.resolve(
+      env.repoRootPath,
+      "tests/example.test.cts",
+    );
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: [absoluteTarget],
+      cwd: env.pathModule.join(env.repoRootPath, "dist"),
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+    const expectedTarget = env.pathModule.join(
+      env.repoRootPath,
+      "dist",
+      "tests",
+      "example.test.cjs",
+    );
+    assert.ok(
+      args.includes(expectedTarget),
+      `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
+    );
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
+test(
   "run-tests script preserves flag values for known option arguments",
   async () => {
     const env = await loadEnvironment();


### PR DESCRIPTION
## Summary
- add coverage to run-tests script tests for .mts and .cts inputs
- update run-tests script to map TypeScript module extensions to corresponding dist outputs

## Testing
- npm run build && node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f52071026c8321b5b5690954d11222