### PR TITLE
Fix WeakRef handling for local symbol sentinel registration

### DIFF
--- a/tests/serialize/symbol-registry.test.ts
+++ b/tests/serialize/symbol-registry.test.ts
@@ -9,6 +9,98 @@ import {
   __peekLocalSymbolSentinelRecordForTest,
 } from "../../src/serialize.js";
 
+let weakRefReloadSequence = 0;
+
+test(
+  "WeakRef 定義環境でローカルシンボルの stringify が 2 回とも成功する",
+  async () => {
+    if (
+      typeof globalThis.WeakRef !== "function" ||
+      typeof globalThis.FinalizationRegistry !== "function"
+    ) {
+      return;
+    }
+
+    const originalWeakRef = globalThis.WeakRef;
+    const originalFinalizationRegistry = globalThis.FinalizationRegistry;
+
+    class StrictWeakRef<T extends object> {
+      #inner: WeakRef<T>;
+
+      constructor(target: T) {
+        if (
+          (typeof target !== "object" || target === null) &&
+          typeof target !== "function"
+        ) {
+          throw new TypeError("WeakRef target must be an object");
+        }
+
+        this.#inner = new originalWeakRef(target);
+      }
+
+      deref(): T | undefined {
+        return this.#inner.deref();
+      }
+    }
+
+    class StrictFinalizationRegistry<T> {
+      #registry: FinalizationRegistry<T>;
+
+      constructor(cleanup: (heldValue: T) => void) {
+        this.#registry = new originalFinalizationRegistry(cleanup);
+      }
+
+      register(target: object, heldValue: T, unregisterToken?: object): void {
+        if (
+          (typeof target !== "object" || target === null) &&
+          typeof target !== "function"
+        ) {
+          throw new TypeError("FinalizationRegistry target must be an object");
+        }
+
+        this.#registry.register(target, heldValue, unregisterToken);
+      }
+
+      unregister(unregisterToken: object): boolean {
+        return this.#registry.unregister(unregisterToken);
+      }
+    }
+
+    Object.defineProperty(globalThis, "WeakRef", {
+      value: StrictWeakRef as unknown as typeof WeakRef,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "FinalizationRegistry", {
+      value: StrictFinalizationRegistry as unknown as typeof FinalizationRegistry,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const moduleSpecifier = `../../src/index.js?strict-weakref=${weakRefReloadSequence}`;
+      weakRefReloadSequence += 1;
+      const { stableStringify: strictStableStringify } = await import(moduleSpecifier);
+
+      const symbol = Symbol("weakref");
+      strictStableStringify(symbol);
+      strictStableStringify(symbol);
+    } finally {
+      weakRefReloadSequence += 1;
+      Object.defineProperty(globalThis, "WeakRef", {
+        value: originalWeakRef,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(globalThis, "FinalizationRegistry", {
+        value: originalFinalizationRegistry,
+        configurable: true,
+        writable: true,
+      });
+    }
+  },
+);
+
 test("ローカルシンボルのセンチネルレコードがキャッシュされる", () => {
   const local = Symbol("local sentinel");
 


### PR DESCRIPTION
## Summary
- add a regression test that exercises `stableStringify` twice under a strict `WeakRef` shim
- wrap local symbol sentinel registration in concrete holder objects that can be reused across accesses

## Testing
- npm test -- --test-name-pattern symbol-registry

------
https://chatgpt.com/codex/tasks/task_e_68f88ed256608321a60ae51e355d1c5b