### PR TITLE
Fix duplicate local symbol finalization guards

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -77,21 +77,6 @@ const LOCAL_SYMBOL_IDENTIFIER_INDEX =
         })
       : undefined;
 
-const HAS_LOCAL_SYMBOL_FINALIZATION_SUPPORT =
-  typeof globalThis.WeakRef === "function" &&
-  typeof globalThis.FinalizationRegistry === "function";
-
-const LOCAL_SYMBOL_IDENTIFIER_INDEX: Set<string> | undefined =
-  HAS_LOCAL_SYMBOL_FINALIZATION_SUPPORT ? new Set<string>() : undefined;
-
-const LOCAL_SYMBOL_IDENTIFIER_FINALIZATION_REGISTRY:
-  | FinalizationRegistry<string>
-  | undefined = HAS_LOCAL_SYMBOL_FINALIZATION_SUPPORT
-  ? new FinalizationRegistry<string>((identifier) => {
-      LOCAL_SYMBOL_IDENTIFIER_INDEX?.delete(identifier);
-    })
-  : undefined;
-
 let nextLocalSymbolSentinelId = 0;
 
 function getLocalSymbolHolder(symbol: symbol): LocalSymbolHolder {


### PR DESCRIPTION
## Summary
- remove the redundant local symbol finalization registry constants that redeclared LOCAL_SYMBOL_IDENTIFIER_INDEX

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f96f2e54208321aa4846af8ff07d27