### PR TITLE
Fix symbol lint issues

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -34,7 +34,7 @@ function isBigIntObject(value: unknown): value is { valueOf(): bigint } {
 
 type ValueOfCapable = { valueOf(): unknown };
 
-type SymbolObject = Symbol & object;
+type SymbolObject = symbol & object;
 
 type LocalSymbolHolder = {
   symbol: symbol;

--- a/tests/build/fixtures/symbol-wrapper-typing.ts
+++ b/tests/build/fixtures/symbol-wrapper-typing.ts
@@ -4,7 +4,7 @@ type SymbolObject = __SymbolObjectForTest;
 
 type AssertFalse<T extends false> = T;
 type SymbolObjectIsNever = [SymbolObject] extends [never] ? true : false;
-type _AssertSymbolObjectIsNotNever = AssertFalse<SymbolObjectIsNever>;
+export type AssertSymbolObjectIsNotNever = AssertFalse<SymbolObjectIsNever>;
 
 const localSymbolObjectRegistry = new Map<symbol, SymbolObject>();
 const localSymbolSentinelRegistry = new WeakMap<SymbolObject, { sentinel: string }>();
@@ -27,6 +27,4 @@ const exampleSymbol = Symbol("symbol-wrapper-typing");
 const exampleObject = getOrCreateSymbolObject(exampleSymbol);
 const maybeRecord = localSymbolSentinelRegistry.get(exampleObject);
 
-if (maybeRecord) {
-  maybeRecord.sentinel.length;
-}
+export const sentinelLength = maybeRecord?.sentinel.length ?? 0;


### PR DESCRIPTION
## Summary
- update the symbol wrapper alias to use the primitive `symbol` type
- expose the test assertion helpers to satisfy lint requirements without disabling rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f9ba5a04ac8321be9aa5d9e145bde6