### PR TITLE
Fix sentinel escaping for numeric literals

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -17,6 +17,14 @@ const REGEXP_SENTINEL_TYPE = "regexp";
 const MAP_ENTRY_INDEX_LITERAL_SEGMENT =
   `${STRING_LITERAL_SENTINEL_PREFIX}${SENTINEL_PREFIX}map-entry-index:`;
 const HEX_DIGITS = "0123456789abcdef";
+const STRING_LITERAL_ESCAPED_SENTINEL_TYPES = new Set<string>([
+  REGEXP_SENTINEL_TYPE,
+  "typedarray",
+  "arraybuffer",
+  "sharedarraybuffer",
+  "number",
+  "bigint",
+]);
 const ARRAY_BUFFER_LIKE_SENTINEL_PREFIXES = [
   `${SENTINEL_PREFIX}typedarray:`,
   `${SENTINEL_PREFIX}arraybuffer:`,
@@ -461,12 +469,7 @@ function needsStringLiteralSentinelEscape(value: string): boolean {
     const separatorIndex = inner.indexOf(":");
     if (separatorIndex !== -1) {
       const type = inner.slice(0, separatorIndex);
-      if (
-        type === REGEXP_SENTINEL_TYPE ||
-        type === "typedarray" ||
-        type === "arraybuffer" ||
-        type === "sharedarraybuffer"
-      ) {
+      if (STRING_LITERAL_ESCAPED_SENTINEL_TYPES.has(type)) {
         return true;
       }
     }

--- a/tests/stable-stringify-string-collisions.test.ts
+++ b/tests/stable-stringify-string-collisions.test.ts
@@ -65,3 +65,28 @@ test("sentinel canonical encodings are preserved", () => {
   assert.equal(holeAssignment.key, stableStringify(hole));
   assert.ok(holeAssignment.key.includes("__hole__"));
 });
+
+test("numeric and bigint sentinel literals are escaped", () => {
+  const cat = new Cat32();
+
+  const cases: Array<{ value: number | bigint }> = [
+    { value: Number.NaN },
+    { value: Number.POSITIVE_INFINITY },
+    { value: 1n },
+  ];
+
+  for (const { value } of cases) {
+    const sentinelLiteral = JSON.parse(stableStringify(value));
+    const literalAssignment = cat.assign(sentinelLiteral);
+    const actualAssignment = cat.assign(value);
+
+    assert.ok(literalAssignment.key !== actualAssignment.key);
+    assert.ok(literalAssignment.hash !== actualAssignment.hash);
+
+    assert.equal(
+      literalAssignment.key,
+      JSON.stringify(`__string__:${sentinelLiteral}`),
+    );
+    assert.equal(actualAssignment.key, JSON.stringify(sentinelLiteral));
+  }
+});


### PR DESCRIPTION
## Summary
- add regression coverage ensuring numeric and bigint sentinel string literals do not collide with canonical numeric keys
- escape number and bigint sentinel strings during normalization to avoid canonical key collisions
- update categorizer expectations for escaped numeric sentinel literals

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f69b6a2ce08321a93956d161654ccd