### PR TITLE
Fix Map Date key canonicalization

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -280,12 +280,6 @@ function toMapPropertyKey(
   serializedKey: string,
 ): { bucketKey: string; propertyKey: string } {
   const bucketTag = mapBucketTypeTag(rawKey);
-  if (rawKey instanceof Date) {
-    return {
-      bucketKey: `${bucketTag}|${serializedKey}`,
-      propertyKey: normalizePlainObjectKey(String(rawKey)),
-    };
-  }
   const revivedKey = reviveFromSerialized(serializedKey);
   return {
     bucketKey: `${bucketTag}|${serializedKey}`,

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -1547,15 +1547,16 @@ test("Map keys align with plain object representation when property keys are uni
   assert.ok(duplicateKeyMapAssignment.hash !== duplicateKeyObjectAssignment.hash);
 });
 
-test("Map Date key matches plain object string key", () => {
+test("Map Date key uses ISO sentinel distinct from plain object string key", () => {
   const c = new Cat32();
   const date = new Date("2024-05-01T00:00:00.000Z");
 
   const mapAssignment = c.assign(new Map([[date, "value"]]));
   const objectAssignment = c.assign({ [String(date)]: "value" });
 
-  assert.equal(mapAssignment.key, objectAssignment.key);
-  assert.equal(mapAssignment.hash, objectAssignment.hash);
+  assert.ok(mapAssignment.key.includes(`"__date__:${date.toISOString()}"`));
+  assert.ok(mapAssignment.key !== objectAssignment.key);
+  assert.ok(mapAssignment.hash !== objectAssignment.hash);
 });
 
 test("Map duplicate property keys retain distinct entries per key type", () => {

--- a/tests/serialize-map-date.test.ts
+++ b/tests/serialize-map-date.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { Cat32 } from "../src/index.js";
+import { stableStringify } from "../src/serialize.js";
+
+test("Map with Date key serializes using ISO sentinel", () => {
+  const date = new Date("2020-01-01T00:00:00Z");
+  const map = new Map([[date, "v"]]);
+
+  const serialized = stableStringify(map);
+  const parsed = JSON.parse(serialized) as Record<string, string>;
+  const keys = Object.keys(parsed);
+  const expectedKey = `__date__:${date.toISOString()}`;
+
+  assert.equal(keys.length, 1);
+  assert.equal(keys[0], expectedKey);
+  assert.equal(parsed[expectedKey], "v");
+});
+
+test("Cat32.assign uses ISO sentinel for Map Date keys", () => {
+  const date = new Date("2020-01-01T00:00:00Z");
+  const map = new Map([[date, "v"]]);
+
+  const cat = new Cat32();
+  const assignment = cat.assign(map);
+  const serialized = stableStringify(map);
+
+  assert.equal(assignment.key, serialized);
+  assert.ok(assignment.key.includes(date.toISOString()));
+});


### PR DESCRIPTION
## Summary
- add a regression test covering Map Date key serialization and Cat32.assign canonical keys
- use the revived sentinel string when deriving Map property keys so Date keys yield ISO-based canonical keys
- update the Map Date regression to expect the ISO sentinel representation

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f64142b8b08321a0ca8ac1512f6f61