### PR TITLE
Fix local symbol sentinel reuse

### DIFF
--- a/frontend/tests/sw/refresh-queue-store.test.ts
+++ b/frontend/tests/sw/refresh-queue-store.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { rejects } from "node:assert/promises";
 import test from "node:test";
 
 import { createRefreshQueueStore } from "../../src/sw/refreshQueueStore.js";
@@ -8,6 +7,14 @@ import { retryQueueEntry } from "../../src/sw.js";
 
 type RequestConstructor = new (input: string | URL, init?: RequestInit) => Request;
 type HeadersInput = RequestInit["headers"] | Iterable<readonly [string, string]>;
+
+const assertRejects = (assert as unknown as {
+  rejects: (
+    block: () => Promise<unknown> | unknown,
+    error?: unknown,
+    message?: string,
+  ) => Promise<void>;
+}).rejects;
 
 const normalizeBody = (body: unknown): string => {
   if (typeof body === "string") {
@@ -198,7 +205,7 @@ test("retryQueueEntry throws when record is missing", async () => {
     },
   };
 
-  await rejects(async () => {
+  await assertRejects(async () => {
     await retryQueueEntry(store, recordId, async () => {
       attemptInvocations += 1;
       return undefined;

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -67,7 +67,7 @@ function getLocalSymbolSentinelRecord(
   symbol: symbol,
 ): LocalSymbolSentinelRecord {
   const symbolObject = toSymbolObject(symbol);
-  const existing = peekLocalSymbolSentinelRecord(symbol);
+  const existing = LOCAL_SYMBOL_SENTINEL_REGISTRY.get(symbolObject);
   if (existing !== undefined) {
     return existing;
   }


### PR DESCRIPTION
## Summary
- reuse the cached symbol object when fetching local symbol sentinel records to avoid duplicate declarations
- update the refresh queue store test to rely on assert.rejects via a locally typed helper instead of node:assert/promises

## Testing
- npm run build
- npm run test *(fails: CLI stdin newline assertions expect trimmed output in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f82f7162f88321b80a622f334752c9