### PR TITLE
Fix sentinel escaping for buffer string literals

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -382,6 +382,13 @@ function normalizeStringLiteral(value: string): string {
   return value;
 }
 
+function isSentinelStringOfType(value: string, type: string): boolean {
+  return (
+    value.startsWith(`${SENTINEL_PREFIX}${type}:`) &&
+    value.endsWith(SENTINEL_SUFFIX)
+  );
+}
+
 function needsStringLiteralSentinelEscape(value: string): boolean {
   if (value === HOLE_SENTINEL_RAW) {
     return true;
@@ -396,6 +403,18 @@ function needsStringLiteralSentinelEscape(value: string): boolean {
   }
 
   if (value.startsWith(DATE_SENTINEL_PREFIX)) {
+    return true;
+  }
+
+  if (isSentinelStringOfType(value, "typedarray")) {
+    return true;
+  }
+
+  if (isSentinelStringOfType(value, "arraybuffer")) {
+    return true;
+  }
+
+  if (isSentinelStringOfType(value, "sharedarraybuffer")) {
     return true;
   }
 

--- a/tests/stable-stringify-typed-array.test.ts
+++ b/tests/stable-stringify-typed-array.test.ts
@@ -28,3 +28,59 @@ test("Cat32 assign key differs for ArrayBuffers with different content", () => {
   assert.ok(assignmentLeft.key !== assignmentRight.key);
   assert.ok(assignmentLeft.hash !== assignmentRight.hash);
 });
+
+test("Cat32 assign distinguishes typed array from its serialized string", () => {
+  const cat = new Cat32();
+  const typedArray = new Uint8Array([1, 2, 3]);
+  const serialized = JSON.parse(stableStringify(typedArray));
+
+  const typedAssignment = cat.assign(typedArray);
+  const stringAssignment = cat.assign(serialized);
+
+  assert.ok(typedAssignment.key !== stringAssignment.key);
+  assert.ok(typedAssignment.hash !== stringAssignment.hash);
+});
+
+test("Cat32 assign distinguishes ArrayBuffer from its serialized string", () => {
+  const cat = new Cat32();
+  const arrayBuffer = new Uint8Array([4, 5]).buffer;
+  const serialized = JSON.parse(stableStringify(arrayBuffer));
+
+  const bufferAssignment = cat.assign(arrayBuffer);
+  const stringAssignment = cat.assign(serialized);
+
+  assert.ok(bufferAssignment.key !== stringAssignment.key);
+  assert.ok(bufferAssignment.hash !== stringAssignment.hash);
+});
+
+test("Cat32 assign distinguishes SharedArrayBuffer from its serialized string", () => {
+  if (typeof SharedArrayBuffer !== "function") {
+    assert.ok(true, "SharedArrayBuffer unavailable in this runtime");
+    return;
+  }
+
+  const cat = new Cat32();
+  const shared = new SharedArrayBuffer(4);
+  const view = new Uint8Array(shared);
+  view.set([6, 7, 8, 9]);
+  const serialized = JSON.parse(stableStringify(shared));
+
+  const bufferAssignment = cat.assign(shared);
+  const stringAssignment = cat.assign(serialized);
+
+  assert.ok(bufferAssignment.key !== stringAssignment.key);
+  assert.ok(bufferAssignment.hash !== stringAssignment.hash);
+});
+
+test("Cat32 assign distinguishes Map with typed array key from serialized key", () => {
+  const cat = new Cat32();
+  const typedArray = new Uint8Array([10, 11]);
+  const mapWithTypedKey = new Map([[typedArray, 1]]);
+  const mapWithSerializedKey = new Map([[stableStringify(typedArray), 1]]);
+
+  const typedAssignment = cat.assign(mapWithTypedKey);
+  const stringAssignment = cat.assign(mapWithSerializedKey);
+
+  assert.ok(typedAssignment.key !== stringAssignment.key);
+  assert.ok(typedAssignment.hash !== stringAssignment.hash);
+});


### PR DESCRIPTION
## Summary
- add regression coverage to confirm Cat32 assigns distinct keys for typed array, ArrayBuffer, and SharedArrayBuffer values versus their serialized sentinels
- detect typedarray/arraybuffer/sharedarraybuffer sentinel strings in normalization to keep string literals distinct

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f67ae67938832188c389eb51276d5b