### PR TITLE
Ensure Map Date keys use ISO sentinel

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -288,6 +288,19 @@ function toMapPropertyKey(
 ): { bucketKey: string; propertyKey: string } {
   const bucketTag = mapBucketTypeTag(rawKey);
   const revivedKey = reviveFromSerialized(serializedKey);
+  if (rawKey instanceof Date) {
+    const revivedString = typeof revivedKey === "string" ? revivedKey : "";
+    const isoValue = rawKey.toISOString();
+    const normalizedDateKey =
+      revivedString && revivedString.startsWith(DATE_SENTINEL_PREFIX)
+        ? revivedString
+        : `${DATE_SENTINEL_PREFIX}${revivedString || isoValue}`;
+    const escapedDateKey = escapeSentinelString(normalizedDateKey);
+    return {
+      bucketKey: `${bucketTag}|${escapedDateKey}`,
+      propertyKey: escapedDateKey,
+    };
+  }
   return {
     bucketKey: `${bucketTag}|${serializedKey}`,
     propertyKey: toPropertyKeyString(rawKey, revivedKey, serializedKey),

--- a/tests/serialize-map-date.test.ts
+++ b/tests/serialize-map-date.test.ts
@@ -1,5 +1,5 @@
 import test from "node:test";
-import assert from "node:assert";
+import assert from "node:assert/strict";
 
 import { Cat32 } from "../src/index.js";
 import { stableStringify } from "../src/serialize.js";
@@ -9,13 +9,9 @@ test("Map with Date key serializes using ISO sentinel", () => {
   const map = new Map([[date, "v"]]);
 
   const serialized = stableStringify(map);
-  const parsed = JSON.parse(serialized) as Record<string, string>;
-  const keys = Object.keys(parsed);
   const expectedKey = `__date__:${date.toISOString()}`;
 
-  assert.equal(keys.length, 1);
-  assert.equal(keys[0], expectedKey);
-  assert.equal(parsed[expectedKey], "v");
+  assert.deepEqual(JSON.parse(serialized), { [expectedKey]: "v" });
 });
 
 test("Cat32.assign uses ISO sentinel for Map Date keys", () => {
@@ -25,7 +21,8 @@ test("Cat32.assign uses ISO sentinel for Map Date keys", () => {
   const cat = new Cat32();
   const assignment = cat.assign(map);
   const serialized = stableStringify(map);
+  const expectedKey = `__date__:${date.toISOString()}`;
 
   assert.equal(assignment.key, serialized);
-  assert.ok(assignment.key.includes(date.toISOString()));
+  assert.deepEqual(JSON.parse(assignment.key), { [expectedKey]: "v" });
 });


### PR DESCRIPTION
## Summary
- add regression coverage for Map Date keys to assert ISO-based sentinel output
- normalize Map key serialization to reuse revived Date sentinel strings for environment-independent keys

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f64f71d2c88321a7b26e5c10d84219