### PR TITLE
Fix local symbol registry bookkeeping

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -39,22 +39,7 @@ type SymbolObject = Symbol & object;
 type LocalSymbolHolder = {
   symbol: symbol;
   target: SymbolObject;
-};
-
-type LocalSymbolWeakEntry = {
-  ref: WeakRef<LocalSymbolHolder>;
-  finalizerToken: object;
-};
-
-type LocalSymbolRegistryEntry =
-  | LocalSymbolWeakEntry
-  | {
-      holder: LocalSymbolHolder;
-    };
-
-type LocalSymbolFinalizerRecord = {
-  symbol: symbol;
-  token: object;
+  finalizerToken?: LocalSymbolFinalizerToken;
 };
 
 type LocalSymbolSentinelRecord = {
@@ -76,24 +61,47 @@ const HAS_WEAK_REFS = typeof WeakRef === "function",
 
 const LOCAL_SYMBOL_SENTINEL_REGISTRY =
   new WeakMap<SymbolObject, LocalSymbolSentinelRecord>();
-const LOCAL_SYMBOL_OBJECT_REGISTRY = new Map<symbol, LocalSymbolRegistryEntry>();
+const LOCAL_SYMBOL_OBJECT_REGISTRY = new Map<symbol, SymbolObject>();
+const LOCAL_SYMBOL_HOLDER_REGISTRY = new Map<symbol, LocalSymbolHolder>();
+const LOCAL_SYMBOL_IDENTIFIER_INDEX =
+  HAS_WEAK_REFS && HAS_FINALIZATION_REGISTRY
+    ? new Map<string, LocalSymbolIdentifierEntry>()
+    : undefined;
+const LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER =
+  HAS_WEAK_REFS && HAS_FINALIZATION_REGISTRY
+    ? new WeakMap<LocalSymbolHolder, string>()
+    : undefined;
 const LOCAL_SYMBOL_FINALIZER =
   HAS_WEAK_REFS && HAS_FINALIZATION_REGISTRY
-    ? new FinalizationRegistry<LocalSymbolFinalizerRecord>((record) => {
-        const entry = LOCAL_SYMBOL_OBJECT_REGISTRY.get(record.symbol);
-        if (entry === undefined || !isWeakRegistryEntry(entry)) {
+    ? new FinalizationRegistry<string>((identifier) => {
+        if (
+          LOCAL_SYMBOL_IDENTIFIER_INDEX === undefined ||
+          LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER === undefined
+        ) {
           return;
         }
-        if (entry.finalizerToken !== record.token) {
+
+        const entry = LOCAL_SYMBOL_IDENTIFIER_INDEX.get(identifier);
+        if (entry === undefined) {
           return;
         }
-        LOCAL_SYMBOL_OBJECT_REGISTRY.delete(record.symbol);
+
+        LOCAL_SYMBOL_IDENTIFIER_INDEX.delete(identifier);
+        LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER.delete(entry.holder);
+        entry.holder.finalizerToken = undefined;
+        LOCAL_SYMBOL_HOLDER_REGISTRY.delete(entry.holder.symbol);
+        LOCAL_SYMBOL_OBJECT_REGISTRY.delete(entry.holder.symbol);
       })
     : undefined;
 
 let nextLocalSymbolSentinelId = 0;
 
 function getOrCreateSymbolObject(symbol: symbol): SymbolObject {
+  const holder = LOCAL_SYMBOL_HOLDER_REGISTRY.get(symbol);
+  if (holder !== undefined) {
+    return holder.target;
+  }
+
   const existing = LOCAL_SYMBOL_OBJECT_REGISTRY.get(symbol);
   if (existing !== undefined) {
     return existing;
@@ -102,6 +110,12 @@ function getOrCreateSymbolObject(symbol: symbol): SymbolObject {
   const created = Object(symbol) as SymbolObject;
   LOCAL_SYMBOL_OBJECT_REGISTRY.set(symbol, created);
   return created;
+}
+
+function getExistingLocalSymbolHolder(
+  symbol: symbol,
+): LocalSymbolHolder | undefined {
+  return LOCAL_SYMBOL_HOLDER_REGISTRY.get(symbol);
 }
 
 function getLocalSymbolHolder(symbol: symbol): LocalSymbolHolder {
@@ -113,6 +127,7 @@ function getLocalSymbolHolder(symbol: symbol): LocalSymbolHolder {
   const target = getOrCreateSymbolObject(symbol);
   const holder: LocalSymbolHolder = { symbol, target };
   LOCAL_SYMBOL_HOLDER_REGISTRY.set(symbol, holder);
+  LOCAL_SYMBOL_OBJECT_REGISTRY.set(symbol, target);
   return holder;
 }
 
@@ -139,16 +154,28 @@ function registerLocalSymbolSentinelRecord(
 ): void {
   LOCAL_SYMBOL_SENTINEL_REGISTRY.set(holder.target, record);
 
-  if (LOCAL_SYMBOL_FINALIZER !== undefined) {
-    const entry = LOCAL_SYMBOL_OBJECT_REGISTRY.get(holder.symbol);
-    if (entry !== undefined && isWeakRegistryEntry(entry)) {
-      LOCAL_SYMBOL_FINALIZER.unregister(entry.finalizerToken);
-      LOCAL_SYMBOL_FINALIZER.register(
-        holder.target,
-        { symbol: holder.symbol, token: entry.finalizerToken },
-        entry.finalizerToken,
-      );
+  if (
+    LOCAL_SYMBOL_FINALIZER !== undefined &&
+    LOCAL_SYMBOL_IDENTIFIER_INDEX !== undefined &&
+    LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER !== undefined
+  ) {
+    const previousIdentifier = LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER.get(holder);
+    if (previousIdentifier !== undefined) {
+      LOCAL_SYMBOL_IDENTIFIER_INDEX.delete(previousIdentifier);
     }
+
+    let token = holder.finalizerToken;
+    if (token === undefined) {
+      token = { holder };
+      holder.finalizerToken = token;
+    } else {
+      LOCAL_SYMBOL_FINALIZER.unregister(token);
+    }
+
+    const entry: LocalSymbolIdentifierEntry = { holder, token };
+    LOCAL_SYMBOL_IDENTIFIER_INDEX.set(record.identifier, entry);
+    LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER.set(holder, record.identifier);
+    LOCAL_SYMBOL_FINALIZER.register(holder.target, record.identifier, token);
   }
 }
 

--- a/tests/build/tsc-regression.test.ts
+++ b/tests/build/tsc-regression.test.ts
@@ -73,6 +73,20 @@ const assertNoLocalSymbolRegistryErrors = (stderr: string): void => {
       `${identifier} が未定義として報告されている`,
     );
   }
+
+  for (const diagnostic of [
+    "TS2339: Property 'finalizerToken' does not exist on type",
+    "TS2322: Type 'LocalSymbolRegistryEntry' is not assignable to type 'SymbolObject'",
+    "TS2345: Argument of type 'SymbolObject' is not assignable to parameter of type 'LocalSymbolRegistryEntry'",
+    "TS2552: Cannot find name 'getExistingLocalSymbolHolder'",
+    "TS2552: Cannot find name 'LOCAL_SYMBOL_HOLDER_REGISTRY'",
+    "TS2304: Cannot find name 'isWeakRegistryEntry'",
+  ]) {
+    assert.ok(
+      !stderr.includes(diagnostic),
+      `${diagnostic} が出力されている`,
+    );
+  }
 };
 
 test(


### PR DESCRIPTION
## Summary
- update the local symbol registry tracking to manage holder finalization tokens explicitly and clean up maps safely
- expand the TypeScript regression test to assert that additional local symbol diagnostics do not reappear

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f9b87e069083218397124b4baf8d24