### PR TITLE
Fix hyphen-prefixed test target mapping

### DIFF
--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -535,6 +535,7 @@ test(
     const expectedTarget = env.pathModule.join(
       env.repoRootPath,
       "dist",
+      "tests",
       "--edge-case.test.js",
     );
     const targetIndex = args.indexOf(expectedTarget);
@@ -545,6 +546,42 @@ test(
     assert.ok(
       sentinelIndex < targetIndex,
       `expected -- sentinel to appear before ${expectedTarget}, received: ${args.join(", ")}`,
+    );
+
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
+test(
+  "run-tests script maps hyphen-prefixed TS targets without CLI sentinel",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["--edge-case.test.ts"],
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+
+    const expectedArgs = [
+      "--test",
+      env.pathModule.join(
+        env.repoRootPath,
+        "dist",
+        "tests",
+        "--edge-case.test.js",
+      ),
+    ];
+
+    assert.deepEqual(
+      args,
+      expectedArgs,
+      `expected spawn args to equal ${expectedArgs.join(", ")}, received: ${args.join(", ")}`,
     );
 
     assert.deepEqual(result.exitCodes, [0]);


### PR DESCRIPTION
## Summary
- ensure run-tests script recognises hyphen-prefixed test arguments and maps them to dist targets via default source directories
- keep `--` sentinel ordering while adding coverage for hyphenated arguments without explicit sentinel
- recognise `--test-ignore` as flag with value to preserve default targets

## Testing
- npm run test
- npm run test -- --edge-case.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f5e7905c808321aa1e6defc390326d