### PR TITLE
Ensure unique salt namespace encoding

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,7 +140,7 @@ async function main() {
   }
   const key = args._;
   const salt = typeof args.salt === "string" ? args.salt : "";
-  const namespace = typeof args.namespace === "string" ? args.namespace : "";
+  const namespace = typeof args.namespace === "string" ? args.namespace : undefined;
   const normalize = parseNormalizeOption(
     typeof args.normalize === "string" ? args.normalize : undefined,
   );

--- a/tests/test_vectors.test.ts
+++ b/tests/test_vectors.test.ts
@@ -187,16 +187,14 @@ function deriveSaltedKey(
   options?: Pick<CategorizerOptions, "salt" | "namespace">,
 ): string {
   const baseSalt = options?.salt ?? "";
-  const namespaceValue =
-    options?.namespace !== undefined && options.namespace !== ""
-      ? options.namespace
-      : undefined;
+  const namespaceValue = options?.namespace;
+  const hasNamespace = namespaceValue !== undefined;
 
-  if (!baseSalt && namespaceValue === undefined) {
+  if (!baseSalt && !hasNamespace) {
     return key;
   }
 
-  if (namespaceValue === undefined) {
+  if (!hasNamespace) {
     return `${key}|salt:${baseSalt}`;
   }
 


### PR DESCRIPTION
## Summary
- add regression coverage ensuring unique canonical key/hash pairs for salt and namespace combinations
- precompute a salt/namespace suffix and allow empty namespaces while keeping default behavior unchanged
- avoid passing an empty namespace from the CLI when the flag is omitted and align test vectors with the new encoding

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f7542b8ccc83218b7fa6bf1ec9d0ad