### PR TITLE
Fix local symbol registry to avoid primitive WeakMap keys

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -51,6 +51,7 @@ const HAS_FINALIZATION_REGISTRY = typeof FinalizationRegistry === "function";
 
 const LOCAL_SYMBOL_SENTINEL_REGISTRY =
   new WeakMap<SymbolObject, LocalSymbolSentinelRecord>();
+const LOCAL_SYMBOL_OBJECT_REGISTRY = new Map<symbol, SymbolObject>();
 const LOCAL_SYMBOL_IDENTIFIER_INDEX =
   HAS_WEAK_REFS && HAS_FINALIZATION_REGISTRY
     ? new Map<string, WeakRef<SymbolObject>>()
@@ -64,8 +65,15 @@ const LOCAL_SYMBOL_FINALIZER =
 
 let nextLocalSymbolSentinelId = 0;
 
-function toSymbolObject(symbol: symbol): SymbolObject {
-  return symbol as SymbolObject;
+function getOrCreateSymbolObject(symbol: symbol): SymbolObject {
+  const existing = LOCAL_SYMBOL_OBJECT_REGISTRY.get(symbol);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const symbolObject = Object(symbol) as SymbolObject;
+  LOCAL_SYMBOL_OBJECT_REGISTRY.set(symbol, symbolObject);
+  return symbolObject;
 }
 
 function peekLocalSymbolSentinelRecordFromObject(
@@ -77,7 +85,11 @@ function peekLocalSymbolSentinelRecordFromObject(
 function peekLocalSymbolSentinelRecord(
   symbol: symbol,
 ): LocalSymbolSentinelRecord | undefined {
-  const symbolObject = toSymbolObject(symbol);
+  const symbolObject = LOCAL_SYMBOL_OBJECT_REGISTRY.get(symbol);
+  if (symbolObject === undefined) {
+    return undefined;
+  }
+
   return peekLocalSymbolSentinelRecordFromObject(symbolObject);
 }
 
@@ -117,7 +129,7 @@ function createLocalSymbolSentinelRecord(
 function getLocalSymbolSentinelRecord(
   symbol: symbol,
 ): LocalSymbolSentinelRecord {
-  const symbolObject = toSymbolObject(symbol);
+  const symbolObject = getOrCreateSymbolObject(symbol);
   const existing = peekLocalSymbolSentinelRecordFromObject(symbolObject);
   if (existing !== undefined) {
     return existing;

--- a/tests/serialize/symbol-registry.test.ts
+++ b/tests/serialize/symbol-registry.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  Cat32,
   stableStringify,
 } from "../../src/index.js";
 import {
@@ -59,4 +60,13 @@ test("ローカルシンボルのピークはレコードを生成しない", ()
     record,
     "センチネル作成後は同一レコードを返す",
   );
+});
+
+test("ローカルシンボルのシリアライズと assign が例外を送出しない", () => {
+  const crash = Symbol("crash");
+
+  stableStringify(crash);
+
+  const cat = new Cat32();
+  cat.assign(crash);
 });


### PR DESCRIPTION
## Summary
- cache per-symbol wrapper objects to ensure WeakMap/WeakRef usage always receives objects
- adjust local symbol peek/get helpers to reuse the cached wrappers instead of passing primitives
- add regression test covering stableStringify and Cat32.assign on a local symbol

## Testing
- npm test -- tests/serialize/symbol-registry.test.ts
- npm test -- tests/stable-stringify-symbol-determinism.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f88ed14dd483218af03c76b67a1a74