### PR TITLE
Fix Date sentinel collisions with prefixed string literals

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -428,6 +428,16 @@ function normalizeStringLiteral(value: string): string {
     if (needsStringLiteralSentinelEscape(value)) {
       return `${STRING_LITERAL_SENTINEL_PREFIX}${value}`;
     }
+
+    let innerValue = value.slice(STRING_LITERAL_SENTINEL_PREFIX.length);
+    while (innerValue.startsWith(STRING_LITERAL_SENTINEL_PREFIX)) {
+      innerValue = innerValue.slice(STRING_LITERAL_SENTINEL_PREFIX.length);
+    }
+
+    if (needsNestedStringLiteralSentinelEscape(innerValue)) {
+      return `${STRING_LITERAL_SENTINEL_PREFIX}${value}`;
+    }
+
     return value;
   }
 
@@ -436,6 +446,10 @@ function normalizeStringLiteral(value: string): string {
   }
 
   return value;
+}
+
+function needsNestedStringLiteralSentinelEscape(value: string): boolean {
+  return value.startsWith(DATE_SENTINEL_PREFIX);
 }
 
 function hasArrayBufferLikeSentinelPrefix(value: string): boolean {

--- a/tests/serialize-map-date.test.ts
+++ b/tests/serialize-map-date.test.ts
@@ -57,3 +57,20 @@ test("Cat32.assign uses invalid sentinel for Map invalid Date keys", () => {
   assert.equal(assignment.key, serialized);
   assert.deepEqual(JSON.parse(assignment.key), { [expectedKey]: "v" });
 });
+
+test("Map Date key canonical key differs from __string__ Date sentinel", () => {
+  const date = new Date("2020-01-01T00:00:00Z");
+  const dateMap = new Map([[date, 1]]);
+  const stringKey = `__string__:__date__:${date.toISOString()}`;
+  const stringMap = new Map([[stringKey, 1]]);
+
+  const cat = new Cat32();
+  const dateAssignment = cat.assign(dateMap);
+  const stringAssignment = cat.assign(stringMap);
+
+  assert.ok(dateAssignment.key !== stringAssignment.key);
+  assert.ok(dateAssignment.hash !== stringAssignment.hash);
+  assert.deepEqual(JSON.parse(stringAssignment.key), {
+    [`__string__:${stringKey}`]: 1,
+  });
+});


### PR DESCRIPTION
## Summary
- add regression coverage ensuring Map Date keys and prefixed Date sentinel strings yield distinct canonical keys and hashes
- tighten string literal normalization so nested Date sentinel payloads receive an extra escape to avoid collisions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f7ebe38d8c83219eb0e22b234b0312