### PR TITLE
Add Cat32 property tests for canonical keys

### DIFF
--- a/tests/property/cat32.property.test.ts
+++ b/tests/property/cat32.property.test.ts
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { Cat32, stableStringify } from "../../src/index.js";
+
+const ITERATIONS = 64;
+const webCrypto = globalThis.crypto;
+if (!webCrypto || typeof webCrypto.getRandomValues !== "function") throw new Error("WebCrypto unavailable for property tests");
+
+test("Cat32 canonical key is stable for random object permutations", () => {
+  const categorizer = new Cat32();
+  for (let i = 0; i < ITERATIONS; i += 1) {
+    const entries = randomObjectEntries(2);
+    const shuffled = shuffle(entries.slice());
+    const objectA = Object.fromEntries(entries);
+    const objectB = Object.fromEntries(shuffled);
+
+    const assignmentA = categorizer.assign(objectA);
+    const assignmentB = categorizer.assign(objectB);
+
+    assert.equal(assignmentA.key, assignmentB.key);
+    assert.equal(assignmentA.index, assignmentB.index);
+    assert.equal(assignmentA.key, stableStringify(objectA));
+    assert.equal(assignmentB.key, stableStringify(objectB));
+  }
+});
+
+test("Cat32 Map canonical key matches equivalent objects", () => {
+  const categorizer = new Cat32();
+  for (let i = 0; i < ITERATIONS; i += 1) {
+    const entries = randomObjectEntries(1);
+    const map = new Map(shuffle(entries.slice()));
+    const plainObject = Object.fromEntries(entries);
+
+    const objectAssignment = categorizer.assign(plainObject);
+    const mapAssignment = categorizer.assign(map);
+
+    assert.equal(mapAssignment.key, objectAssignment.key);
+    assert.equal(mapAssignment.index, objectAssignment.index);
+    assert.equal(stableStringify(map), stableStringify(plainObject));
+  }
+});
+
+function randomObjectEntries(depth: number): Array<[string, unknown]> {
+  const size = 1 + randomInt(4);
+  const entries: Array<[string, unknown]> = [];
+  const seen = new Set<string>();
+  while (entries.length < size) {
+    const key = randomKey();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    entries.push([key, randomValue(depth)]);
+  }
+  return entries;
+}
+function randomValue(depth: number): unknown {
+  if (depth <= 0) return randomPrimitive();
+  switch (randomInt(3)) {
+    case 0: return randomArray(depth - 1);
+    case 1: return randomPlainObject(depth - 1);
+    default: return randomPrimitive();
+  }
+}
+function randomPrimitive(): unknown {
+  switch (randomInt(5)) {
+    case 0: return randomString();
+    case 1: return randomNumber();
+    case 2: return randomBoolean();
+    case 3: return null;
+    default: return undefined;
+  }
+}
+function randomArray(depth: number): unknown[] {
+  const length = randomInt(4);
+  return Array.from({ length }, () => randomValue(depth));
+}
+const randomPlainObject = (depth: number): Record<string, unknown> => Object.fromEntries(randomObjectEntries(depth));
+function randomInt(max: number): number {
+  if (max <= 0) throw new RangeError("max must be positive");
+  return getRandomBytes(4).reduce((value, byte) => (value * 256) + byte, 0) % max;
+}
+function shuffle<T>(values: T[]): T[] {
+  for (let i = values.length - 1; i > 0; i -= 1) {
+    const j = randomInt(i + 1);
+    [values[i], values[j]] = [values[j], values[i]];
+  }
+  return values;
+}
+const randomKey = (): string => bytesToHex(getRandomBytes(4));
+const randomString = (): string => bytesToHex(getRandomBytes(6));
+const randomNumber = (): number => (getRandomBytes(6).reduce((value, byte) => (value * 256) + byte, 0) % 2000) - 1000;
+const randomBoolean = (): boolean => (getRandomBytes(1)[0] & 1) === 1;
+const bytesToHex = (bytes: Uint8Array): string => Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+function getRandomBytes(size: number): Uint8Array {
+  const array = new Uint8Array(size);
+  webCrypto.getRandomValues(array);
+  return array;
+}


### PR DESCRIPTION
## Summary
- add property-based node:test coverage to verify Cat32 canonical keys remain stable across randomized object permutations
- confirm Map inputs yield the same canonical key/index as equivalent plain objects through randomized checks

## Testing
- npm run test
- npm run lint

## Property tests
- Randomized object permutations and Map inputs both retain matching canonical keys/indices under Cat32; all property iterations pass locally.


------
https://chatgpt.com/codex/tasks/task_e_68f62ca5a1d08321a9bb4c70f13b6497