### PR TITLE
Fix typed array serialization collisions

### DIFF
--- a/tests/serialize-typed-array.test.ts
+++ b/tests/serialize-typed-array.test.ts
@@ -3,38 +3,73 @@ import assert from "node:assert";
 
 import { Cat32, stableStringify } from "../src/index.js";
 
-const typedArray = new Uint8Array([10, 20, 30]);
-
 const sharedArrayBuffer =
   typeof SharedArrayBuffer === "function" ? new SharedArrayBuffer(4) : undefined;
 
-if (sharedArrayBuffer) {
-  const sharedView = new Uint8Array(sharedArrayBuffer);
-  for (let i = 0; i < sharedView.length; i += 1) {
-    sharedView[i] = i + 1;
-  }
-}
+test("stableStringify distinguishes typed array views with different bytes", () => {
+  const left = new Uint16Array([0x0102, 0x0304]);
+  const right = new Uint16Array([0x0102, 0x0305]);
 
-test("stableStringify of Uint8Array matches JSON string of its String coercion", () => {
-  const value = new Uint8Array(typedArray);
-  assert.equal(stableStringify(value), JSON.stringify(String(value)));
+  assert.ok(stableStringify(left) !== stableStringify(right));
 });
 
-test("Cat32.assign key for Uint8Array matches JSON string of its String coercion", () => {
-  const value = new Uint8Array(typedArray);
-  const assignment = new Cat32().assign(value);
-  assert.equal(assignment.key, JSON.stringify(String(value)));
+test("Cat32 assign key differs for typed array views with different bytes", () => {
+  const cat = new Cat32();
+  const left = new Uint16Array([0x0102, 0x0304]);
+  const right = new Uint16Array([0x0102, 0x0305]);
+
+  const assignmentLeft = cat.assign(left);
+  const assignmentRight = cat.assign(right);
+
+  assert.ok(assignmentLeft.key !== assignmentRight.key);
+  assert.ok(assignmentLeft.hash !== assignmentRight.hash);
+});
+
+test("Cat32 distinguish typed array views with same bytes but different view types", () => {
+  const cat = new Cat32();
+  const source = new ArrayBuffer(4);
+  const asUint8 = new Uint8Array(source);
+  const asUint16 = new Uint16Array(source);
+
+  asUint8.set([1, 2, 3, 4]);
+
+  const assignmentUint8 = cat.assign(asUint8);
+  const assignmentUint16 = cat.assign(asUint16);
+
+  assert.ok(assignmentUint8.key !== assignmentUint16.key);
+  assert.ok(assignmentUint8.hash !== assignmentUint16.hash);
 });
 
 if (sharedArrayBuffer) {
-  test("stableStringify of SharedArrayBuffer view matches JSON string of its String coercion", () => {
-    const view = new Uint8Array(sharedArrayBuffer);
-    assert.equal(stableStringify(view), JSON.stringify(String(view)));
+  const buildShared = () => {
+    const buffer = new SharedArrayBuffer(4);
+    const view = new Uint8Array(buffer);
+    for (let i = 0; i < view.length; i += 1) {
+      view[i] = i + 1;
+    }
+    return buffer;
+  };
+
+  test("stableStringify distinguishes SharedArrayBuffer instances by content", () => {
+    const left = buildShared();
+    const right = buildShared();
+    const rightView = new Uint8Array(right);
+    rightView[1] = 9;
+
+    assert.ok(stableStringify(left) !== stableStringify(right));
   });
 
-  test("Cat32.assign key for SharedArrayBuffer view matches JSON string of its String coercion", () => {
-    const view = new Uint8Array(sharedArrayBuffer);
-    const assignment = new Cat32().assign(view);
-    assert.equal(assignment.key, JSON.stringify(String(view)));
+  test("Cat32 assign key differs for SharedArrayBuffers with different content", () => {
+    const cat = new Cat32();
+    const left = buildShared();
+    const right = buildShared();
+    const rightView = new Uint8Array(right);
+    rightView[1] = 9;
+
+    const assignmentLeft = cat.assign(left);
+    const assignmentRight = cat.assign(right);
+
+    assert.ok(assignmentLeft.key !== assignmentRight.key);
+    assert.ok(assignmentLeft.hash !== assignmentRight.hash);
   });
 }

--- a/tests/stable-stringify-typed-array.test.ts
+++ b/tests/stable-stringify-typed-array.test.ts
@@ -3,24 +3,28 @@ import assert from "node:assert";
 
 import { Cat32, stableStringify } from "../src/index.js";
 
-test("Cat32 assign key matches JSON.stringify for typed array views", () => {
-  const value = new Uint8Array([1, 2]);
-  const assignment = new Cat32().assign(value);
-  assert.equal(assignment.key, JSON.stringify(String(value)));
+test("stableStringify distinguishes typed array views by content", () => {
+  const left = new Uint8Array([1, 2]);
+  const right = new Uint8Array([1, 3]);
+
+  assert.ok(stableStringify(left) !== stableStringify(right));
 });
 
-test("Cat32 assign key matches JSON.stringify for ArrayBuffer", () => {
-  const value = new ArrayBuffer(4);
-  const assignment = new Cat32().assign(value);
-  assert.equal(assignment.key, JSON.stringify(String(value)));
+test("stableStringify distinguishes ArrayBuffer instances by content", () => {
+  const left = new Uint8Array([1, 2]).buffer;
+  const right = new Uint8Array([1, 3]).buffer;
+
+  assert.ok(stableStringify(left) !== stableStringify(right));
 });
 
-test("stableStringify matches JSON.stringify for typed array views", () => {
-  const value = new Uint8Array([1, 2]);
-  assert.equal(stableStringify(value), JSON.stringify(String(value)));
-});
+test("Cat32 assign key differs for ArrayBuffers with different content", () => {
+  const cat = new Cat32();
+  const left = new Uint8Array([1, 2]).buffer;
+  const right = new Uint8Array([1, 3]).buffer;
 
-test("stableStringify matches JSON.stringify for ArrayBuffer", () => {
-  const value = new ArrayBuffer(4);
-  assert.equal(stableStringify(value), JSON.stringify(String(value)));
+  const assignmentLeft = cat.assign(left);
+  const assignmentRight = cat.assign(right);
+
+  assert.ok(assignmentLeft.key !== assignmentRight.key);
+  assert.ok(assignmentLeft.hash !== assignmentRight.hash);
 });


### PR DESCRIPTION
## Summary
- add regression tests that ensure typed arrays and buffers with different bytes yield different Cat32 keys and hashes
- serialize ArrayBuffer, SharedArrayBuffer, and typed array views using sentinel strings that capture their metadata and hex payloads
- update build-time serialization expectations to assert the new sentinel encoding

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f63b35b9e083219236f2b14a378092