### PR TITLE
Handle passthrough double dash targets for JSON reporter

### DIFF
--- a/--test-reporter=json
+++ b/--test-reporter=json
@@ -167,6 +167,7 @@ const prepareRunnerOptions = (
   const seenTargets = new Set();
   let destinationOverride = null;
   let pendingOption = null;
+  let treatRemainingArgumentsAsTargets = false;
 
   const addResolvedTarget = (candidate, bucket) => {
     if (!candidate) {
@@ -286,6 +287,24 @@ const prepareRunnerOptions = (
         passthroughArgs.push(argument);
       }
       pendingOption = null;
+      continue;
+    }
+
+    if (argument === '--') {
+      passthroughArgs.push(argument);
+      treatRemainingArgumentsAsTargets = true;
+      continue;
+    }
+
+    if (treatRemainingArgumentsAsTargets) {
+      const resolvedTarget = resolveTargetCandidate(argument);
+
+      if (resolvedTarget) {
+        addResolvedTarget(resolvedTarget, explicitTargets);
+        continue;
+      }
+
+      passthroughArgs.push(argument);
       continue;
     }
 

--- a/tests/json-reporter-runner.test.ts
+++ b/tests/json-reporter-runner.test.ts
@@ -232,6 +232,30 @@ test(
   },
 );
 
+test(
+  "prepareRunnerOptions keeps -- terminator while mapping following hyphen target",
+  async () => {
+    const prepareRunnerOptions = await loadPrepareRunnerOptions("double-dash");
+
+    const result = prepareRunnerOptions(
+      [
+        "node",
+        "script.mjs",
+        "--",
+        "--edge-case.test.ts",
+      ],
+      {
+        defaultTargets: [],
+        existsSync: (candidate) =>
+          typeof candidate === "string" && candidate.includes("--edge-case.test"),
+      },
+    );
+
+    assert.deepEqual(result.targets, ["dist/--edge-case.test.js"]);
+    assert.deepEqual(result.passthroughArgs, ["--"]);
+  },
+);
+
 test("JSON reporter runner uses dist target when invoked with TS input", async () => {
   const { createRequire } = (await dynamicImport("node:module")) as {
     createRequire: (specifier: string | URL) => (id: string) => unknown;


### PR DESCRIPTION
## Summary
- add a regression test covering double dash terminated arguments in `prepareRunnerOptions`
- update the JSON reporter runner to keep `--` passthrough while mapping following hyphenated targets
- teach `scripts/run-tests.js` to stop option parsing after the CLI terminator and forward literal targets

## Testing
- npm run build
- node --test dist/tests/json-reporter-runner.test.js
- node scripts/run-tests.js -- --test-reporter=json -- --edge-case.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f5729e1a688321a5a6056cdaf151c1