### PR TITLE
Handle test match flag in run tests script

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -127,6 +127,7 @@ const flagsWithValues = new Set([
   "--require",
   "--test-concurrency",
   "--test-name-pattern",
+  "--test-match",
   "--test-reporter",
   "--test-reporter-destination",
   testSkipPatternFlag,

--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -621,6 +621,40 @@ test(
 );
 
 test(
+  "run-tests script preserves default targets when --test-match is provided",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["--test-match", "**/*.test.js"],
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+
+    const expectedArgs = [
+      "--test",
+      "--test-match",
+      "**/*.test.js",
+      env.pathModule.join(env.repoRootPath, "dist", "tests"),
+      env.pathModule.join(env.repoRootPath, "dist", "frontend", "tests"),
+    ];
+
+    assert.deepEqual(
+      args,
+      expectedArgs,
+      `expected spawn args to equal ${expectedArgs.join(", ")}, received: ${args.join(", ")}`,
+    );
+
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
+test(
   "run-tests script keeps module registration flag values separate from default targets",
   async () => {
     const env = await loadEnvironment();


### PR DESCRIPTION
## Summary
- add coverage ensuring the run-tests script keeps default targets when --test-match is passed
- include --test-match in the flag set that skips target mapping so its value is forwarded untouched

## Testing
- `npm run build && node scripts/run-tests.js -- --test-match '**/*.test.js'` *(fails: Node reports "bad option: --test-match")*

------
https://chatgpt.com/codex/tasks/task_e_68f56bfd41bc8321bb90eac70b4c2726