### PR TITLE
Add RUNBOOK diff verification instructions and tests

### DIFF
--- a/workflow-cookbook-main/RUNBOOK.md
+++ b/workflow-cookbook-main/RUNBOOK.md
@@ -19,6 +19,9 @@ next_review_due: 2025-11-14
   - 準備: データ投入 / キャッシュ初期化
   - 実行: コマンド/ジョブ名
   - 確認: 出力の存在・件数・整合
+- 設定差分検証（責任者: Release エンジニア）
+  - デプロイ前: `scripts/dump_env.sh > logs/env.before` で本番環境変数を保存し、`config/prod.yaml` など対象設定ファイルを `cp config/prod.yaml logs/config.prod.before` に退避
+  - デプロイ後: `scripts/dump_env.sh > logs/env.after` を取得し、`diff -u logs/env.before logs/env.after` と `diff -u logs/config.prod.before config/prod.yaml` で環境変数・設定ファイルの差分を確認し、想定外差分がないことを Slack #release に記録
 
 ## Observability
 
@@ -29,3 +32,6 @@ next_review_due: 2025-11-14
 
 - どこまで戻すか、再実行条件
 - インシデントサマリを更新後、該当PRの説明欄と本RUNBOOKの該当セクションにリンクを追加する
+- ロールバック後差分確認（責任者: SRE オンコール）
+  - ロールバック前: 現行の `logs/env.after` を `logs/env.rollback.before` にコピーし、`config/prod.yaml` を `logs/config.prod.rollback.before` に退避
+  - ロールバック後: `scripts/dump_env.sh > logs/env.rollback.after` を取得し、`diff -u logs/env.rollback.before logs/env.rollback.after` と `diff -u logs/config.prod.rollback.before config/prod.yaml` で環境変数・設定ファイルがデプロイ前状態へ戻っていることを確認し、結果をインシデントノートに追記

--- a/workflow-cookbook-main/tests/test_runbook_diff_steps.py
+++ b/workflow-cookbook-main/tests/test_runbook_diff_steps.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+RUNBOOK_PATH = Path(__file__).resolve().parents[1] / "RUNBOOK.md"
+
+
+@pytest.fixture(scope="module")
+def runbook_text() -> str:
+    return RUNBOOK_PATH.read_text(encoding="utf-8")
+
+
+def extract_section(text: str, heading: str) -> str:
+    pattern = rf"^## {re.escape(heading)}\n(.*?)(?=\n## |\Z)"
+    match = re.search(pattern, text, flags=re.MULTILINE | re.DOTALL)
+    if match is None:
+        raise AssertionError(f"heading '{heading}' not found in RUNBOOK")
+    return match.group(1)
+
+
+@pytest.mark.parametrize(
+    ("heading", "patterns"),
+    (
+            (
+                "Execute",
+                (
+                    r"環境変数",
+                    r"設定(?:ファイル)?",
+                    r"diff",
+                    r"(責任者|担当)",
+                ),
+            ),
+            (
+                "Rollback / Retry",
+                (
+                    r"環境変数",
+                    r"設定(?:ファイル)?",
+                    r"diff",
+                    r"(責任者|担当)",
+                ),
+            ),
+    ),
+)
+def test_runbook_sections_include_diff_validation(runbook_text: str, heading: str, patterns: tuple[str, ...]) -> None:
+    section = extract_section(runbook_text, heading)
+    for pattern in patterns:
+        if re.search(pattern, section, flags=re.DOTALL) is None:
+            pytest.fail(f"Pattern '{pattern}' not found in section '{heading}'")


### PR DESCRIPTION
## Summary
- add a documentation test that enforces diff validation steps in the RUNBOOK Execute and Rollback sections
- document the environment variable and configuration diff checks, including ownership, in the Execute and Rollback steps

## Testing
- pytest workflow-cookbook-main/tests

------
https://chatgpt.com/codex/tasks/task_e_68f93a77b5a08321b98a40bcdb71ca34