### PR TITLE
Handle RegExp serialization collisions

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -42,6 +42,10 @@ function buildArrayBufferPayload(length: number, bytes: Uint8Array): string {
   return `byteLength=${length};hex=${toHex(bytes)}`;
 }
 
+function buildRegExpPayload(value: RegExp): string {
+  return JSON.stringify([value.source, value.flags]);
+}
+
 function getArrayBufferViewTag(view: ArrayBufferView): string {
   const raw = Object.prototype.toString.call(view);
   return raw.slice(8, -1);
@@ -211,6 +215,12 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
     return out;
   }
 
+  if (v instanceof RegExp) {
+    return stringifySentinelLiteral(
+      typeSentinel("regexp", buildRegExpPayload(v)),
+    );
+  }
+
   // Plain object
   const o = v as Record<string, unknown>;
   if (stack.has(o)) throw new TypeError("Cyclic object");
@@ -276,6 +286,7 @@ function mapBucketTypeTag(rawKey: unknown): string {
   if (rawKey instanceof Date) return "date";
   if (rawKey instanceof Map) return "map";
   if (rawKey instanceof Set) return "set";
+  if (rawKey instanceof RegExp) return "regexp";
   if (Array.isArray(rawKey)) return "array";
   if (sharedArrayBufferCtor && rawKey instanceof sharedArrayBufferCtor) return "sharedarraybuffer";
   if (rawKey instanceof ArrayBuffer || ArrayBuffer.isView(rawKey)) return "arraybuffer";
@@ -375,6 +386,18 @@ function reviveSentinelValue(value: unknown): unknown {
           return value;
         }
       }
+      if (type === "regexp") {
+        try {
+          const parsed = JSON.parse(payload) as unknown;
+          if (Array.isArray(parsed) && typeof parsed[0] === "string") {
+            const flags = typeof parsed[1] === "string" ? parsed[1] : "";
+            return new RegExp(parsed[0], flags);
+          }
+        } catch {
+          return value;
+        }
+        return value;
+      }
     }
   }
   return value;
@@ -401,6 +424,26 @@ function toPropertyKeyString(
       return escapeSentinelString(revivedKey);
     }
     return `${DATE_SENTINEL_PREFIX}${rawKey.toISOString()}`;
+  }
+
+  if (rawKey instanceof RegExp) {
+    const normalizedFromRaw = normalizePlainObjectKey(
+      escapeSentinelString(typeSentinel("regexp", buildRegExpPayload(rawKey))),
+    );
+    if (revivedKey instanceof RegExp) {
+      return normalizePlainObjectKey(
+        escapeSentinelString(typeSentinel("regexp", buildRegExpPayload(revivedKey))),
+      );
+    }
+    if (typeof revivedKey === "string") {
+      const normalizedRevived = normalizePlainObjectKey(
+        escapeSentinelString(revivedKey),
+      );
+      if (normalizedRevived !== normalizedFromRaw) {
+        return normalizedRevived;
+      }
+    }
+    return normalizedFromRaw;
   }
 
   const rawType = typeof rawKey;

--- a/tests/stable-stringify-regexp.test.ts
+++ b/tests/stable-stringify-regexp.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { stableStringify } from "../src/serialize.js";
+
+test("stableStringify distinguishes RegExp variants", () => {
+  const foo = stableStringify(/foo/);
+  const fooIgnoreCase = stableStringify(/foo/i);
+  const fooGlobal = stableStringify(new RegExp("foo", "g"));
+  const emptyObject = stableStringify({});
+
+  assert.ok(foo !== fooIgnoreCase);
+  assert.ok(foo !== fooGlobal);
+  assert.ok(fooIgnoreCase !== fooGlobal);
+
+  assert.ok(foo !== emptyObject);
+  assert.ok(fooIgnoreCase !== emptyObject);
+  assert.ok(fooGlobal !== emptyObject);
+});


### PR DESCRIPTION
## Summary
- add a regression test to ensure RegExp values produce unique stable stringify results
- encode RegExp values with a regexp sentinel that captures pattern and flags
- extend map key normalization to understand regexp sentinels

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f6595d19e083218236a906c3ff782c