### PR TITLE
Fix canonical keys for global/local symbol containers

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -589,11 +589,10 @@ function reviveSentinelValue(value: unknown): unknown {
 
 function toSymbolSentinel(symbol: symbol): string {
   const globalKey = typeof Symbol.keyFor === "function" ? Symbol.keyFor(symbol) : undefined;
-  if (globalKey !== undefined) {
-    return `${SYMBOL_SENTINEL_PREFIX}global:${globalKey}`;
-  }
-  const description = symbol.description;
-  return `${SYMBOL_SENTINEL_PREFIX}local:${description ?? ""}`;
+  const scope = globalKey !== undefined ? "global" : "local";
+  const identifier = globalKey ?? symbol.description ?? "";
+  const payload = JSON.stringify([scope, identifier]);
+  return `${SYMBOL_SENTINEL_PREFIX}${payload}`;
 }
 
 function toPropertyKeyString(


### PR DESCRIPTION
## Summary
- add a regression test to ensure Cat32 assigns distinct canonical keys/hashes for maps and objects keyed by global vs local symbols
- encode the symbol scope in the sentinel payload so global and local symbols no longer collide

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f7e33d44cc832181129ea553c01373