### PR TITLE
Add regression test for local symbol map serialization

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -56,18 +56,24 @@ function toSymbolObject(symbol: symbol): SymbolObject {
   return symbol as SymbolObject;
 }
 
+function peekLocalSymbolSentinelRecordFromObject(
+  symbolObject: SymbolObject,
+): LocalSymbolSentinelRecord | undefined {
+  return LOCAL_SYMBOL_SENTINEL_REGISTRY.get(symbolObject);
+}
+
 function peekLocalSymbolSentinelRecord(
   symbol: symbol,
 ): LocalSymbolSentinelRecord | undefined {
   const symbolObject = toSymbolObject(symbol);
-  return LOCAL_SYMBOL_SENTINEL_REGISTRY.get(symbolObject);
+  return peekLocalSymbolSentinelRecordFromObject(symbolObject);
 }
 
 function getLocalSymbolSentinelRecord(
   symbol: symbol,
 ): LocalSymbolSentinelRecord {
   const symbolObject = toSymbolObject(symbol);
-  const existing = peekLocalSymbolSentinelRecord(symbol);
+  const existing = peekLocalSymbolSentinelRecordFromObject(symbolObject);
   if (existing !== undefined) {
     return existing;
   }

--- a/tests/serialize-symbol.test.ts
+++ b/tests/serialize-symbol.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { stableStringify } from "../src/serialize.js";
+
+const MAP_SENTINEL_PREFIX = "\u0000cat32:map:";
+const MAP_ENTRY_INDEX_SENTINEL_PREFIX = "\u0000cat32:map-entry-index:";
+const SENTINEL_SUFFIX = "\u0000";
+
+type MapSentinelEntries = Array<[string, string]>;
+type MapEntryIndexPayload = [string, string, number];
+
+function decodeMapSentinel(serialized: string): MapSentinelEntries {
+  const sentinel = JSON.parse(serialized);
+  assert.equal(typeof sentinel, "string");
+  assert.ok(
+    sentinel.startsWith(MAP_SENTINEL_PREFIX) &&
+      sentinel.endsWith(SENTINEL_SUFFIX),
+  );
+  const payload = sentinel.slice(
+    MAP_SENTINEL_PREFIX.length,
+    -SENTINEL_SUFFIX.length,
+  );
+  return JSON.parse(payload) as MapSentinelEntries;
+}
+
+function decodeMapEntryPropertyKey(propertyKey: string): string {
+  if (
+    propertyKey.startsWith(MAP_ENTRY_INDEX_SENTINEL_PREFIX) &&
+    propertyKey.endsWith(SENTINEL_SUFFIX)
+  ) {
+    const payload = propertyKey.slice(
+      MAP_ENTRY_INDEX_SENTINEL_PREFIX.length,
+      -SENTINEL_SUFFIX.length,
+    );
+    const [, symbolSentinel, index] = JSON.parse(
+      payload,
+    ) as MapEntryIndexPayload;
+    assert.equal(index, 0);
+    return symbolSentinel;
+  }
+  return propertyKey;
+}
+
+test(
+  "stableStringify handles local symbol sentinel reuse for map keys",
+  () => {
+    const localSymbol = Symbol("map-key");
+    const symbolSerialized = stableStringify(localSymbol);
+    const symbolSentinel = JSON.parse(symbolSerialized);
+
+    assert.equal(typeof symbolSentinel, "string");
+    assert.ok(symbolSentinel.startsWith("__symbol__:"));
+
+    const map = new Map([[localSymbol, "value"]]);
+    const mapSerialized = stableStringify(map);
+    const entries = decodeMapSentinel(mapSerialized);
+
+    assert.equal(entries.length, 1);
+    const [propertyKey, valueSerialized] = entries[0]!;
+
+    assert.equal(
+      decodeMapEntryPropertyKey(propertyKey),
+      symbolSentinel,
+    );
+    assert.equal(JSON.parse(valueSerialized), "value");
+    assert.equal(stableStringify(localSymbol), symbolSerialized);
+  },
+);

--- a/types/node-assert-promises/index.d.ts
+++ b/types/node-assert-promises/index.d.ts
@@ -1,0 +1,10 @@
+declare module "node:assert/promises" {
+  export function rejects(
+    value: unknown,
+    message?: string | Error | ((error: unknown) => boolean),
+  ): Promise<void>;
+  export function doesNotReject(
+    value: unknown,
+    message?: string | Error | ((error: unknown) => boolean),
+  ): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- add a regression test covering local symbol serialization and map property key reuse
- stub the node:assert/promises module so TypeScript can compile frontend tests
- refactor the local symbol sentinel registry helpers to avoid duplicate WeakMap lookups

## Testing
- npm run build
- npm run test *(fails: ERR_UNKNOWN_BUILTIN_MODULE: node:assert/promises)*

------
https://chatgpt.com/codex/tasks/task_e_68f82f94f1fc8321aeeefe45302273fc