### PR TITLE
Fix Map null key collisions

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -380,6 +380,15 @@ function mapBucketTypeTag(rawKey: unknown): string {
   return typeof rawKey;
 }
 
+const NULL_PROPERTY_KEY_SENTINEL_BUCKET_TAG = mapBucketTypeTag(null);
+
+function buildNullPropertyKeySentinel(serializedKey: string): string {
+  return typeSentinel(
+    PROPERTY_KEY_SENTINEL_TYPE,
+    JSON.stringify([NULL_PROPERTY_KEY_SENTINEL_BUCKET_TAG, serializedKey]),
+  );
+}
+
 function buildPropertyKeySentinel(
   rawKey: unknown,
   serializedKey: string,
@@ -608,7 +617,7 @@ function toPropertyKeyString(
   }
 
   if (rawKey === null) {
-    return buildPropertyKeySentinel(rawKey, serializedKey);
+    return buildNullPropertyKeySentinel(serializedKey);
   }
 
   if (rawKey instanceof Date) {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -670,6 +670,32 @@ test(
   },
 );
 
+test("Map null key remains distinct from string 'null' key", () => {
+  const c = new Cat32();
+  const mapWithNullKey = new Map<unknown, string>([[null, "a"]]);
+  const mapWithStringKey = new Map<string, string>([["null", "a"]]);
+
+  const nullAssignment = c.assign(mapWithNullKey);
+  const stringAssignment = c.assign(mapWithStringKey);
+
+  assert.ok(
+    nullAssignment.key !== stringAssignment.key,
+    'Cat32 canonical key should differ for null and "null" Map keys',
+  );
+  assert.ok(
+    nullAssignment.hash !== stringAssignment.hash,
+    'Cat32 hash should differ for null and "null" Map keys',
+  );
+
+  const nullSerialized = stableStringify(mapWithNullKey);
+  const stringSerialized = stableStringify(mapWithStringKey);
+
+  assert.ok(
+    nullSerialized !== stringSerialized,
+    'stableStringify should distinguish null and "null" Map keys',
+  );
+});
+
 test(
   "Cat32 assign differentiates Map object keys from sentinel-style string keys",
   () => {


### PR DESCRIPTION
## Summary
- ensure Map null keys build a dedicated property key sentinel instead of colliding with string keys
- add a regression test covering the null vs "null" Map key scenario to guard against future regressions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f7ec0076d88321b8864435e89da49b