### PR TITLE
Add bundle size check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,15 @@ jobs:
           if [ "$s" != pass ]; then
             exit 1
           fi
+      - name: Check bundle size
+        run: |
+          set -Eeuo pipefail
+          start=$(date +%s%3N)
+          if npm run size; then s=pass; else s=fail; fi
+          echo "{\"name\":\"size\",\"status\":\"$s\",\"duration_ms\":$(( $(date +%s%3N)-start ))}" >> workflow-cookbook/logs/test.jsonl
+          if [ "$s" != pass ]; then
+            exit 1
+          fi
       - name: Security audit
         run: |
           set +e

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "build": "node scripts/build.js",
+    "size": "npm run build && node dist/scripts/check-size.js",
     "bench": "npm run build && node dist/scripts/bench.js",
     "test": "npm run build && node scripts/run-tests.js",
     "prepare": "npm run build",

--- a/scripts/check-size.ts
+++ b/scripts/check-size.ts
@@ -1,0 +1,170 @@
+const dynamicImport = new Function(
+  "specifier",
+  "return import(specifier);",
+) as (specifier: string) => Promise<unknown>;
+
+interface ProcessLike {
+  argv: string[];
+  exitCode?: number;
+}
+
+declare const process: ProcessLike;
+
+type ReadFileResult = ArrayBufferView | ArrayBuffer | string;
+
+type ReadFileFunction = (
+  path: string | URL,
+) => Promise<ReadFileResult> | ReadFileResult;
+
+type PathResolve = (...segments: string[]) => string;
+
+type FileURLToPath = (url: string | URL) => string;
+
+type GzipFunction = (input: ReadFileResult) => { readonly byteLength: number };
+
+type Logger = (message: string) => void;
+
+type Setter = (code: number) => void;
+
+const loadFunction = async <T>(
+  specifier: string,
+  key: string,
+  description: string,
+): Promise<T> => {
+  const module = (await dynamicImport(specifier)) as { [exported: string]: unknown } | null;
+  if (!module || typeof module !== "object") {
+    throw new TypeError(`expected ${specifier} module to be an object`);
+  }
+  const candidate = module[key];
+  if (typeof candidate !== "function") {
+    throw new TypeError(`expected ${description}`);
+  }
+  return candidate as T;
+};
+
+const loadReadFile = (): Promise<ReadFileFunction> =>
+  loadFunction<ReadFileFunction>("node:fs/promises", "readFile", "node:fs/promises.readFile");
+
+const loadResolve = (): Promise<PathResolve> =>
+  loadFunction<PathResolve>("node:path", "resolve", "node:path.resolve");
+
+const loadFileURLToPath = (): Promise<FileURLToPath> =>
+  loadFunction<FileURLToPath>("node:url", "fileURLToPath", "node:url.fileURLToPath");
+
+const loadGzipSync = (): Promise<GzipFunction> =>
+  loadFunction<GzipFunction>("node:zlib", "gzipSync", "node:zlib.gzipSync");
+
+export const MAX_GZIP_SIZE_BYTES = 10 * 1024;
+
+const DEFAULT_TARGET_PATH = new URL("../index.js", import.meta.url);
+
+export type RunCheckSizeOptions = {
+  readonly targetPath?: string | URL;
+  readonly maxBytes?: number;
+  readonly readFile?: ReadFileFunction;
+  readonly log?: Logger;
+  readonly error?: Logger;
+  readonly setExitCode?: Setter;
+};
+
+export type CheckSizeResult = {
+  readonly gzipSize: number;
+  readonly limit: number;
+  readonly exceeded: boolean;
+  readonly targetPath: string;
+};
+
+const textEncoder = new TextEncoder();
+
+const toUint8Array = (value: ReadFileResult): Uint8Array => {
+  if (typeof value === "string") {
+    return textEncoder.encode(value);
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  throw new TypeError("expected readFile to return string or ArrayBuffer view");
+};
+
+const describeTarget = async (target: string | URL): Promise<string> => {
+  if (typeof target === "string") {
+    return target;
+  }
+  if (target instanceof URL) {
+    if (target.protocol === "file:") {
+      const fileURLToPath = await loadFileURLToPath();
+      return fileURLToPath(target);
+    }
+    return target.href;
+  }
+  return String(target);
+};
+
+const setProcessExitCode: Setter = (code) => {
+  process.exitCode = code;
+};
+
+export const runCheckSize = async (
+  options: RunCheckSizeOptions = {},
+): Promise<CheckSizeResult> => {
+  const targetPath = options.targetPath ?? DEFAULT_TARGET_PATH;
+  const maxBytes = options.maxBytes ?? MAX_GZIP_SIZE_BYTES;
+  const readFile = options.readFile ?? (await loadReadFile());
+  const log = options.log ?? ((message) => console.log(message));
+  const error = options.error ?? ((message) => console.error(message));
+  const setExitCode = options.setExitCode ?? setProcessExitCode;
+
+  const gzipSync = await loadGzipSync();
+  const rawContent = await readFile(targetPath);
+  const bytes = toUint8Array(rawContent);
+  const gzipSize = gzipSync(bytes).byteLength;
+  const exceeded = gzipSize > maxBytes;
+  const describedTarget = await describeTarget(targetPath);
+
+  if (exceeded) {
+    error(
+      `[check-size] ${describedTarget} gzip size ${gzipSize} bytes exceeds limit ${maxBytes} bytes`,
+    );
+    setExitCode(1);
+  } else {
+    log(
+      `[check-size] ${describedTarget} gzip size ${gzipSize} bytes within limit ${maxBytes} bytes`,
+    );
+  }
+
+  return { gzipSize, limit: maxBytes, exceeded, targetPath: describedTarget };
+};
+
+const isExecutedDirectly = async (): Promise<boolean> => {
+  const fileURLToPath = await loadFileURLToPath();
+  const resolve = await loadResolve();
+  const scriptPath = resolve(fileURLToPath(import.meta.url));
+  const invokedPath = process.argv[1];
+  return typeof invokedPath === "string" && invokedPath.length > 0
+    ? resolve(invokedPath) === scriptPath
+    : false;
+};
+
+const runCli = async (): Promise<void> => {
+  try {
+    await runCheckSize();
+  } catch (error) {
+    const message =
+      error instanceof Error && typeof error.message === "string"
+        ? error.message
+        : String(error);
+    console.error(`[check-size] failed: ${message}`);
+    setProcessExitCode(1);
+  }
+};
+
+const runCliIfNeeded = async (): Promise<void> => {
+  if (await isExecutedDirectly()) {
+    await runCli();
+  }
+};
+
+void runCliIfNeeded();

--- a/tests/check-size.test.ts
+++ b/tests/check-size.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type RunCheckSize = (options?: {
+  readonly targetPath?: string | URL;
+  readonly maxBytes?: number;
+  readonly readFile?: (
+    path: string | URL,
+  ) => Promise<ArrayBufferView | ArrayBuffer | string> | ArrayBufferView | ArrayBuffer | string;
+  readonly log?: (message: string) => void;
+  readonly error?: (message: string) => void;
+  readonly setExitCode?: (code: number) => void;
+}) => Promise<{
+  readonly gzipSize: number;
+  readonly limit: number;
+  readonly exceeded: boolean;
+  readonly targetPath: string;
+}>;
+
+type CheckSizeModule = {
+  readonly runCheckSize: RunCheckSize;
+  readonly MAX_GZIP_SIZE_BYTES: number;
+};
+
+const dynamicImport = new Function(
+  "specifier",
+  "return import(specifier);",
+) as (specifier: string) => Promise<unknown>;
+
+type GzipSync = (
+  input: ArrayBufferView | ArrayBuffer | string,
+) => { readonly byteLength: number };
+
+const loadGzipSync = async (): Promise<GzipSync> => {
+  const module = (await dynamicImport("node:zlib")) as { gzipSync?: unknown };
+  if (!module || typeof module !== "object") {
+    throw new TypeError("expected node:zlib module to be an object");
+  }
+  const { gzipSync } = module as { gzipSync?: GzipSync };
+  if (typeof gzipSync !== "function") {
+    throw new TypeError("expected node:zlib module to provide gzipSync");
+  }
+  return gzipSync;
+};
+
+const repoRootUrl = import.meta.url.includes("/dist/tests/")
+  ? new URL("../..", import.meta.url)
+  : new URL("..", import.meta.url);
+
+const scriptModuleUrl = import.meta.url.includes("/dist/tests/")
+  ? new URL("dist/scripts/check-size.js", repoRootUrl)
+  : new URL("scripts/check-size.ts", repoRootUrl);
+
+const loadModule = async (): Promise<CheckSizeModule> => {
+  return (await dynamicImport(scriptModuleUrl.href)) as CheckSizeModule;
+};
+
+const createPseudoRandomBytes = (length: number): Uint8Array => {
+  const buffer = new Uint8Array(length);
+  let state = 0x12345678;
+  for (let index = 0; index < length; index += 1) {
+    state = (state * 1664525 + 1013904223) & 0xffffffff;
+    buffer[index] = (state >>> 24) & 0xff;
+  }
+  return buffer;
+};
+
+test("runCheckSize reports an error when gzip size exceeds the limit", async () => {
+  const { runCheckSize, MAX_GZIP_SIZE_BYTES } = await loadModule();
+  const gzipSync = await loadGzipSync();
+
+  const content = createPseudoRandomBytes(MAX_GZIP_SIZE_BYTES + 512);
+  const expectedGzipSize = gzipSync(content).byteLength;
+
+  const capturedLogs: string[] = [];
+  const capturedErrors: string[] = [];
+  let exitCode: number | undefined;
+
+  const result = await runCheckSize({
+    readFile: async () => content,
+    log: (message) => {
+      capturedLogs.push(message);
+    },
+    error: (message) => {
+      capturedErrors.push(message);
+    },
+    setExitCode: (code) => {
+      exitCode = code;
+    },
+    targetPath: new URL("file:///tmp/dist/index.js"),
+  });
+
+  assert.equal(result.gzipSize, expectedGzipSize);
+  assert.equal(result.limit, MAX_GZIP_SIZE_BYTES);
+  assert.equal(result.exceeded, true);
+  assert.equal(exitCode, 1);
+  assert.deepEqual(capturedLogs, []);
+  assert.ok(
+    capturedErrors.some((line) =>
+      line.includes("dist/index.js") && line.includes(`${expectedGzipSize}`),
+    ),
+    "expected error output to include the target path and gzip size",
+  );
+});
+
+test("runCheckSize logs success when gzip size is within the limit", async () => {
+  const { runCheckSize, MAX_GZIP_SIZE_BYTES } = await loadModule();
+  const gzipSync = await loadGzipSync();
+
+  const textEncoder = new TextEncoder();
+  const content = textEncoder.encode("export const value = 1;\n".repeat(4));
+  const expectedGzipSize = gzipSync(content).byteLength;
+
+  const capturedLogs: string[] = [];
+  const capturedErrors: string[] = [];
+  let exitCode: number | undefined;
+
+  const result = await runCheckSize({
+    readFile: async () => content,
+    log: (message) => {
+      capturedLogs.push(message);
+    },
+    error: (message) => {
+      capturedErrors.push(message);
+    },
+    setExitCode: (code) => {
+      exitCode = code;
+    },
+    targetPath: new URL("file:///tmp/dist/index.js"),
+  });
+
+  assert.equal(result.gzipSize, expectedGzipSize);
+  assert.equal(result.limit, MAX_GZIP_SIZE_BYTES);
+  assert.equal(result.exceeded, false);
+  assert.equal(exitCode, undefined);
+  assert.deepEqual(capturedErrors, []);
+  assert.ok(
+    capturedLogs.some((line) =>
+      line.includes("dist/index.js") && line.includes(`${expectedGzipSize}`),
+    ),
+    "expected log output to include the target path and gzip size",
+  );
+});


### PR DESCRIPTION
## Summary
- add a CLI script that computes the gzipped size of `dist/index.js` and exits with a non-zero code when it exceeds 10 KiB
- add tests that cover success and failure paths of the size check using mocked file reads
- register an `npm run size` command and execute it in CI after the build step

## Testing
- npm run test
- npm run build && npm run size

------
https://chatgpt.com/codex/tasks/task_e_68f62ca5429c8321a559f3a00224aead