### PR TITLE
Ensure stable stringify distinguishes sets

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -35,6 +35,7 @@ const STRING_LITERAL_ESCAPED_SENTINEL_TYPES = new Set<string>([
   "bigint",
   "hole",
   PROPERTY_KEY_SENTINEL_TYPE,
+  "set",
 ]);
 const ARRAY_BUFFER_LIKE_SENTINEL_PREFIXES = [
   `${SENTINEL_PREFIX}typedarray:`,
@@ -313,7 +314,8 @@ function _stringify(v: unknown, stack: Set<unknown>): string {
       return 0;
     });
     const body = entries.map((entry) => entry.serializedValue);
-    const out = "[" + body.join(",") + "]";
+    const payload = "[" + body.join(",") + "]";
+    const out = stringifySentinelLiteral(typeSentinel("set", payload));
     stack.delete(v);
     return out;
   }

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -2492,15 +2492,15 @@ test("map payload remains distinct from plain object with numeric keys", () => {
   );
 });
 
-test("set serialization matches array entries regardless of insertion order", () => {
+test("set serialization matches across insertion order but differs from arrays", () => {
   const c = new Cat32();
   const values = [1, 2, 3];
 
   const setAssignment = c.assign(new Set(values));
   const arrayAssignment = c.assign([...values]);
 
-  assert.equal(setAssignment.key, arrayAssignment.key);
-  assert.equal(setAssignment.hash, arrayAssignment.hash);
+  assert.ok(setAssignment.key !== arrayAssignment.key);
+  assert.ok(setAssignment.hash !== arrayAssignment.hash);
 
   const reorderedSetAssignment = c.assign(new Set([...values].reverse()));
 

--- a/tests/stable-stringify-set.test.ts
+++ b/tests/stable-stringify-set.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { Cat32, stableStringify } from "../src/index.js";
+
+test("Set は同内容の配列と異なる canonical key を生成する", () => {
+  const cat = new Cat32();
+  const entries = ["a", 1, { nested: true }];
+
+  const arrayAssignment = cat.assign(entries);
+  const setAssignment = cat.assign(new Set(entries));
+
+  assert.ok(
+    setAssignment.key !== arrayAssignment.key,
+    "Set と配列は異なる canonical key であるべき",
+  );
+
+  assert.ok(
+    stableStringify(new Set(entries)) !== stableStringify(entries),
+    "stableStringify も Set と配列で差分が必要",
+  );
+});


### PR DESCRIPTION
## Summary
- add a regression test covering Cat32 assign/stableStringify differences between Set values and arrays
- encode Set serialization with a dedicated sentinel payload so it no longer matches the array encoding
- refresh the categorizer test to expect array vs Set differences while keeping order-invariant Set keys

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f805f6b59c8321a97ec5cd6ffe0ed8