### PR TITLE
Fix property key sentinel collisions for Map primitive keys

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -609,7 +609,7 @@ function toPropertyKeyString(
   }
 
   if (rawKey === null) {
-    return "null";
+    return buildPropertyKeySentinel(rawKey, serializedKey);
   }
 
   if (rawKey instanceof Date) {
@@ -658,14 +658,7 @@ function toPropertyKeyString(
     rawType === "boolean" ||
     rawType === "undefined"
   ) {
-    const stringifiedPrimitive = String(
-      rawKey as number | bigint | boolean | undefined,
-    );
-    return buildPropertyKeySentinel(
-      rawKey,
-      serializedKey,
-      stringifiedPrimitive,
-    );
+    return buildPropertyKeySentinel(rawKey, serializedKey);
   }
 
   if (rawType === "object" || rawType === "function") {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -1979,6 +1979,66 @@ test("Map collisions with identical property keys produce deterministic output",
   assert.equal(forwardAssignment.hash, reverseAssignment.hash);
 });
 
+test(
+  "Map numeric keys remain distinct from string keys in canonical form",
+  () => {
+    const c = new Cat32();
+    const mixedKeyMap = new Map<unknown, string>([
+      [1, "number"],
+      ["1", "string"],
+    ]);
+
+    const assignment = c.assign(mixedKeyMap);
+    const serialized = stableStringify(mixedKeyMap);
+
+    assert.ok(
+      serialized.includes("\\u0000cat32:propertykey:"),
+      "stableStringify should encode property key sentinel for numeric Map keys",
+    );
+    assert.ok(
+      assignment.key.includes("\\u0000cat32:propertykey:"),
+      "Cat32 canonical key should encode property key sentinel for numeric Map keys",
+    );
+
+    const stringOnlyAssignment = c.assign(
+      new Map<string, string>([["1", "string"]]),
+    );
+
+    assert.ok(assignment.key !== stringOnlyAssignment.key);
+    assert.ok(assignment.hash !== stringOnlyAssignment.hash);
+  },
+);
+
+test(
+  "Map bigint keys remain distinct from string keys in canonical form",
+  () => {
+    const c = new Cat32();
+    const mixedKeyMap = new Map<unknown, string>([
+      [1n, "bigint"],
+      ["1", "string"],
+    ]);
+
+    const assignment = c.assign(mixedKeyMap);
+    const serialized = stableStringify(mixedKeyMap);
+
+    assert.ok(
+      serialized.includes("\\u0000cat32:propertykey:"),
+      "stableStringify should encode property key sentinel for bigint Map keys",
+    );
+    assert.ok(
+      assignment.key.includes("\\u0000cat32:propertykey:"),
+      "Cat32 canonical key should encode property key sentinel for bigint Map keys",
+    );
+
+    const stringOnlyAssignment = c.assign(
+      new Map<string, string>([["1", "string"]]),
+    );
+
+    assert.ok(assignment.key !== stringOnlyAssignment.key);
+    assert.ok(assignment.hash !== stringOnlyAssignment.hash);
+  },
+);
+
 test("Map values serialize identically to plain object values", () => {
   const c = new Cat32();
   const fn = function foo() {};


### PR DESCRIPTION
## Summary
- add regression coverage ensuring Map number and bigint keys keep distinct canonical identifiers from string keys
- normalize primitive Map property keys to dedicated sentinels to prevent collisions with string keys

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f7e33cb1548321b437d496aaacb583