### PR TITLE
Handle .mts and .cts targets in JSON reporter

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -42,6 +42,12 @@ const projectRoot = (() => {
   }
 })();
 
+const EXTENSION_MAPPING = new Map([
+  [".ts", ".js"],
+  [".mts", ".mjs"],
+  [".cts", ".cjs"],
+]);
+
 const mapTargetArgument = (
   target,
   { existsSync = fs.existsSync, mapDirectoriesToDist = false } = {},
@@ -109,7 +115,9 @@ const mapTargetArgument = (
     return target;
   }
 
-  if (extension === '.ts') {
+  const mappedExtension = EXTENSION_MAPPING.get(extension);
+
+  if (mappedExtension) {
     const withoutExtension = extension.length > 0
       ? normalizedRelative.slice(0, -extension.length)
       : normalizedRelative;
@@ -119,7 +127,7 @@ const mapTargetArgument = (
       .filter((segment) => segment && segment !== '.' && segment !== '..');
     const distPath = path.join('dist', ...normalizedSegments);
 
-    return `${distPath}.js`;
+    return `${distPath}${mappedExtension}`;
   }
 
   const inDistAlready =

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -129,6 +129,52 @@ test(
   },
 );
 
+test(
+  "prepareRunnerOptions maps .mts target to dist .mjs path",
+  async () => {
+    const prepareRunnerOptions = await loadPrepareRunnerOptions("mts-target");
+
+    const result = prepareRunnerOptions(
+      [
+        "node",
+        "script.mjs",
+        "tests/example.test.mts",
+      ],
+      {
+        existsSync: (candidate) =>
+          typeof candidate === "string" &&
+          (candidate.endsWith("tests/example.test.mts") ||
+            candidate.endsWith("dist/tests/example.test.mjs")),
+      },
+    );
+
+    assert.deepEqual(result.targets, ["dist/tests/example.test.mjs"]);
+  },
+);
+
+test(
+  "prepareRunnerOptions maps .cts target to dist .cjs path",
+  async () => {
+    const prepareRunnerOptions = await loadPrepareRunnerOptions("cts-target");
+
+    const result = prepareRunnerOptions(
+      [
+        "node",
+        "script.mjs",
+        "tests/example.test.cts",
+      ],
+      {
+        existsSync: (candidate) =>
+          typeof candidate === "string" &&
+          (candidate.endsWith("tests/example.test.cts") ||
+            candidate.endsWith("dist/tests/example.test.cjs")),
+      },
+    );
+
+    assert.deepEqual(result.targets, ["dist/tests/example.test.cjs"]);
+  },
+);
+
 test("JSON reporter runner uses dist target when invoked with TS input", async () => {
   const { createRequire } = (await dynamicImport("node:module")) as {
     createRequire: (specifier: string | URL) => (id: string) => unknown;


### PR DESCRIPTION
## Summary
- extend the JSON reporter runner to translate .mts and .cts targets to their built outputs
- add coverage for prepareRunnerOptions mapping .mts/.cts targets to dist .mjs/.cjs files

## Testing
- npm run build && node scripts/run-tests.js -- --test-reporter=json

------
https://chatgpt.com/codex/tasks/task_e_68f52071160483219f3ebd715694a591