### PR TITLE
docs: describe sparse array hole sentinel

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -34,6 +34,7 @@ tests/
   - Set: 要素の `stableStringify` 結果と `buildSetSortKey` が返すセンチネル対応ソートキーで比較し、`sortKey` → `serializedValue` → 挿入順の優先度で整列した配列を `payload` (`"[... ]"`) として `typeSentinel("set", payload)` に埋め込む。重複要素も同じ順序規則で保持される。
 - **Date**: `__date__:<ISO8601>`
 - `undefined` は `"__undefined__"` の**文字列**にエンコード。
+- **Array**: 疎配列で欠番がある場合は、`typeSentinel("hole", "__hole__")` を JSON 文字列として挿入し、`undefined` を要素値として持つケース（`"__undefined__"` センチネル）と区別する。
 
 ## 5. 文字コードとランタイム
 - UTF‑8 バイト化は `TextEncoder`（ブラウザ/Node18+）で統一。

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -35,7 +35,7 @@ input (unknown)
   - `bigint` → 常に `typeSentinel("bigint", value.toString())` を生成し、センチネル文字列として直列化する。
   - `string` → `JSON.stringify` に準拠（`"` で囲む）。センチネル文字列（`__undefined__` や `\u0000cat32:...\u0000` など）と衝突する場合は `__string__:` プレフィックスを 1 回以上付与してエスケープする。
   - `new Number(...)` / `new Boolean(...)` / `Object(1n)` などのボックス化プリミティブは `.valueOf()` でアンボックスした値に対して上記ルール（含センチネル処理）を適用する。
-  - **Array**: `[...]`（順序維持）
+  - **Array**: `[...]`（順序維持）。**疎配列**の欠番は `typeSentinel("hole", "__hole__")` をセンチネル文字列として挿入し、値として `undefined` を明示的に格納した要素（`"__undefined__"` センチネル）とは区別する。
   - **Object**: 自身の**列挙可能プロパティ**を**キー昇順**で `{k:v}` 並べる
   - **Date**: `"__date__:<ISO8601>"`（`getTime()` が **有限値** の場合）。`getTime()` が `NaN` や `±Infinity` などの **非有限値** を返したときは `"__date__:invalid"` をセンチネルとして返し、例外は投げない。
   - **Map**: `typeSentinel("map", payload)` 形式のセンチネル文字列（`"\u0000cat32:map:<payload>\u0000"`）。`payload` は `JSON.stringify` された

--- a/docs/TEST_VECTORS.md
+++ b/docs/TEST_VECTORS.md
@@ -90,6 +90,16 @@ stableStringify(Object(false))
 → "false" // ボックス化 Boolean はアンボックス後に処理
 ```
 
+### Sparse array hole sentinel
+
+```
+stableStringify([1,,3])
+→ "[1,\"\\u0000cat32:hole:__hole__\\u0000\",3]"
+
+// `[1, undefined, 3]` は欠番ではなく `undefined` を要素に保持するため、
+// "[1,\"__undefined__\",3]" となり、疎配列とは区別される。
+```
+
 ### Date sentinel examples
 
 ```


### PR DESCRIPTION
## Summary
- clarify in the specification that sparse array holes are encoded via the `hole` type sentinel and remain distinct from explicit `undefined` elements
- extend the design notes with the same clarification for implementors
- add a test vector example demonstrating how `[1,,3]` is serialized compared to `[1, undefined, 3]`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f88ea2bbc88321afbfc984dace698c