### PR TITLE
Validate optional --json values

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,12 +87,9 @@ function parseArgs(argv: string[]): ParsedArgs {
         }
 
         const next = argv[i + 1];
-        const hasNextToken = next !== undefined && next !== "--" && !next.startsWith("--");
-        const nextIsAllowedValue =
-          hasNextToken &&
-          (spec.allowedValues === undefined || spec.allowedValues.includes(next));
 
-        if (nextIsAllowedValue) {
+        if (next !== undefined && next !== "--" && !next.startsWith("--")) {
+          assertAllowedFlagValue(key, next, spec.allowedValues);
           args[key] = next;
           i += 1;
         } else {

--- a/tests/cli-help.test.ts
+++ b/tests/cli-help.test.ts
@@ -36,6 +36,51 @@ const CAT32_BIN = import.meta.url.includes("/dist/tests/")
   ? new URL("../cli.js", import.meta.url).pathname
   : new URL("../dist/cli.js", import.meta.url).pathname;
 
+test("cat32 --json invalid reports an error", async () => {
+  const { spawn } = (await dynamicImport("node:child_process")) as {
+    spawn: SpawnFunction;
+  };
+
+  const child = spawn(
+    process.argv[0],
+    [CAT32_BIN, "--json", "invalid", "sample"],
+    {
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdoutChunks.push(chunk);
+  });
+
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderrChunks.push(chunk);
+  });
+
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (signal !== null) {
+        reject(new Error(`terminated by signal ${signal}`));
+        return;
+      }
+      resolve(code ?? -1);
+    });
+  });
+
+  assert.equal(stdoutChunks.join(""), "");
+  assert.equal(exitCode, 2);
+  assert.ok(
+    stderrChunks.join("").includes('RangeError: unsupported --json value "invalid"'),
+    "stderr should report unsupported --json value",
+  );
+});
+
 const HELP_OUTPUT = [
   "Usage: cat32 [options] [input]",
   "",


### PR DESCRIPTION
## Summary
- ensure parseArgs treats the next token for optional-value flags as a candidate and raises RangeError when unsupported
- add regression coverage for `cat32 --json invalid` and update CLI integration tests to expect the error behaviour

## Testing
- npm run test *(fails: tty-based CLI newline assertions and stable stringify perf guardrails already failing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8226a61188321ad0a2a9418edfb76