### PR TITLE
Fix refresh queue timestamping and speed up symbol sentinel generation

### DIFF
--- a/frontend/src/sw/refreshQueueStore.ts
+++ b/frontend/src/sw/refreshQueueStore.ts
@@ -42,7 +42,8 @@ export const createRefreshQueueStore = (): RefreshQueueStore => {
       return;
     }
     record.attempts += 1;
-    record.lastAttemptedAt = new Date();
+    const now = Date.now();
+    record.lastAttemptedAt = new Date(now);
   };
 
   const recordFailure = (id: string, error: unknown): void => {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -67,7 +67,8 @@ function getLocalSymbolSentinelRecord(
   const identifier = nextLocalSymbolSentinelId.toString(36);
   nextLocalSymbolSentinelId += 1;
   const description = symbol.description ?? "";
-  const payload = JSON.stringify(["local", identifier, description]);
+  const descriptionJson = JSON.stringify(description);
+  const payload = `["local","${identifier}",${descriptionJson}]`;
   const sentinel = `${SYMBOL_SENTINEL_PREFIX}${payload}`;
 
   const record: LocalSymbolSentinelRecord = { identifier, sentinel };


### PR DESCRIPTION
## Summary
- ensure refresh queue attempt metadata records the mocked Date.now value
- optimize local symbol sentinel payload construction to avoid unnecessary JSON serialization

## Testing
- npm run build
- node --test dist/frontend/tests/sw/refreshQueueStore.test.js
- node --test dist/tests/stable-stringify-string-collisions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f81bf96f9c8321903f0c3d84d788d4