### PR TITLE
Update docs for TypedArray sentinel serialization

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -38,7 +38,13 @@ input (unknown)
   - **循環参照**を検出したら **`TypeError("Cyclic object")`** を投げる。
 - 実装ノート:
   - JSON表現は**ASCIIエスケープ不要**（UTF‑8運用を前提）。
-  - TypedArray/ArrayBuffer等は**`String(v)`** か実装外とし、必要なら将来の拡張（`namespace`切替）で対応。
+  - **TypedArray**: `"\u0000cat32:typedarray:kind=<ViewName>;byteOffset=<n>;byteLength=<n>;length=<len?>;hex=<bytes>\u0000"`
+    - `length` パラメータは `view.length` が存在する場合のみ付与。
+    - バイト列は **16進小文字** (`00`-`ff`) で連結し、センチネル末尾 `\u0000` を付ける。
+  - **ArrayBuffer**: `"\u0000cat32:arraybuffer:byteLength=<n>;hex=<bytes>\u0000"`
+  - **SharedArrayBuffer**: `"\u0000cat32:sharedarraybuffer:byteLength=<n>;hex=<bytes>\u0000"`
+    - ArrayBuffer/SharedArrayBuffer の各バイトも TypedArray と同様に 16進列へ変換。
+  - 上記センチネル文字列は `stableStringify` が JSON 文字列として返し、`JSON.parse` するとセンチネル本体を得る。
 
 ## 5. ハッシュ（FNV‑1a 32-bit）
 - 定数: `offset = 0x811C9DC5`、`prime = 0x01000193`。

--- a/docs/TEST_VECTORS.md
+++ b/docs/TEST_VECTORS.md
@@ -59,3 +59,17 @@ FNV-1a32 over UTF-8 for salted key `{"id":123,"tags":["a","b"]}|saltns:["projX",
 - index = `23`
 
 **Note:** Different key order → same canonical string → same hash/index.
+
+### Sentinel examples (TypedArray / ArrayBuffer)
+
+```
+stableStringify(new Uint8Array([1, 2, 3]))
+→ "\"\\u0000cat32:typedarray:kind=Uint8Array;byteOffset=0;byteLength=3;length=3;hex=010203\\u0000\""
+
+stableStringify(new ArrayBuffer(2))
+→ "\"\\u0000cat32:arraybuffer:byteLength=2;hex=0000\\u0000\""
+
+// SharedArrayBuffer はランタイムがサポートしている場合に限り利用可能。
+stableStringify(new SharedArrayBuffer(2))
+→ "\"\\u0000cat32:sharedarraybuffer:byteLength=2;hex=0000\\u0000\""
+```


### PR DESCRIPTION
## Summary
- document stableStringify's sentinel serialization for TypedArray, ArrayBuffer, and SharedArrayBuffer in the spec
- add reference examples for TypedArray and ArrayBuffer sentinel outputs to the test vectors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f805dba29883219fdd9225f0032c0b