### PR TITLE
Ensure cat32 CLI preserves stdin newlines

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,12 +146,7 @@ async function main() {
   const cat = new Cat32({ salt, namespace, normalize });
 
   const shouldReadFromStdin = key === undefined;
-  type StderrLike = { isTTY?: boolean };
-  const stderrStream = (process as { stderr?: StderrLike }).stderr;
-  const preserveTrailingNewline = stderrStream?.isTTY === false;
-  const input = shouldReadFromStdin
-    ? await readStdin({ preserveTrailingNewline })
-    : key;
+  const input = shouldReadFromStdin ? await readStdin() : key;
   const res = cat.assign(input);
   const normalizedKey = normalizeCanonicalKey(res.key);
   const outputRecord =
@@ -191,7 +186,8 @@ type ReadStdinOptions = {
 };
 
 function readStdin(options: ReadStdinOptions = {}): Promise<string> {
-  const { preserveTrailingNewline = false } = options;
+  const { preserveTrailingNewline } = options;
+  const shouldPreserveTrailingNewline = preserveTrailingNewline ?? true;
   return new Promise((resolve, reject) => {
     const stdin = process.stdin as ReadableStdin;
     let data = "";
@@ -211,7 +207,7 @@ function readStdin(options: ReadStdinOptions = {}): Promise<string> {
       }
       settled = true;
       cleanup();
-      if (preserveTrailingNewline) {
+      if (shouldPreserveTrailingNewline) {
         resolve(data);
         return;
       }

--- a/tests/cli/stdio-newline.test.ts
+++ b/tests/cli/stdio-newline.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert";
+import test from "node:test";
+
+import type { ChildProcessWithoutNullStreams } from "child_process";
+
+type Spawn = (
+  command: string,
+  args: readonly string[],
+  options: { stdio: ("pipe" | "inherit" | "ignore")[] },
+) => ChildProcessWithoutNullStreams;
+
+type SpawnModule = { spawn: Spawn };
+
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+const dynamicImport = new Function(
+  "specifier",
+  "return import(specifier);",
+) as (specifier: string) => Promise<SpawnModule>;
+
+const CAT32_MODULE_SPECIFIER = import.meta.url.includes("/dist/tests/")
+  ? new URL("../../cli.js", import.meta.url).href
+  : new URL("../../dist/cli.js", import.meta.url).href;
+
+async function runCat32(stderrIsTTY: boolean): Promise<RunResult> {
+  const { spawn } = (await dynamicImport("node:child_process")) as SpawnModule;
+  const inlineScript = `process.stderr.isTTY = ${stderrIsTTY ? "true" : "false"};\nawait import(${JSON.stringify(
+    CAT32_MODULE_SPECIFIER,
+  )});`;
+  const child = spawn(process.argv[0], ["--input-type=module", "-e", inlineScript], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdin.end("foo\n");
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    collectStream(child.stdout),
+    collectStream(child.stderr),
+    waitForExit(child),
+  ]);
+
+  return { stdout, stderr, exitCode };
+}
+
+function collectStream(stream: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: string[] = [];
+    const onData = (chunk: unknown) => {
+      chunks.push(String(chunk));
+    };
+    const onSettled = () => {
+      stream.removeListener("data", onData);
+      stream.removeListener("end", onSettled);
+      stream.removeListener("close", onSettled);
+      resolve(chunks.join(""));
+    };
+
+    stream.on("data", onData);
+    stream.on("end", onSettled);
+    stream.on("close", onSettled);
+  });
+}
+
+function waitForExit(child: ChildProcessWithoutNullStreams): Promise<number> {
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+      if (signal !== null) {
+        reject(new Error(`terminated by signal ${signal}`));
+        return;
+      }
+      resolve(code ?? -1);
+    });
+  });
+}
+
+function assertKeyWithTrailingNewline(output: string) {
+  const [line] = output.split("\n");
+  const record = JSON.parse(line);
+  assert.equal(record.key, "\"foo\n\"");
+}
+
+test("cat32 preserves newline when stderr is a TTY", async () => {
+  const result = await runCat32(true);
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stderr, "");
+  assertKeyWithTrailingNewline(result.stdout);
+});
+
+test("cat32 preserves newline when stderr is not a TTY", async () => {
+  const result = await runCat32(false);
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stderr, "");
+  assertKeyWithTrailingNewline(result.stdout);
+});


### PR DESCRIPTION
## Summary
- add a regression test that runs cat32 via a child process and asserts newline preservation in both TTY and non-TTY stderr modes
- update the CLI stdin reader to retain trailing newlines by default while keeping the preserveTrailingNewline override for callers that still opt out

## Testing
- npm run test *(fails: TypeScript compilation errors in src/serialize.ts unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f9b839074483219cbc092c1dc4dd70