### PR TITLE
Add success metadata assertions for refresh queue store

### DIFF
--- a/frontend/tests/sw/refresh-queue-store.test.ts
+++ b/frontend/tests/sw/refresh-queue-store.test.ts
@@ -205,6 +205,16 @@ test("retryQueueEntry resolves with attempt result and removes entry on success"
       recordDuringAttempt.lastAttemptedAt instanceof Date,
       "recordAttempt should set lastAttemptedAt before attempt resolves",
     );
+    assert.equal(
+      recordDuringAttempt.lastError,
+      undefined,
+      "recordFailure metadata should not be set during successful attempt",
+    );
+    assert.equal(
+      recordDuringAttempt.failedAt,
+      undefined,
+      "recordFailure timestamp should remain unset during successful attempt",
+    );
     return attemptResult;
   });
 


### PR DESCRIPTION
## Summary
- ensure the refresh queue success path confirms failure metadata remains unset
- continue to verify attempt counters and timestamp updates during a successful retry

## Testing
- npm run test -- frontend/tests/sw/refresh-queue-store.test.ts *(fails: TypeScript compilation error in src/serialize.ts unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f81762c4c08321b09213a03940ec58