### PR TITLE
Update documentation for stableStringify sentinel encoding

### DIFF
--- a/docs/TEST_VECTORS.md
+++ b/docs/TEST_VECTORS.md
@@ -72,4 +72,9 @@ stableStringify(new ArrayBuffer(2))
 // SharedArrayBuffer はランタイムがサポートしている場合に限り利用可能。
 stableStringify(new SharedArrayBuffer(2))
 → "\"\\u0000cat32:sharedarraybuffer:byteLength=2;hex=0000\\u0000\""
+
+// センチネル文字列そのものを渡した場合は __string__: プレフィックスでエスケープされる。
+const sentinel = "\u0000cat32:number:NaN\u0000";
+stableStringify(sentinel)
+→ "\"__string__:\\u0000cat32:number:NaN\\u0000\""
 ```


### PR DESCRIPTION
## Summary
- describe how stableStringify escapes sentinel collisions and encodes symbols
- document Map/Set key normalization with typeSentinel-based buckets
- add a test vector example for __string__ escaping of sentinel literals

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f81762bde8832191f2794d0c6ec490