### PR TITLE
Use ubuntu-latest runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: mkdir -p workflow-cookbook/logs
@@ -38,7 +38,7 @@ jobs:
         with: { name: 'test-logs-${{ github.job }}', path: workflow-cookbook/logs/* }
 
   typecheck:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: mkdir -p workflow-cookbook/logs
@@ -94,7 +94,7 @@ jobs:
         with: { name: 'test-logs-${{ github.job }}', path: workflow-cookbook/logs/* }
 
   unit:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: mkdir -p workflow-cookbook/logs


### PR DESCRIPTION
## Summary
- update CI jobs to use the ubuntu-latest runner so queued builds can start immediately

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f638791fb483219f5e6271f8b7f51f