### PR TITLE
Support test ignore flag passthrough

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -125,6 +125,7 @@ const flagsWithValues = new Set([
   "--require",
   "--test-concurrency",
   "--test-name-pattern",
+  "--test-ignore",
   "--test-skip-pattern",
   "--test-reporter",
   "--test-reporter-destination",

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -233,6 +233,41 @@ test(
 );
 
 test(
+  "run-tests script preserves default targets when --test-ignore is provided",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["--test-ignore", "tests/example.test.js"],
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+
+    const expectedTargets = [
+      env.pathModule.join(env.repoRootPath, "dist", "tests"),
+      env.pathModule.join(env.repoRootPath, "dist", "frontend", "tests"),
+    ];
+
+    for (const expectedTarget of expectedTargets) {
+      assert.ok(
+        args.includes(expectedTarget),
+        `expected spawn args to include ${expectedTarget}, received: ${args.join(", ")}`,
+      );
+    }
+
+    assert.ok(args.includes("--test-ignore"));
+    assert.ok(args.includes("tests/example.test.js"));
+
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
+test(
   "run-tests script preserves default targets when --test-skip-pattern is provided",
   async () => {
     const env = await loadEnvironment();


### PR DESCRIPTION
## Summary
- ensure the run-tests script treats --test-ignore as a flag with a value and forwards it unchanged
- add a regression test that verifies default targets remain when --test-ignore is provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f55d541c3c8321a4d1425c54bf6a63