### PR TITLE
Fix Map duplicate bucket serialization

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -183,12 +183,17 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
     };
     const normalizedEntries: Record<
       string,
-      { propertyKey: string; entries: SerializedEntry[] }
+      {
+        propertyKey: string;
+        entries: SerializedEntry[];
+        shouldDedupe: boolean;
+      }
     > = Object.create(null);
     for (const [rawKey, rawValue] of v.entries()) {
       const serializedKey = _stringify(rawKey, stack);
       const { bucketKey, propertyKey } = toMapPropertyKey(rawKey, serializedKey);
       const serializedValue = _stringify(rawValue, stack);
+      const shouldDedupe = typeof rawKey !== "symbol";
       const bucket = normalizedEntries[bucketKey];
       if (bucket) {
         bucket.entries.push({
@@ -196,6 +201,7 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
           serializedValue,
           order: bucket.entries.length,
         });
+        bucket.shouldDedupe &&= shouldDedupe;
       } else {
         normalizedEntries[bucketKey] = {
           propertyKey,
@@ -206,6 +212,7 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
               order: 0,
             },
           ],
+          shouldDedupe,
         };
       }
     }
@@ -225,9 +232,16 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
       if (!bucket?.entries.length) continue;
       const entries = bucket.entries;
       entries.sort(compareSerializedEntry);
-      for (const entry of entries) {
+      for (let index = 0; index < entries.length; index += 1) {
+        const entry = entries[index]!;
         if (bodyParts.length) bodyParts.push(",");
-        bodyParts.push(JSON.stringify(bucket.propertyKey), ":", entry.serializedValue);
+        const propertyKey = mapEntryPropertyKey(
+          bucket.propertyKey,
+          index,
+          entries.length,
+          bucket.shouldDedupe,
+        );
+        bodyParts.push(JSON.stringify(propertyKey), ":", entry.serializedValue);
       }
     }
     stack.delete(v);
@@ -307,6 +321,19 @@ function compareSerializedEntry(
   if (left.order < right.order) return -1;
   if (left.order > right.order) return 1;
   return 0;
+}
+
+function mapEntryPropertyKey(
+  baseKey: string,
+  entryIndex: number,
+  totalEntries: number,
+  shouldDedupe: boolean,
+): string {
+  if (!shouldDedupe || totalEntries <= 1 || entryIndex === 0) {
+    return baseKey;
+  }
+
+  return `${baseKey}${typeSentinel("map-entry-index", String(entryIndex))}`;
 }
 
 function mapBucketTypeTag(rawKey: unknown): string {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -440,6 +440,23 @@ test("Cat32 assign retains distinct Map entries for identical property keys", ()
   assert.ok(first.hash !== second.hash);
 });
 
+test("Map serialization differentiates duplicate-like object entries", () => {
+  const withDuplicates = new Map<unknown, string>([
+    [{}, "a"],
+    [{}, "b"],
+  ]);
+  const singleEntry = new Map<unknown, string>([[{}, "a"]]);
+
+  assert.ok(stableStringify(withDuplicates) !== stableStringify(singleEntry));
+
+  const cat = new Cat32();
+  const withDuplicatesAssignment = cat.assign(withDuplicates);
+  const singleEntryAssignment = cat.assign(singleEntry);
+
+  assert.ok(withDuplicatesAssignment.key !== singleEntryAssignment.key);
+  assert.ok(withDuplicatesAssignment.hash !== singleEntryAssignment.hash);
+});
+
 test("Cat32 assign distinguishes Map keys when String(key) collides", () => {
   const obj = { foo: 1 };
   const instance = new Cat32();


### PR DESCRIPTION
## Summary
- add a regression test ensuring multi-entry Maps with duplicate-like object keys serialize distinctly from single-entry Maps
- adjust Map normalization to retain ordered output for all bucket entries by appending stable index sentinels only when deduping non-symbol keys

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f67724897c8321b72a94cbd7de2d64