### PR TITLE
Handle test skip pattern passthrough for JSON reporter

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -12,7 +12,7 @@ const OPTIONS_EXPECTING_VALUE = new Set([
   '--require',
   '--test-ignore',
   '--test-name-pattern',
-  '--test-skip-pattern',
+  '--test-skip-pattern', // ensure value is consumed via pendingOption
   '--test-reporter',
   '--test-reporter-destination',
 ]);

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -125,6 +125,7 @@ const flagsWithValues = new Set([
   "--require",
   "--test-concurrency",
   "--test-name-pattern",
+  "--test-skip-pattern",
   "--test-reporter",
   "--test-reporter-destination",
   "--test-timeout",

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -207,6 +207,31 @@ for (const { extension, distExtension } of [
   );
 }
 
+test(
+  "prepareRunnerOptions forwards skip pattern arguments as passthrough",
+  async () => {
+    const prepareRunnerOptions = await loadPrepareRunnerOptions(
+      "skip-pattern-passthrough",
+    );
+
+    const result = prepareRunnerOptions(
+      [
+        "node",
+        "script.mjs",
+        "--test-skip-pattern",
+        "tests/example.test.js",
+      ],
+      { defaultTargets: [] },
+    );
+
+    assert.deepEqual(result.targets, []);
+    assert.deepEqual(result.passthroughArgs, [
+      "--test-skip-pattern",
+      "tests/example.test.js",
+    ]);
+  },
+);
+
 test("JSON reporter runner uses dist target when invoked with TS input", async () => {
   const { createRequire } = (await dynamicImport("node:module")) as {
     createRequire: (specifier: string | URL) => (id: string) => unknown;


### PR DESCRIPTION
## Summary
- add a regression test that ensures prepareRunnerOptions leaves --test-skip-pattern in passthroughArgs
- document the skip pattern option within the JSON reporter so its value is consumed through pendingOption
- treat --test-skip-pattern as a flag that expects a value in scripts/run-tests.js

## Testing
- npm run build && node scripts/run-tests.js -- --test-reporter=json --test-skip-pattern tests/example.test.js *(fails: /root/.nvm/versions/node/v20.19.4/bin/node: bad option: --test-skip-pattern)*

------
https://chatgpt.com/codex/tasks/task_e_68f54c13a6208321b5e027f9b82a5cd3