### PR TITLE
Fix symbol wrapper lint regressions

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -34,7 +34,10 @@ function isBigIntObject(value: unknown): value is { valueOf(): bigint } {
 
 type ValueOfCapable = { valueOf(): unknown };
 
-type SymbolObject = ValueOfCapable & { valueOf(): symbol };
+type SymbolObject = ValueOfCapable & {
+  valueOf(): symbol;
+  readonly __cat32SymbolObjectBrand?: never;
+};
 
 type LocalSymbolHolder = {
   symbol: symbol;

--- a/tests/build/fixtures/symbol-wrapper-typing.ts
+++ b/tests/build/fixtures/symbol-wrapper-typing.ts
@@ -4,8 +4,8 @@ type SymbolObject = __SymbolObjectForTest;
 
 type AssertFalse<T extends false> = T;
 type SymbolObjectIsNever = [SymbolObject] extends [never] ? true : false;
-export type AssertSymbolObjectIsNotNever = AssertFalse<SymbolObjectIsNever>;
-export const assertSymbolObjectIsNotNever: AssertSymbolObjectIsNotNever = false;
+type SymbolObjectIsNotNever = AssertFalse<SymbolObjectIsNever>;
+export const assertSymbolObjectIsNotNever: SymbolObjectIsNotNever = false;
 
 const localSymbolObjectRegistry = new Map<symbol, SymbolObject>();
 const localSymbolSentinelRegistry = new WeakMap<SymbolObject, { sentinel: string }>();
@@ -28,6 +28,7 @@ const exampleSymbol = Symbol("symbol-wrapper-typing");
 const exampleObject = getOrCreateSymbolObject(exampleSymbol);
 const maybeRecord = localSymbolSentinelRegistry.get(exampleObject);
 
-if (maybeRecord) {
-  void maybeRecord.sentinel.length;
+const sentinelLength = maybeRecord?.sentinel.length;
+if (typeof sentinelLength === "number") {
+  sentinelLength.toFixed();
 }


### PR DESCRIPTION
## Summary
- add a local brand to the SymbolObject wrapper type used by serialize to silence wrapper linting
- update the symbol wrapper typing fixture to keep the assertions lint-clean

## Testing
- npm run lint -- --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68f9c1a8aa3c83218ab4e645f15edd94