### PR TITLE
Add diagnostics for duplicate symbol map regression test

### DIFF
--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -785,11 +785,26 @@ test(
       [right, "left"],
     ]);
 
-    assert.ok(stableStringify(original) !== stableStringify(swapped));
+    const originalStable = stableStringify(original);
+    const swappedStable = stableStringify(swapped);
+    assert.ok(originalStable !== swappedStable);
 
     const cat = new Cat32();
     const originalAssignment = cat.assign(original);
     const swappedAssignment = cat.assign(swapped);
+
+    console.log(
+      JSON.stringify(
+        {
+          originalKey: originalAssignment.key,
+          swappedKey: swappedAssignment.key,
+          originalStable,
+          swappedStable,
+        },
+        null,
+        2,
+      ),
+    );
 
     assert.ok(originalAssignment.key !== swappedAssignment.key);
   },


### PR DESCRIPTION
## Summary
- log the Cat32/stableStringify outputs for the duplicate Symbol map regression test to aid manual inspection

## Testing
- npm run test *(fails: dist/tests/categorizer.test.js currently reports ERR_ASSERTION)*

------
https://chatgpt.com/codex/tasks/task_e_68f7f6efc75c8321b41184ebfe14e6b1