### PR TITLE
Ensure JSON reporter handles ./prefixed TS targets

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -105,7 +105,7 @@ const mapTargetArgument = (
 
   const relativePathFromProject = path.relative(projectRoot, absolute);
   const normalizedRelative = path.normalize(relativePathFromProject);
-  const extension = path.extname(normalizedRelative);
+  const extension = path.extname(normalizedRelative).toLowerCase();
   const upwardPrefix = `..${path.sep}`;
 
   if (

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -175,6 +175,38 @@ test(
   },
 );
 
+for (const { extension, distExtension } of [
+  { extension: ".mts", distExtension: ".mjs" },
+  { extension: ".cts", distExtension: ".cjs" },
+]) {
+  test(
+    `prepareRunnerOptions maps ./ prefixed ${extension} target to dist ${distExtension} path`,
+    async () => {
+      const prepareRunnerOptions = await loadPrepareRunnerOptions(
+        `${extension.slice(1)}-prefixed-target`,
+      );
+
+      const result = prepareRunnerOptions(
+        [
+          "node",
+          "script.mjs",
+          `./tests/example.test${extension}`,
+        ],
+        {
+          existsSync: (candidate) =>
+            typeof candidate === "string" &&
+            (candidate.endsWith(`example.test${extension}`) ||
+              candidate.endsWith(`example.test${distExtension}`)),
+        },
+      );
+
+      assert.deepEqual(result.targets, [
+        `dist/tests/example.test${distExtension}`,
+      ]);
+    },
+  );
+}
+
 test("JSON reporter runner uses dist target when invoked with TS input", async () => {
   const { createRequire } = (await dynamicImport("node:module")) as {
     createRequire: (specifier: string | URL) => (id: string) => unknown;


### PR DESCRIPTION
## Summary
- add coverage for ./ prefixed `.mts`/`.cts` targets to confirm the JSON reporter picks the built `.mjs`/`.cjs` files
- normalise target extensions before looking them up in the extension mapping table so `.mts`/`.cts` cases resolve consistently

## Testing
- npm run build
- node scripts/run-tests.js -- --test-reporter=json

------
https://chatgpt.com/codex/tasks/task_e_68f52639f2308321a8aac85d31e6da25