### PR TITLE
Fix map entry sentinel collisions with literal strings

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -16,6 +16,7 @@ const STRING_LITERAL_SENTINEL_PREFIX = "__string__:";
 const REGEXP_SENTINEL_TYPE = "regexp";
 const MAP_ENTRY_INDEX_LITERAL_SEGMENT =
   `${STRING_LITERAL_SENTINEL_PREFIX}${SENTINEL_PREFIX}map-entry-index:`;
+const MAP_ENTRY_INDEX_SENTINEL_SEGMENT = `${SENTINEL_PREFIX}map-entry-index:`;
 const HEX_DIGITS = "0123456789abcdef";
 const ARRAY_BUFFER_LIKE_SENTINEL_PREFIXES = [
   `${SENTINEL_PREFIX}typedarray:`,
@@ -188,6 +189,7 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
       serializedKey: string;
       serializedValue: string;
       order: number;
+      propertyKey: string;
     };
     const normalizedEntries: Record<
       string,
@@ -208,6 +210,7 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
           serializedKey,
           serializedValue,
           order: bucket.entries.length,
+          propertyKey,
         });
         bucket.shouldDedupe &&= shouldDedupe;
       } else {
@@ -218,6 +221,7 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
               serializedKey,
               serializedValue,
               order: 0,
+              propertyKey,
             },
           ],
           shouldDedupe,
@@ -245,6 +249,7 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
         if (bodyParts.length) bodyParts.push(",");
         const propertyKey = mapEntryPropertyKey(
           bucket.propertyKey,
+          entry.propertyKey,
           index,
           entries.length,
           bucket.shouldDedupe,
@@ -332,20 +337,18 @@ function compareSerializedEntry(
 }
 
 function mapEntryPropertyKey(
-  baseKey: string,
+  bucketKey: string,
+  entryPropertyKey: string,
   entryIndex: number,
   totalEntries: number,
   shouldDedupe: boolean,
 ): string {
   if (!shouldDedupe || totalEntries <= 1 || entryIndex === 0) {
-    return baseKey;
+    return entryPropertyKey;
   }
 
-  const indexSuffix = `${STRING_LITERAL_SENTINEL_PREFIX}${typeSentinel(
-    "map-entry-index",
-    String(entryIndex),
-  )}`;
-  return `${baseKey}${indexSuffix}`;
+  const payload = JSON.stringify([bucketKey, entryPropertyKey, entryIndex]);
+  return typeSentinel("map-entry-index", payload);
 }
 
 function mapBucketTypeTag(rawKey: unknown): string {
@@ -473,6 +476,10 @@ function needsStringLiteralSentinelEscape(value: string): boolean {
   }
 
   if (value.includes(MAP_ENTRY_INDEX_LITERAL_SEGMENT)) {
+    return true;
+  }
+
+  if (value.includes(MAP_ENTRY_INDEX_SENTINEL_SEGMENT)) {
     return true;
   }
 

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -450,6 +450,68 @@ test("Cat32 assign retains distinct Map entries for identical property keys", ()
   assert.ok(first.hash !== second.hash);
 });
 
+function createNonEnumerableToStringObject(literal: string): Record<string, never> {
+  const object: Record<string, never> = {};
+  Object.defineProperty(object, "toString", {
+    value() {
+      return literal;
+    },
+    enumerable: false,
+  });
+  return object;
+}
+
+test(
+  "stableStringify differentiates Map entries from sentinel-style literal strings",
+  () => {
+    const baseLiteral = "__string__:foo";
+    const suffix = "__string__:\u0000cat32:map-entry-index:1\u0000";
+
+    const duplicateLike = new Map<unknown, string>([
+      [createNonEnumerableToStringObject(baseLiteral), "a"],
+      [createNonEnumerableToStringObject(baseLiteral), "b"],
+    ]);
+
+    const sentinelLike = new Map<unknown, string>([
+      [createNonEnumerableToStringObject(baseLiteral), "a"],
+      [
+        createNonEnumerableToStringObject(`${baseLiteral}${suffix}`),
+        "b",
+      ],
+    ]);
+
+    assert.ok(stableStringify(duplicateLike) !== stableStringify(sentinelLike));
+  },
+);
+
+test(
+  "Cat32 assign differentiates Map entries from sentinel-style literal strings",
+  () => {
+    const baseLiteral = "__string__:foo";
+    const suffix = "__string__:\u0000cat32:map-entry-index:1\u0000";
+
+    const duplicateLike = new Map<unknown, string>([
+      [createNonEnumerableToStringObject(baseLiteral), "a"],
+      [createNonEnumerableToStringObject(baseLiteral), "b"],
+    ]);
+
+    const sentinelLike = new Map<unknown, string>([
+      [createNonEnumerableToStringObject(baseLiteral), "a"],
+      [
+        createNonEnumerableToStringObject(`${baseLiteral}${suffix}`),
+        "b",
+      ],
+    ]);
+
+    const categorizer = new Cat32();
+    const duplicateAssignment = categorizer.assign(duplicateLike);
+    const sentinelAssignment = categorizer.assign(sentinelLike);
+
+    assert.ok(duplicateAssignment.key !== sentinelAssignment.key);
+    assert.ok(duplicateAssignment.hash !== sentinelAssignment.hash);
+  },
+);
+
 test("Map serialization differentiates duplicate-like object entries", () => {
   const withDuplicates = new Map<unknown, string>([
     [{}, "a"],


### PR DESCRIPTION
## Summary
- add regression tests covering map-entry collisions caused by sentinel-like string literals
- ensure map serialization dedupes map entry indexes using a dedicated sentinel payload per entry
- update sentinel-escape detection to cover raw map-entry sentinel strings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f69b6a86308321bc2b37cb84e74a4d