### PR TITLE
Remove unused local symbol helper

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -92,10 +92,6 @@ function getLocalSymbolHolder(symbol: symbol): LocalSymbolHolder {
   return holder;
 }
 
-function getOrCreateSymbolObject(symbol: symbol): SymbolObject {
-  return getLocalSymbolHolder(symbol).target;
-}
-
 function peekLocalSymbolSentinelRecordFromObject(
   symbolObject: SymbolObject,
 ): LocalSymbolSentinelRecord | undefined {


### PR DESCRIPTION
## Summary
- remove the unused getOrCreateSymbolObject helper from serialize.ts to satisfy eslint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f9701287608321af5989cc2af514cf