### PR TITLE
Fix map entry sentinel string collisions

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -421,6 +421,9 @@ function stringifyStringLiteral(value: string): string {
 
 function normalizeStringLiteral(value: string): string {
   if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
+    if (needsStringLiteralSentinelEscape(value)) {
+      return `${STRING_LITERAL_SENTINEL_PREFIX}${value}`;
+    }
     return value;
   }
 

--- a/tests/stable-stringify-typed-array.test.ts
+++ b/tests/stable-stringify-typed-array.test.ts
@@ -112,3 +112,30 @@ test("Cat32 assign distinguishes Map with typed array key from serialized key", 
   assert.ok(typedAssignment.key !== stringAssignment.key);
   assert.ok(typedAssignment.hash !== stringAssignment.hash);
 });
+
+test(
+  "Cat32 assign distinguishes Map typed array key collision with sentinel string",
+  () => {
+    const cat = new Cat32();
+    const first = new Uint8Array([12, 13]);
+    const second = new Uint8Array([12, 13]);
+    const mapWithTypedKeys = new Map<unknown, number>([
+      [first, 1],
+      [second, 2],
+    ]);
+
+    const sentinelLiteral = JSON.parse(stableStringify(second));
+    const mapEntryIndexSentinel = "\u0000cat32:map-entry-index:1\u0000";
+    const collisionString = `__string__:${sentinelLiteral}${mapEntryIndexSentinel}`;
+    const mapWithCollisionString = new Map<unknown, number>([
+      [first, 1],
+      [collisionString, 2],
+    ]);
+
+    const typedAssignment = cat.assign(mapWithTypedKeys);
+    const stringAssignment = cat.assign(mapWithCollisionString);
+
+    assert.ok(typedAssignment.key !== stringAssignment.key);
+    assert.ok(typedAssignment.hash !== stringAssignment.hash);
+  },
+);


### PR DESCRIPTION
## Summary
- add a regression test covering maps whose typed array key collides with a sentinel string literal
- ensure normalizeStringLiteral re-escapes strings that already start with the string sentinel prefix when they contain sentinel fragments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f73c98c32c83218f909e7de11865a7