### PR TITLE
Fix local symbol serialization under strict WeakRef environments

### DIFF
--- a/dist/serialize.js
+++ b/dist/serialize.js
@@ -25,60 +25,86 @@ function isBigIntObject(value) {
         value !== null &&
         OBJECT_TO_STRING.call(value) === "[object BigInt]");
 }
-const LOCAL_SYMBOL_SENTINEL_REGISTRY = new WeakMap();
-const LOCAL_SYMBOL_OBJECT_REGISTRY = new Map();
-const HAS_LOCAL_SYMBOL_FINALIZATION_SUPPORT = typeof globalThis.WeakRef === "function" &&
-    typeof globalThis.FinalizationRegistry === "function";
-const LOCAL_SYMBOL_IDENTIFIER_INDEX = HAS_LOCAL_SYMBOL_FINALIZATION_SUPPORT ? new Set() : undefined;
-const LOCAL_SYMBOL_IDENTIFIER_FINALIZATION_REGISTRY = HAS_LOCAL_SYMBOL_FINALIZATION_SUPPORT
+const HAS_WEAK_REFS = typeof WeakRef === "function", HAS_FINALIZATION_REGISTRY = typeof FinalizationRegistry === "function";
+const LOCAL_SYMBOL_SENTINEL_REGISTRY = new WeakMap(), LOCAL_SYMBOL_OBJECT_REGISTRY = new Map(), LOCAL_SYMBOL_HOLDER_REGISTRY = new Map();
+const LOCAL_SYMBOL_IDENTIFIER_INDEX = HAS_WEAK_REFS && HAS_FINALIZATION_REGISTRY
+    ? new Map()
+    : undefined, LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER = HAS_WEAK_REFS && HAS_FINALIZATION_REGISTRY
+    ? new WeakMap()
+    : undefined, LOCAL_SYMBOL_FINALIZER = HAS_WEAK_REFS && HAS_FINALIZATION_REGISTRY
     ? new FinalizationRegistry((identifier) => {
+        const entry = LOCAL_SYMBOL_IDENTIFIER_INDEX?.get(identifier);
+        if (entry === undefined) {
+            return;
+        }
         LOCAL_SYMBOL_IDENTIFIER_INDEX?.delete(identifier);
+        LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER?.delete(entry.holder);
+        entry.holder.finalizerToken = undefined;
+        LOCAL_SYMBOL_HOLDER_REGISTRY.delete(entry.holder.symbol);
+        LOCAL_SYMBOL_OBJECT_REGISTRY.delete(entry.holder.symbol);
     })
     : undefined;
 let nextLocalSymbolSentinelId = 0;
