### PR TITLE
Handle boxed primitives in stable stringify

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -106,6 +106,10 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
     return String(v);
   }
 
+  if (v instanceof Number || v instanceof Boolean || v instanceof BigInt) {
+    return _stringify(v.valueOf(), stack);
+  }
+
   if (Array.isArray(v)) {
     if (stack.has(v)) throw new TypeError("Cyclic object");
     stack.add(v);
@@ -264,6 +268,9 @@ function compareSerializedEntry(
 }
 
 function mapBucketTypeTag(rawKey: unknown): string {
+  if (rawKey instanceof Number || rawKey instanceof Boolean || rawKey instanceof BigInt) {
+    return mapBucketTypeTag(rawKey.valueOf());
+  }
   if (typeof rawKey === "symbol") return "symbol";
   if (rawKey === null) return "null";
   if (rawKey instanceof Date) return "date";
@@ -371,6 +378,9 @@ function toPropertyKeyString(
   revivedKey: unknown,
   serializedKey: string,
 ): string {
+  if (rawKey instanceof Number || rawKey instanceof Boolean || rawKey instanceof BigInt) {
+    return toPropertyKeyString(rawKey.valueOf(), revivedKey, serializedKey);
+  }
   if (typeof rawKey === "symbol") {
     return (rawKey as symbol).toString();
   }

--- a/tests/stable-stringify-boxed-primitives.test.ts
+++ b/tests/stable-stringify-boxed-primitives.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { Cat32, stableStringify } from "../src/index.js";
+
+test("stableStringify distinguishes boxed primitive numbers", () => {
+  const boxedOne = Object(1);
+  const boxedTwo = Object(2);
+
+  assert.ok(stableStringify(boxedOne) !== stableStringify(boxedTwo));
+});
+
+test("Cat32 assign key reflects boxed boolean value", () => {
+  const cat = new Cat32();
+
+  const trueAssignment = cat.assign(Object(true));
+  const falseAssignment = cat.assign(Object(false));
+
+  assert.ok(trueAssignment.key !== falseAssignment.key);
+  assert.ok(trueAssignment.key === "true");
+  assert.ok(falseAssignment.key === "false");
+});


### PR DESCRIPTION
## Summary
- add regression tests covering boxed primitive serialization and Cat32 canonical keys
- unwrap Number/Boolean/BigInt objects during stable serialization and Map key normalization

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f641436b1483218fb96fbd25437265