### PR TITLE
Remove unused local symbol identifier helper

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -94,10 +94,6 @@ function getLocalSymbolSentinelRecord(
   return record;
 }
 
-function getLocalSymbolSentinelIdentifier(symbol: symbol): string {
-  return getLocalSymbolSentinelRecord(symbol).identifier;
-}
-
 function buildLocalSymbolSentinel(
   identifier: string,
   description: string,


### PR DESCRIPTION
## Summary
- remove the unused getLocalSymbolSentinelIdentifier helper from src/serialize.ts
- keep the serialization helpers limited to the functions that are consumed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f832a1b4148321833a69a616d5a75d