-function getOrCreateSymbolObject(symbol) {
-    const existing = LOCAL_SYMBOL_OBJECT_REGISTRY.get(symbol);
+function getLocalSymbolHolder(symbol) {
+    const existing = LOCAL_SYMBOL_HOLDER_REGISTRY.get(symbol);
     if (existing !== undefined) {
         return existing;
     }
-    const symbolObject = Object(symbol);
-    LOCAL_SYMBOL_OBJECT_REGISTRY.set(symbol, symbolObject);
-    return symbolObject;
+    const target = Object(symbol);
+    const holder = { symbol, target };
+    LOCAL_SYMBOL_HOLDER_REGISTRY.set(symbol, holder);
+    LOCAL_SYMBOL_OBJECT_REGISTRY.set(symbol, target);
+    return holder;
 }
 function peekLocalSymbolSentinelRecordFromObject(symbolObject) {
     return LOCAL_SYMBOL_SENTINEL_REGISTRY.get(symbolObject);
 }
 function peekLocalSymbolSentinelRecord(symbol) {
-    const symbolObject = LOCAL_SYMBOL_OBJECT_REGISTRY.get(symbol);
-    if (symbolObject === undefined) {
+    const holder = LOCAL_SYMBOL_HOLDER_REGISTRY.get(symbol);
+    if (holder === undefined) {
         return undefined;
     }
-    return peekLocalSymbolSentinelRecordFromObject(symbolObject);
+    return peekLocalSymbolSentinelRecordFromObject(holder.target);
 }
-function registerLocalSymbolSentinelRecord(symbolObject, record) {
-    LOCAL_SYMBOL_SENTINEL_REGISTRY.set(symbolObject, record);
-    if (LOCAL_SYMBOL_IDENTIFIER_INDEX !== undefined &&
-        LOCAL_SYMBOL_IDENTIFIER_FINALIZATION_REGISTRY !== undefined) {
-        LOCAL_SYMBOL_IDENTIFIER_INDEX.add(record.identifier);
-        LOCAL_SYMBOL_IDENTIFIER_FINALIZATION_REGISTRY.register(symbolObject, record.identifier);
+function registerLocalSymbolSentinelRecord(holder, record) {
+    LOCAL_SYMBOL_SENTINEL_REGISTRY.set(holder.target, record);
+    if (LOCAL_SYMBOL_FINALIZER !== undefined &&
+        LOCAL_SYMBOL_IDENTIFIER_INDEX !== undefined &&
+        LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER !== undefined) {
+        const previousIdentifier = LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER.get(holder);
+        if (previousIdentifier !== undefined) {
+            LOCAL_SYMBOL_IDENTIFIER_INDEX.delete(previousIdentifier);
+        }
+        let token = holder.finalizerToken;
+        if (token === undefined) {
+            token = { holder };
+            holder.finalizerToken = token;
+        }
+        else {
+            LOCAL_SYMBOL_FINALIZER.unregister(token);
+        }
+        const entry = { holder, token };
+        LOCAL_SYMBOL_IDENTIFIER_INDEX.set(record.identifier, entry);
+        LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER.set(holder, record.identifier);
+        LOCAL_SYMBOL_FINALIZER.register(holder.target, record.identifier, token);
     }
 }
-function createLocalSymbolSentinelRecord(symbol, symbolObject) {
+function createLocalSymbolSentinelRecord(symbol, holder) {
     const identifier = nextLocalSymbolSentinelId.toString(36);
     nextLocalSymbolSentinelId += 1;
     const description = symbol.description ?? "";
     const sentinel = buildLocalSymbolSentinel(identifier, description);
     const record = { identifier, sentinel };
-    registerLocalSymbolSentinelRecord(symbolObject, record);
+    registerLocalSymbolSentinelRecord(holder, record);
     return record;
 }
 function getLocalSymbolSentinelRecord(symbol) {
-    const symbolObject = getOrCreateSymbolObject(symbol);
-    const existing = peekLocalSymbolSentinelRecordFromObject(symbolObject);
+    const holder = getLocalSymbolHolder(symbol);
+    const existing = peekLocalSymbolSentinelRecordFromObject(holder.target);
     if (existing !== undefined) {
         return existing;
     }
-    return createLocalSymbolSentinelRecord(symbol, symbolObject);
+    return createLocalSymbolSentinelRecord(symbol, holder);
 }
 function buildLocalSymbolSentinel(identifier, description) {
     const descriptionJson = JSON.stringify(description);
@@ -159,62 +185,6 @@ const sharedArrayBufferGlobal = globalThis;
 const sharedArrayBufferCtor = typeof sharedArrayBufferGlobal.SharedArrayBuffer === "function"
     ? sharedArrayBufferGlobal.SharedArrayBuffer
     : undefined;
-const LOCAL_SYMBOL_SENTINEL_REGISTRY = new WeakMap();
-const LOCAL_SYMBOL_OBJECT_REGISTRY = new Map();
-let nextLocalSymbolSentinelId = 0;
-function getOrCreateSymbolObject(symbol) {
-    const existing = LOCAL_SYMBOL_OBJECT_REGISTRY.get(symbol);
-    if (existing !== undefined) {
-        return existing;
-    }
-    const symbolObject = Object(symbol);
-    LOCAL_SYMBOL_OBJECT_REGISTRY.set(symbol, symbolObject);
-    return symbolObject;
-}
-function peekLocalSymbolSentinelRecordFromObject(symbolObject) {
-    return LOCAL_SYMBOL_SENTINEL_REGISTRY.get(symbolObject);
-}
-function peekLocalSymbolSentinelRecord(symbol) {
-    const symbolObject = LOCAL_SYMBOL_OBJECT_REGISTRY.get(symbol);
-    if (symbolObject === undefined) {
-        return undefined;
-    }
-    return peekLocalSymbolSentinelRecordFromObject(symbolObject);
-}
-function registerLocalSymbolSentinelRecord(symbolObject, record) {
-    LOCAL_SYMBOL_SENTINEL_REGISTRY.set(symbolObject, record);
-}
-function createLocalSymbolSentinelRecord(symbol, symbolObject) {
-    const identifier = nextLocalSymbolSentinelId.toString(36);
-    nextLocalSymbolSentinelId += 1;
-    const description = symbol.description ?? "";
-    const sentinel = buildLocalSymbolSentinel(identifier, description);
-    const record = { identifier, sentinel };
-    registerLocalSymbolSentinelRecord(symbolObject, record);
-    return record;
-}
-function getLocalSymbolSentinelRecord(symbol) {
-    const symbolObject = getOrCreateSymbolObject(symbol);
-    const existing = peekLocalSymbolSentinelRecordFromObject(symbolObject);
-    if (existing !== undefined) {
-        return existing;
-    }
-    return createLocalSymbolSentinelRecord(symbol, symbolObject);
-}
-function buildLocalSymbolSentinel(identifier, description) {
-    const descriptionJson = JSON.stringify(description);
-    const payload = `["local","${identifier}",${descriptionJson}]`;
-    return `${SYMBOL_SENTINEL_PREFIX}${payload}`;
-}
-function toSymbolSentinel(symbol) {
-    const globalKey = typeof Symbol.keyFor === "function" ? Symbol.keyFor(symbol) : undefined;
-    if (globalKey !== undefined) {
-        const payload = JSON.stringify(["global", globalKey]);
-        return `${SYMBOL_SENTINEL_PREFIX}${payload}`;
-    }
-    const record = getLocalSymbolSentinelRecord(symbol);
-    return record.sentinel;
-}
 export function typeSentinel(type, payload = "") {
     return `${SENTINEL_PREFIX}${type}:${payload}${SENTINEL_SUFFIX}`;
 }
@@ -252,13 +222,13 @@ function _stringify(v, stack) {
         return stringifySentinelLiteral(typeSentinel("bigint", v.toString()));
     if (t === "undefined")
         return stringifySentinelLiteral(UNDEFINED_SENTINEL);
-    if (t === "function") {
+    if (t === "symbol") {
+        return stringifySentinelLiteral(toSymbolSentinel(v));
+    }
+    if (t === "function")
         return String(v);
     if (v instanceof Number || v instanceof Boolean || isBigIntObject(v)) {
         return _stringify(v.valueOf(), stack);
-    }
-    if (t === "symbol") {
-        return stringifySentinelLiteral(toSymbolSentinel(v));
     }
     if (Array.isArray(v)) {
         if (stack.has(v))
@@ -804,4 +774,3 @@ function reviveNumericSentinel(value) {
 function normalizePlainObjectKey(key) {
     return normalizeStringLiteral(key);
 }
-export { getLocalSymbolSentinelRecord as __getLocalSymbolSentinelRecordForTest, peekLocalSymbolSentinelRecord as __peekLocalSymbolSentinelRecordForTest, };

--- a/tests/dist/serialize-symbol-weakref.test.ts
+++ b/tests/dist/serialize-symbol-weakref.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+let strictWeakRefReloadSequence = 0;
+
+test(
+  "dist の stableStringify は StrictWeakRef/StrictFinalizationRegistry 下でも 2 度のローカル Symbol シリアライズに成功する",
+  async () => {
+    if (
+      typeof globalThis.WeakRef !== "function" ||
+      typeof globalThis.FinalizationRegistry !== "function"
+    ) {
+      return;
+    }
+
+    const originalWeakRef = globalThis.WeakRef;
+    const originalFinalizationRegistry = globalThis.FinalizationRegistry;
+
+    class StrictWeakRef<T extends object> {
+      #inner: WeakRef<T>;
+
+      constructor(target: T) {
+        if (
+          (typeof target !== "object" || target === null) &&
+          typeof target !== "function"
+        ) {
+          throw new TypeError("WeakRef target must be an object");
+        }
+
+        this.#inner = new originalWeakRef(target);
+      }
+
+      deref(): T | undefined {
+        return this.#inner.deref();
+      }
+    }
+
+    class StrictFinalizationRegistry<T> {
+      #registry: FinalizationRegistry<T>;
+
+      constructor(cleanup: (heldValue: T) => void) {
+        this.#registry = new originalFinalizationRegistry(cleanup);
+      }
+
+      register(target: object, heldValue: T, unregisterToken?: object): void {
+        if (
+          (typeof target !== "object" || target === null) &&
+          typeof target !== "function"
+        ) {
+          throw new TypeError("FinalizationRegistry target must be an object");
+        }
+
+        this.#registry.register(target, heldValue, unregisterToken);
+      }
+
+      unregister(unregisterToken: object): boolean {
+        return this.#registry.unregister(unregisterToken);
+      }
+    }
+
+    Object.defineProperty(globalThis, "WeakRef", {
+      value: StrictWeakRef as unknown as typeof WeakRef,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "FinalizationRegistry", {
+      value: StrictFinalizationRegistry as unknown as typeof FinalizationRegistry,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const relative = import.meta.url.includes("/dist/tests/")
+        ? "../../../dist/serialize.js"
+        : "../../dist/serialize.js";
+      const specifier = `${relative}?strict-weakref=${strictWeakRefReloadSequence}`;
+      strictWeakRefReloadSequence += 1;
+      const { stableStringify } = await import(
+        new URL(specifier, import.meta.url).href,
+      );
+
+      const symbol = Symbol("weakref");
+
+      try {
+        stableStringify(symbol);
+        stableStringify(symbol);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        assert.ok(false, message);
+      }
+    } finally {
+      strictWeakRefReloadSequence += 1;
+      Object.defineProperty(globalThis, "WeakRef", {
+        value: originalWeakRef,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(globalThis, "FinalizationRegistry", {
+        value: originalFinalizationRegistry,
+        configurable: true,
+        writable: true,
+      });
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- add a dist-level regression test ensuring stableStringify succeeds under StrictWeakRef/StrictFinalizationRegistry wrappers
- update the serializer WeakRef/FinalizationRegistry handling to register the symbol object target and track identifiers safely
- regenerate the serialized dist artifacts to pick up the corrected logic

## Testing
- npm test -- tests/dist/serialize-symbol-weakref.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68f9b03ad674832183992f6948ccdf1f