### PR TITLE
Fix Map entry sentinel collision suffix

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -14,6 +14,8 @@ const DATE_SENTINEL_PREFIX = "__date__:";
 const SYMBOL_SENTINEL_PREFIX = "__symbol__:";
 const STRING_LITERAL_SENTINEL_PREFIX = "__string__:";
 const REGEXP_SENTINEL_TYPE = "regexp";
+const MAP_ENTRY_INDEX_LITERAL_SEGMENT =
+  `${STRING_LITERAL_SENTINEL_PREFIX}${SENTINEL_PREFIX}map-entry-index:`;
 const HEX_DIGITS = "0123456789abcdef";
 
 type DateSentinelParts = {
@@ -334,7 +336,11 @@ function mapEntryPropertyKey(
     return baseKey;
   }
 
-  return `${baseKey}${typeSentinel("map-entry-index", String(entryIndex))}`;
+  const indexSuffix = `${STRING_LITERAL_SENTINEL_PREFIX}${typeSentinel(
+    "map-entry-index",
+    String(entryIndex),
+  )}`;
+  return `${baseKey}${indexSuffix}`;
 }
 
 function mapBucketTypeTag(rawKey: unknown): string {
@@ -446,6 +452,10 @@ function needsStringLiteralSentinelEscape(value: string): boolean {
   }
 
   if (isSentinelStringOfType(value, "sharedarraybuffer")) {
+    return true;
+  }
+
+  if (value.includes(MAP_ENTRY_INDEX_LITERAL_SEGMENT)) {
     return true;
   }
 

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -485,6 +485,30 @@ test("Cat32 assign distinguishes Map keys when String(key) collides", () => {
   assert.ok(mixedAssignment.key !== stringOnlyAssignment.key);
 });
 
+test(
+  "Cat32 assign differentiates Map object keys from sentinel-style string keys",
+  () => {
+    const cat = new Cat32();
+
+    const objectKeyAssignment = cat.assign(
+      new Map<unknown, string>([
+        [{}, "a"],
+        [{}, "b"],
+      ]),
+    );
+
+    const stringKeyAssignment = cat.assign(
+      new Map<string, string>([
+        ["[object Object]", "a"],
+        ["[object Object]\u0000cat32:map-entry-index:1\u0000", "b"],
+      ]),
+    );
+
+    assert.ok(objectKeyAssignment.key !== stringKeyAssignment.key);
+    assert.ok(objectKeyAssignment.hash !== stringKeyAssignment.hash);
+  },
+);
+
 test("Cat32 distinguishes Map symbol keys from string descriptions", () => {
   const symbolKey = Symbol("id");
   const cat = new Cat32();


### PR DESCRIPTION
## Summary
- add a regression test covering Cat32 map keys that collide with sentinel-like strings
- encode duplicate map entry suffixes with a literal-only prefix and escape detection to prevent user string collisions

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68f693ea08e8832190b80ae0742bf2b9