### PR TITLE
Ensure local symbol sentinel holders are reused

### DIFF
--- a/tests/serialize/symbol-registry.test.ts
+++ b/tests/serialize/symbol-registry.test.ts
@@ -157,8 +157,14 @@ test("ローカルシンボルのピークはレコードを生成しない", ()
 test("ローカルシンボルのシリアライズと assign が例外を送出しない", () => {
   const crash = Symbol("crash");
 
-  stableStringify(crash);
+  const sentinelFromStringify = JSON.parse(stableStringify(crash));
 
   const cat = new Cat32();
-  cat.assign(crash);
+  const assignment = cat.assign(crash);
+
+  const sentinelFromAssign = JSON.parse(assignment.key);
+  assert.equal(sentinelFromAssign, sentinelFromStringify);
+
+  const sentinelFromStringifyAgain = JSON.parse(stableStringify(crash));
+  assert.equal(sentinelFromStringifyAgain, sentinelFromStringify);
 });


### PR DESCRIPTION
## Summary
- add a regression test that ensures stableStringify and Cat32.assign reuse the same sentinel for a local symbol
- refactor local symbol sentinel bookkeeping to reuse per-symbol holder objects across WeakMap and WeakRef usage

## Testing
- npm run test *(fails: CLI newline expectations in dist/tests/categorizer.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68f897a6a39c8321a7b8c45c4f61748a