### PR TITLE
docs: clarify saltns concatenation format

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -17,6 +17,7 @@ tests/
   - `constructor(opts)` で `labels(32)`, `salt`, `namespace`, `normalize`, `overrides` を受け取る。
   - `assign(input)` → `{ index, label, hash, key }`
   - `index(input)`, `labelOf(input)`：利便性ラッパー。
+  - `salt`/`namespace` の連結は `canonical + (ns ? "|saltns:" + JSON.stringify([salt, ns]) : salt ? "|salt:" + salt : "")` を厳守する（§7）。旧プロトタイプの `|salt:` + `|ns:` 形式はサポートしない。
 
 ## 3. 正規化戦略
 - 既定は **NFKC**。半角/全角、互換文字等の揺れを低減。

--- a/docs/TEST_VECTORS.md
+++ b/docs/TEST_VECTORS.md
@@ -38,6 +38,8 @@
 | `user:123` | `"user:123"` | `"user:123"|saltns:["projX","v1"]` | `11d00f43` | 3 |
 | `task:register` | `"task:register"` | `"task:register"|saltns:["projX","v1"]` | `d61ce402` | 2 |
 
+> `salted_key` 列は `|saltns:` + `JSON.stringify([salt, namespace])` の現行仕様を反映している（余分な空白は入らない）。旧テーブルにあった `|salt:` + `|ns:` 形式とは互換ではないため注意。
+
 ### Canonicalization example (objects)
 
 Input objects:


### PR DESCRIPTION
## Summary
- document Cat32's current `|saltns:` + JSON array concatenation in the spec and design notes
- add compatibility guidance distinguishing the legacy `|salt:` + `|ns:` format from the current behavior
- annotate the salted test vectors so readers see the `|saltns:` JSON array encoding

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f87fdce7e48321b52dc8fa634a9f49