### PR TITLE
Fix RegExp sentinel string literal collisions

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -433,26 +433,20 @@ function needsStringLiteralSentinelEscape(value: string): boolean {
     return true;
   }
 
-  if (
-    value.startsWith(SENTINEL_PREFIX) &&
-    value.endsWith(SENTINEL_SUFFIX)
-  ) {
-    const inner = value.slice(
-      SENTINEL_PREFIX.length,
-      -SENTINEL_SUFFIX.length,
-    );
-    const separatorIndex = inner.indexOf(":");
-    if (separatorIndex !== -1) {
-      const type = inner.slice(0, separatorIndex);
-      if (
-        type === REGEXP_SENTINEL_TYPE ||
-        type === "typedarray" ||
-        type === "arraybuffer" ||
-        type === "sharedarraybuffer"
-      ) {
-        return true;
-      }
-    }
+  if (isSentinelStringOfType(value, REGEXP_SENTINEL_TYPE)) {
+    return true;
+  }
+
+  if (isSentinelStringOfType(value, "typedarray")) {
+    return true;
+  }
+
+  if (isSentinelStringOfType(value, "arraybuffer")) {
+    return true;
+  }
+
+  if (isSentinelStringOfType(value, "sharedarraybuffer")) {
+    return true;
   }
 
   return false;

--- a/tests/stable-stringify-regexp.test.ts
+++ b/tests/stable-stringify-regexp.test.ts
@@ -23,6 +23,18 @@ test("stableStringify distinguishes RegExp variants", () => {
   assert.ok(JSON.parse(fooGlobal).startsWith("\u0000cat32:regexp:"));
 });
 
+test("stableStringify distinguishes RegExp from RegExp sentinel string literals", () => {
+  const regex = stableStringify(/foo/);
+  const sentinelLiteral = typeSentinel("regexp", JSON.stringify(["foo", ""]));
+  const stringLiteral = stableStringify(sentinelLiteral);
+
+  assert.ok(regex !== stringLiteral);
+  assert.ok(JSON.parse(regex).startsWith("\u0000cat32:regexp:"));
+  assert.ok(
+    JSON.parse(stringLiteral).startsWith("__string__:\u0000cat32:regexp:"),
+  );
+});
+
 test("Cat32.assign produces distinct keys and hashes for RegExp variants", () => {
   const cat = new Cat32();
 


### PR DESCRIPTION
## Summary
- add regression coverage to ensure stableStringify and Cat32 treat RegExp literals distinctly from RegExp sentinel strings
- escape RegExp sentinel literals when serializing strings to avoid canonical key collisions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f68e207344832182110b46cf7f0ca1