### PR TITLE
Handle --test-runner flag in run-tests script

### DIFF
--- a/tests/run-tests-script.test.ts
+++ b/tests/run-tests-script.test.ts
@@ -301,6 +301,45 @@ test(
   },
 );
 
+test(
+  "run-tests script preserves default targets when --test-runner is provided",
+  async () => {
+    const env = await loadEnvironment();
+
+    const result = await runScriptWithEnvironment(env, {
+      argv: ["--test-runner", "tests/custom-runner.js"],
+    });
+
+    assert.equal(result.importError, undefined);
+    assert.equal(result.spawnCalls.length, 1);
+
+    const invocation = result.spawnCalls[0]!;
+    assert.ok(Array.isArray(invocation.args));
+    const args = invocation.args as string[];
+
+    const expectedArgs = [
+      "--test",
+      "--test-runner",
+      "tests/custom-runner.js",
+      env.pathModule.join(env.repoRootPath, "dist", "tests"),
+      env.pathModule.join(
+        env.repoRootPath,
+        "dist",
+        "frontend",
+        "tests",
+      ),
+    ];
+
+    assert.deepEqual(
+      args,
+      expectedArgs,
+      `expected spawn args to equal ${expectedArgs.join(", ")}, received: ${args.join(", ")}`,
+    );
+
+    assert.deepEqual(result.exitCodes, [0]);
+  },
+);
+
 test("run-tests script maps CLI directory arguments to dist targets", async () => {
   const env = await loadEnvironment();
 


### PR DESCRIPTION
## Summary
- add a regression test that ensures the run-tests script keeps default dist targets when --test-runner is provided
- treat --test-runner as a value flag and only forward the CLI sentinel when user-specified targets are present

## Testing
- npm run build
- node scripts/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68f5f2a54ac48321a0c6d8aa3bf5eb1d