### PR TITLE
Handle --test-match flag in JSON reporter runner

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -12,6 +12,7 @@ const OPTIONS_EXPECTING_VALUE = new Set([
   '--require',
   '--test-ignore',
   '--test-name-pattern',
+  '--test-match',
   '--test-skip-pattern', // ensure value is consumed via pendingOption
   '--test-reporter',
   '--test-reporter-destination',


### PR DESCRIPTION
## Summary
- add a regression test ensuring prepareRunnerOptions keeps default targets when --test-match consumes a separate value argument
- treat --test-match as an option that expects a value in the JSON reporter runner so the argument is forwarded correctly

## Testing
- npm run build
- node scripts/run-tests.js -- --test-reporter=json --test-match '**/*.test.js' *(fails: Node 20.19.4 does not support the --test-match flag)*

------
https://chatgpt.com/codex/tasks/task_e_68f56bfc71a48321b6c17718ad4d4629