### PR TITLE
Ensure nested sentinel string literals remain distinct

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -598,6 +598,9 @@ function normalizeStringLiteral(value: string): string {
     }
 
     if (needsNestedStringLiteralSentinelEscape(innerValue)) {
+      if (value.startsWith(STRING_LITERAL_SENTINEL_PREFIX.repeat(2))) {
+        return value;
+      }
       return `${STRING_LITERAL_SENTINEL_PREFIX}${value}`;
     }
 
@@ -612,7 +615,10 @@ function normalizeStringLiteral(value: string): string {
 }
 
 function needsNestedStringLiteralSentinelEscape(value: string): boolean {
-  return value.startsWith(DATE_SENTINEL_PREFIX);
+  if (needsStringLiteralSentinelEscape(value)) {
+    return true;
+  }
+  return value.startsWith(STRING_LITERAL_SENTINEL_PREFIX);
 }
 
 function hasArrayBufferLikeSentinelPrefix(value: string): boolean {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -205,7 +205,7 @@ test(
     const prefixedLiteral = "__string__:" + typeSentinel("number", "NaN");
     assert.equal(
       distStableStringify(prefixedLiteral),
-      JSON.stringify(prefixedLiteral),
+      JSON.stringify(`__string__:${prefixedLiteral}`),
     );
     assert.ok(
       distStableStringify(prefixedLiteral) !== distStableStringify(NaN),
@@ -226,14 +226,17 @@ test(
     const sentinelStringLiteral = `__string__:${typeSentinel("number", "NaN")}`;
     assert.equal(
       stableStringify(sentinelStringLiteral),
-      JSON.stringify(sentinelStringLiteral),
+      JSON.stringify(`__string__:${sentinelStringLiteral}`),
     );
   },
 );
 
 test("stableStringify preserves prefixed sentinel string literal content", () => {
   const value = "__string__:" + typeSentinel("number", "NaN");
-  assert.equal(stableStringify(value), JSON.stringify(value));
+  assert.equal(
+    stableStringify(value),
+    JSON.stringify(`__string__:${value}`),
+  );
 });
 
 test("global and local symbols remain distinguishable", () => {
@@ -352,7 +355,15 @@ test(
     const holeSentinelResult = stableStringify([holeSentinelLiteral]);
     const sparseResult = stableStringify(sparseArray);
 
-    assert.equal(prefixedResult, sentinelResult);
+    assert.equal(
+      prefixedResult,
+      JSON.stringify([`__string__:${prefixedLiteral}`]),
+    );
+    assert.equal(
+      sentinelResult,
+      JSON.stringify([`__string__:${sentinelLiteral}`]),
+    );
+    assert.ok(prefixedResult !== sentinelResult);
     assert.ok(prefixedResult !== sparseResult);
     assert.ok(sentinelResult !== sparseResult);
     assert.ok(holeSentinelResult !== sparseResult);
@@ -386,7 +397,7 @@ test("Cat32 assign key matches JSON.stringify for string literals", () => {
 test("Cat32 assign key preserves prefixed sentinel string literal content", () => {
   const value = "__string__:" + typeSentinel("number", "NaN");
   const assignment = new Cat32().assign(value);
-  assert.equal(assignment.key, JSON.stringify(value));
+  assert.equal(assignment.key, JSON.stringify(`__string__:${value}`));
 });
 
 test("Cat32 assign escapes sentinel-like string literal keys", () => {
@@ -436,8 +447,16 @@ test(
     const holeSentinelAssignment = categorizer.assign([holeSentinelLiteral]);
     const sparseAssignment = categorizer.assign(sparseArray);
 
-    assert.equal(prefixedAssignment.key, sentinelAssignment.key);
-    assert.equal(prefixedAssignment.hash, sentinelAssignment.hash);
+    assert.equal(
+      prefixedAssignment.key,
+      JSON.stringify([`__string__:${prefixedLiteral}`]),
+    );
+    assert.equal(
+      sentinelAssignment.key,
+      JSON.stringify([`__string__:${sentinelLiteral}`]),
+    );
+    assert.ok(prefixedAssignment.key !== sentinelAssignment.key);
+    assert.ok(prefixedAssignment.hash !== sentinelAssignment.hash);
     assert.ok(prefixedAssignment.key !== sparseAssignment.key);
     assert.ok(prefixedAssignment.hash !== sparseAssignment.hash);
     assert.ok(holeSentinelAssignment.key !== sparseAssignment.key);
@@ -457,8 +476,16 @@ test("Cat32 assign treats prefixed literal strings as distinct from NaN", () => 
 
   assert.ok(literalAssignment.key !== nanAssignment.key);
   assert.ok(literalAssignment.hash !== nanAssignment.hash);
-  assert.equal(literalAssignment.key, sentinelAssignment.key);
-  assert.equal(literalAssignment.hash, sentinelAssignment.hash);
+  assert.equal(
+    literalAssignment.key,
+    JSON.stringify(`__string__:__string__:\u0000cat32:number:NaN\u0000`),
+  );
+  assert.equal(
+    sentinelAssignment.key,
+    JSON.stringify(`__string__:\u0000cat32:number:NaN\u0000`),
+  );
+  assert.ok(literalAssignment.key !== sentinelAssignment.key);
+  assert.ok(literalAssignment.hash !== sentinelAssignment.hash);
 });
 
 test("dist stableStringify handles Map bucket ordering", async () => {
@@ -521,7 +548,15 @@ test(
     const holeSentinelKey = distStableStringify([holeSentinelLiteral]);
     const sparseKey = distStableStringify(sparseArray);
 
-    assert.equal(prefixedKey, sentinelKey);
+    assert.equal(
+      prefixedKey,
+      JSON.stringify([`__string__:${prefixedLiteral}`]),
+    );
+    assert.equal(
+      sentinelKey,
+      JSON.stringify([`__string__:${sentinelLiteral}`]),
+    );
+    assert.ok(prefixedKey !== sentinelKey);
     assert.ok(prefixedKey !== sparseKey);
     assert.ok(sentinelKey !== sparseKey);
     assert.ok(holeSentinelKey !== sparseKey);
@@ -533,8 +568,16 @@ test(
     const holeSentinelAssignment = categorizer.assign([holeSentinelLiteral]);
     const sparseAssignment = categorizer.assign(sparseArray);
 
-    assert.equal(prefixedAssignment.key, sentinelAssignment.key);
-    assert.equal(prefixedAssignment.hash, sentinelAssignment.hash);
+    assert.equal(
+      prefixedAssignment.key,
+      JSON.stringify([`__string__:${prefixedLiteral}`]),
+    );
+    assert.equal(
+      sentinelAssignment.key,
+      JSON.stringify([`__string__:${sentinelLiteral}`]),
+    );
+    assert.ok(prefixedAssignment.key !== sentinelAssignment.key);
+    assert.ok(prefixedAssignment.hash !== sentinelAssignment.hash);
     assert.ok(prefixedAssignment.key !== sparseAssignment.key);
     assert.ok(prefixedAssignment.hash !== sparseAssignment.hash);
     assert.ok(holeSentinelAssignment.key !== sparseAssignment.key);

--- a/tests/stable-stringify-string-collisions.test.ts
+++ b/tests/stable-stringify-string-collisions.test.ts
@@ -39,6 +39,50 @@ test("string literals matching sentinel encodings are escaped", () => {
   );
 });
 
+test("string literal sentinels remain distinct from actual sentinel values", () => {
+  const cat = new Cat32();
+  const stringPrefix = "__string__:";
+
+  const undefinedLiteral = `${stringPrefix}__undefined__`;
+  const undefinedLiteralAssignment = cat.assign(undefinedLiteral);
+  const undefinedAssignment = cat.assign(undefined);
+
+  assert.ok(undefinedLiteralAssignment.key !== undefinedAssignment.key);
+  assert.ok(undefinedLiteralAssignment.hash !== undefinedAssignment.hash);
+  assert.equal(
+    undefinedLiteralAssignment.key,
+    JSON.stringify(`${stringPrefix}${undefinedLiteral}`),
+  );
+
+  const globalSymbol = Symbol.for("string-literal-collision");
+  const symbolAssignment = cat.assign(globalSymbol);
+  const symbolSentinel = JSON.parse(symbolAssignment.key) as string;
+  const symbolLiteral = `${stringPrefix}${symbolSentinel}`;
+  const symbolLiteralAssignment = cat.assign(symbolLiteral);
+
+  assert.ok(symbolLiteralAssignment.key !== symbolAssignment.key);
+  assert.ok(symbolLiteralAssignment.hash !== symbolAssignment.hash);
+  assert.equal(
+    symbolLiteralAssignment.key,
+    JSON.stringify(`${stringPrefix}${symbolLiteral}`),
+  );
+
+  const mapEntrySentinel = typeSentinel(
+    "map-entry-index",
+    JSON.stringify(["bucket", "property", 0]),
+  );
+  const mapEntryLiteral = `${stringPrefix}${mapEntrySentinel}`;
+  const mapEntryLiteralAssignment = cat.assign(mapEntryLiteral);
+  const mapEntryAssignment = cat.assign(mapEntrySentinel);
+
+  assert.ok(mapEntryLiteralAssignment.key !== mapEntryAssignment.key);
+  assert.ok(mapEntryLiteralAssignment.hash !== mapEntryAssignment.hash);
+  assert.equal(
+    mapEntryLiteralAssignment.key,
+    JSON.stringify(`${stringPrefix}${mapEntryLiteral}`),
+  );
+});
+
 test("sentinel canonical encodings are preserved", () => {
   const cat = new Cat32();
 


### PR DESCRIPTION
## Summary
- add regression coverage to ensure string literals embedding sentinel encodings stay distinct from the actual sentinel values
- extend nested string literal escaping so inner sentinel representations receive an additional `__string__:` prefix
- update existing categorizer assertions to expect the strengthened escaping for prefixed sentinel literals

## Testing
- npm run test *(fails: CLI stdin newline expectations in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f83727df3883218ed1b54ddb286914