### PR TITLE
Fix run-tests mapping for MTS/CTS CLI arguments

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -62,22 +62,29 @@ const mapArgument = (argument) => {
     return { value: argument, isTarget: false };
   }
 
-  const tsExtensionMappings = [
-    [".cts", ".cjs"],
-    [".mts", ".mjs"],
-    [".ts", ".js"],
-  ];
+  const mapTsTarget = (extension, replacement) => {
+    const withoutExtension = projectRelativePath.slice(
+      0,
+      -extension.length,
+    );
+    const mapped = path.join(
+      projectRoot,
+      "dist",
+      `${withoutExtension}${replacement}`,
+    );
+    return { value: mapped, isTarget: true };
+  };
 
-  for (const [extension, replacement] of tsExtensionMappings) {
-    if (projectRelativePath.endsWith(extension)) {
-      const withoutExtension = projectRelativePath.slice(0, -extension.length);
-      const mapped = path.join(
-        projectRoot,
-        "dist",
-        `${withoutExtension}${replacement}`,
-      );
-      return { value: mapped, isTarget: true };
-    }
+  if (projectRelativePath.endsWith(".cts")) {
+    return mapTsTarget(".cts", ".cjs");
+  }
+
+  if (projectRelativePath.endsWith(".mts")) {
+    return mapTsTarget(".mts", ".mjs");
+  }
+
+  if (projectRelativePath.endsWith(".ts")) {
+    return mapTsTarget(".ts", ".js");
   }
 
   if (matchedPathExists) {

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -284,6 +284,64 @@ test(
   },
 );
 
+test(
+  "run-tests script maps CLI MTS file arguments to dist MJS targets",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["tests/example.test.mts"],
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+    const expectedTarget = env.pathModule.join(
+      env.repoRootPath,
+      "dist",
+      "tests",
+      "example.test.mjs",
+    );
+    assert.ok(
+      args.includes(expectedTarget),
+      `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
+    );
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
+test(
+  "run-tests script maps CLI CTS file arguments to dist CJS targets",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["tests/example.test.cts"],
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+    const expectedTarget = env.pathModule.join(
+      env.repoRootPath,
+      "dist",
+      "tests",
+      "example.test.cjs",
+    );
+    assert.ok(
+      args.includes(expectedTarget),
+      `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
+    );
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
 test("run-tests script normalizes absolute TS targets to dist JS paths", async () => {
   const env = await loadEnvironment();
   const absoluteTarget = env.pathModule.resolve(


### PR DESCRIPTION
## Summary
- add coverage that verifies run-tests maps .mts and .cts CLI inputs to the corresponding dist files
- update the run-tests script to map .cts/.mts paths before falling back to .ts

## Testing
- npm run build
- node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f5263975988321b73687bfd3ad6eff