### PR TITLE
Handle invalid Date sentinels

### DIFF
--- a/tests/serialize-map-date.test.ts
+++ b/tests/serialize-map-date.test.ts
@@ -14,6 +14,16 @@ test("Map with Date key serializes using ISO sentinel", () => {
   assert.deepEqual(JSON.parse(serialized), { [expectedKey]: "v" });
 });
 
+test("Map with invalid Date key serializes using invalid sentinel", () => {
+  const date = new Date(NaN);
+  const map = new Map([[date, "v"]]);
+
+  const serialized = stableStringify(map);
+  const expectedKey = "__date__:invalid";
+
+  assert.deepEqual(JSON.parse(serialized), { [expectedKey]: "v" });
+});
+
 test("Cat32.assign uses ISO sentinel for Map Date keys", () => {
   const date = new Date("2020-01-01T00:00:00Z");
   const map = new Map([[date, "v"]]);
@@ -22,6 +32,19 @@ test("Cat32.assign uses ISO sentinel for Map Date keys", () => {
   const assignment = cat.assign(map);
   const serialized = stableStringify(map);
   const expectedKey = `__date__:${date.toISOString()}`;
+
+  assert.equal(assignment.key, serialized);
+  assert.deepEqual(JSON.parse(assignment.key), { [expectedKey]: "v" });
+});
+
+test("Cat32.assign uses invalid sentinel for Map invalid Date keys", () => {
+  const date = new Date(NaN);
+  const map = new Map([[date, "v"]]);
+
+  const cat = new Cat32();
+  const assignment = cat.assign(map);
+  const serialized = stableStringify(map);
+  const expectedKey = "__date__:invalid";
 
   assert.equal(assignment.key, serialized);
   assert.deepEqual(JSON.parse(assignment.key), { [expectedKey]: "v" });


### PR DESCRIPTION
## Summary
- ensure stableStringify encodes invalid Date instances with a deterministic sentinel
- normalize Map key handling so invalid Date payloads round-trip across helpers
- extend Date serialization tests to cover invalid Date inputs for stableStringify and Cat32.assign

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f6595e153483219802ff4938d9d393