### PR TITLE
docs: document regexp serialization behavior

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -38,6 +38,7 @@ input (unknown)
   - **Array**: `[...]`（順序維持）
   - **Object**: 自身の**列挙可能プロパティ**を**キー昇順**で `{k:v}` 並べる
   - **Date**: `"__date__:<ISO8601>"`（`getTime()` が **有限値** の場合）。`getTime()` が `NaN` や `±Infinity` などの **非有限値** を返したときは `"__date__:invalid"` をセンチネルとして返し、例外は投げない。
+  - **RegExp**: `typeSentinel("regexp", JSON.stringify([source, flags]))` を `stringifySentinelLiteral` でラップしたセンチネル文字列。`flags` は `RegExp.prototype.flags` を使用し、`source`/`flags` の組み合わせが異なればセンチネルも異なる。
   - **Map**: `typeSentinel("map", payload)` 形式のセンチネル文字列（`"\u0000cat32:map:<payload>\u0000"`）。`payload` は `JSON.stringify` された
     `[propertyKey, serializedValue]` 配列。生成手順は以下の通り。
     1. 各エントリのキーと値をそれぞれ `stableStringify` する。キーは `toMapPropertyKey` を通じて `(bucketKey, propertyKey)` に正規化し、

--- a/docs/TEST_VECTORS.md
+++ b/docs/TEST_VECTORS.md
@@ -100,6 +100,20 @@ stableStringify(new Date("2024-01-01T00:00:00.000Z"))
 → "\"__date__:2024-01-01T00:00:00.000Z\""
 ```
 
+### RegExp sentinel examples
+
+```
+stableStringify(/foo/)
+→ "\"\\u0000cat32:regexp:[\\"foo\\",\\"\\"]\\u0000\""
+
+stableStringify(/foo/i)
+→ "\"\\u0000cat32:regexp:[\\"foo\\",\\"i\\"]\\u0000\""
+
+const sentinelLiteral = "\u0000cat32:regexp:[\"foo\",\"\"]\u0000";
+stableStringify(sentinelLiteral)
+→ "\"__string__:\\u0000cat32:regexp:[\\"foo\\",\\"\\"]\\u0000\""
+```
+
 ### Sentinel examples (Map / Set)
 
 ```


### PR DESCRIPTION
## Summary
- describe how stableStringify encodes RegExp values in the specification
- add RegExp sentinel examples to the test vectors guide for quick reference

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f893113bf483219c9b9fbe339bf6de