### PR TITLE
Refine local symbol sentinel registry caching

### DIFF
--- a/tests/serialize/symbol-registry.test.ts
+++ b/tests/serialize/symbol-registry.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  stableStringify,
+} from "../../src/index.js";
+import {
+  __getLocalSymbolSentinelRecordForTest,
+  __peekLocalSymbolSentinelRecordForTest,
+} from "../../src/serialize.js";
+
+test("ローカルシンボルのセンチネルレコードがキャッシュされる", () => {
+  const local = Symbol("local sentinel");
+
+  assert.equal(
+    __peekLocalSymbolSentinelRecordForTest(local),
+    undefined,
+    "登録前はレコードが存在しない", 
+  );
+
+  const firstRecord = __getLocalSymbolSentinelRecordForTest(local);
+
+  assert.equal(typeof firstRecord.identifier, "string");
+  assert.ok(firstRecord.identifier.length > 0);
+  assert.equal(typeof firstRecord.sentinel, "string");
+
+  const peekedRecord = __peekLocalSymbolSentinelRecordForTest(local);
+  assert.equal(peekedRecord, firstRecord);
+
+  const secondRecord = __getLocalSymbolSentinelRecordForTest(local);
+  assert.equal(secondRecord, firstRecord);
+
+  const sentinelFromRecord = firstRecord.sentinel;
+  const sentinelFromStringify = JSON.parse(stableStringify(local));
+  assert.equal(sentinelFromStringify, sentinelFromRecord);
+
+  const sentinelFromStringifyAgain = JSON.parse(stableStringify(local));
+  assert.equal(sentinelFromStringifyAgain, sentinelFromRecord);
+});


### PR DESCRIPTION
## Summary
- update local symbol sentinel registry helpers to cache full records and expose test-only accessors
- ensure symbol bucket/sort keys reuse cached identifiers instead of recreating entries
- add a regression test covering local symbol sentinel caching behaviour and sentinel stability

## Testing
- npm run test *(fails: CLI newline assertions in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68f81dfd2a5483219b2cdb6bfc554b03