### PR TITLE
Fix skip pattern flag handling for JSON reporter runner

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -12,6 +12,7 @@ const OPTIONS_EXPECTING_VALUE = new Set([
   '--require',
   '--test-ignore',
   '--test-name-pattern',
+  '--test-skip-pattern',
   '--test-reporter',
   '--test-reporter-destination',
 ]);

--- a/tests/json-reporter-runner-flags.test.ts
+++ b/tests/json-reporter-runner-flags.test.ts
@@ -316,3 +316,100 @@ test("JSON reporter runner does not treat CLI flag values as targets", async () 
   assert.equal(forwardedArgs[flagIndex + 1], "dist");
   assert.equal(forwardedArgs.slice(0, flagIndex).indexOf("dist"), -1);
 });
+
+test("JSON reporter runner does not treat skip pattern values as targets", async () => {
+  const spawnCalls: Array<{
+    command: string;
+    args: string[];
+  }> = [];
+
+  const globalOverride = globalThis as {
+    __CAT32_TEST_SPAWN__?: (
+      command: string,
+      args: readonly string[],
+      options?: unknown,
+    ) => unknown;
+  };
+
+  const originalSpawnOverride = globalOverride.__CAT32_TEST_SPAWN__;
+
+  globalOverride.__CAT32_TEST_SPAWN__ = (
+    command: string,
+    args: readonly string[],
+    _options?: unknown,
+  ) => {
+    spawnCalls.push({ command, args: [...args] });
+
+    const child = createMockChildProcess();
+    queueMicrotask(() => {
+      child.emit("exit", 0, null);
+    });
+
+    return child.child;
+  };
+
+  const nodeProcess = process as unknown as {
+    argv: string[];
+    execPath: string;
+    pid: number;
+    env: Record<string, string | undefined>;
+    exit: (code?: number) => never;
+    kill: (pid: number, signal: string) => void;
+    on: (event: string, listener: Listener) => void;
+    listeners: (event: string) => Listener[];
+    removeListener: (event: string, listener: Listener) => void;
+  };
+
+  const runnerUrl = new URL("./--test-reporter=json", repoRootUrl);
+  const runnerPath = decodeURIComponent(runnerUrl.pathname);
+  const originalArgv = nodeProcess.argv;
+  const trackedSignals: Signal[] = ["SIGINT", "SIGTERM", "SIGQUIT"];
+  const previousListeners = new Map<Signal, Set<Listener>>();
+
+  for (const signal of trackedSignals) {
+    previousListeners.set(signal, new Set(nodeProcess.listeners(signal)));
+  }
+
+  const originalExit = nodeProcess.exit;
+  const exitCalls: Array<number | undefined> = [];
+  nodeProcess.exit = ((code?: number) => {
+    exitCalls.push(code);
+    return undefined as never;
+  }) as (code?: number) => never;
+
+  nodeProcess.argv = [
+    nodeProcess.execPath,
+    runnerPath,
+    "--test-skip-pattern",
+    "tests/example.test.js",
+  ];
+
+  try {
+    await import(`${runnerUrl.href}?${Date.now()}`);
+  } finally {
+    nodeProcess.argv = originalArgv;
+    nodeProcess.exit = originalExit;
+    globalOverride.__CAT32_TEST_SPAWN__ = originalSpawnOverride;
+
+    for (const signal of trackedSignals) {
+      const before = previousListeners.get(signal) ?? new Set();
+      for (const listener of nodeProcess.listeners(signal)) {
+        if (!before.has(listener)) {
+          nodeProcess.removeListener(signal, listener);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(exitCalls.at(-1), 0);
+  assert.equal(spawnCalls.length, 1);
+
+  const forwardedArgs = spawnCalls[0]!.args;
+  const flagIndex = forwardedArgs.indexOf("--test-skip-pattern");
+  assert.ok(flagIndex !== -1);
+  assert.equal(forwardedArgs[flagIndex + 1], "tests/example.test.js");
+  assert.equal(
+    forwardedArgs.slice(0, flagIndex).indexOf("tests/example.test.js"),
+    -1,
+  );
+});


### PR DESCRIPTION
## Summary
- add coverage that ensures `--test-skip-pattern` values stay with the flag in the JSON reporter runner
- treat `--test-skip-pattern` as an option expecting a value so pending parsing works reliably

## Testing
- npm test -- --test-name-pattern json-reporter-runner-flags

------
https://chatgpt.com/codex/tasks/task_e_68f5416a36908321b243c10f023b9458