### PR TITLE
Fix local symbol sentinel registry lookups

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -74,18 +74,18 @@ function getOrCreateSymbolObject(symbol: symbol): LocalSymbolWeakTarget {
 function peekLocalSymbolSentinelRecordFromObject(
   symbolObject: LocalSymbolWeakTarget,
 ): LocalSymbolSentinelRecord | undefined {
-  return LOCAL_SYMBOL_SENTINEL_REGISTRY.get(holder.target);
+  return LOCAL_SYMBOL_SENTINEL_REGISTRY.get(symbolObject);
 }
 
 function peekLocalSymbolSentinelRecord(
   symbol: symbol,
 ): LocalSymbolSentinelRecord | undefined {
-  const holder = LOCAL_SYMBOL_HOLDER_REGISTRY.get(symbol);
-  if (holder === undefined) {
+  const symbolObject = LOCAL_SYMBOL_OBJECT_REGISTRY.get(symbol);
+  if (symbolObject === undefined) {
     return undefined;
   }
 
-  return peekLocalSymbolSentinelRecordFromHolder(holder);
+  return peekLocalSymbolSentinelRecordFromObject(symbolObject);
 }
 
 function registerLocalSymbolSentinelRecord(
@@ -100,7 +100,7 @@ function registerLocalSymbolSentinelRecord(
     LOCAL_SYMBOL_FINALIZER.register(symbolObject, record.identifier);
   }
 
-  LOCAL_SYMBOL_SENTINEL_REGISTRY.set(holder.target, record);
+  LOCAL_SYMBOL_SENTINEL_REGISTRY.set(symbolObject, record);
 }
 
 function createLocalSymbolSentinelRecord(
@@ -114,21 +114,20 @@ function createLocalSymbolSentinelRecord(
   const sentinel = buildLocalSymbolSentinel(identifier, description);
   const record: LocalSymbolSentinelRecord = { identifier, sentinel };
 
-  registerLocalSymbolSentinelRecord(holder, record);
+  registerLocalSymbolSentinelRecord(symbolObject, record);
   return record;
 }
 
 function getLocalSymbolSentinelRecord(
   symbol: symbol,
 ): LocalSymbolSentinelRecord {
-  const holder = getLocalSymbolHolder(symbol);
-  const existing = peekLocalSymbolSentinelRecordFromHolder(holder);
+  const symbolObject = getOrCreateSymbolObject(symbol);
+  const existing = peekLocalSymbolSentinelRecordFromObject(symbolObject);
   if (existing !== undefined) {
     return existing;
   }
 
-  toSymbolObject(symbol);
-  return createLocalSymbolSentinelRecord(symbol, holder);
+  return createLocalSymbolSentinelRecord(symbol, symbolObject);
 }
 
 function buildLocalSymbolSentinel(


### PR DESCRIPTION
## Summary
- fix the local symbol sentinel registry helpers to reference symbol objects correctly
- ensure local symbol sentinel creation reuses the cached symbol object

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f92f5d6ea08321ba02743802c59ddd