### PR TITLE
Add regression test for NormalizeMode typings

### DIFF
--- a/dist/categorizer.d.ts
+++ b/dist/categorizer.d.ts
@@ -1,4 +1,9 @@
-export type NormalizeMode = "none" | "nfc" | "nfd" | "nfkc" | "nfkd";
+export type NormalizeMode =
+    | "none"
+    | "nfc"
+    | "nfd"
+    | "nfkc"
+    | "nfkd";
 export interface CategorizerOptions {
     salt?: string;
     namespace?: string;


### PR DESCRIPTION
## Summary
- add a regression test that runs `npm run build` and asserts `dist/categorizer.d.ts` contains the NFD/NFKD normalize modes
- format the generated `dist/categorizer.d.ts` union type so the newly required modes are explicit

## Testing
- npm run build *(fails: TS2304 et al. in src/serialize.ts)*
- npm test -- tests/build/tsc-regression.test.ts *(fails: TS2304 et al. in src/serialize.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68f9b830909883219484a7cc666aa892