### PR TITLE
Fix TypeScript build issues around symbol registry cleanup and CLI test types

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -72,12 +72,19 @@ const LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER =
 const LOCAL_SYMBOL_FINALIZER =
   HAS_WEAK_REFS && HAS_FINALIZATION_REGISTRY
     ? new FinalizationRegistry<string>((identifier) => {
-        const entry = LOCAL_SYMBOL_IDENTIFIER_INDEX?.get(identifier);
+        const index = LOCAL_SYMBOL_IDENTIFIER_INDEX;
+        const identifiersByHolder = LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER;
+        if (index === undefined || identifiersByHolder === undefined) {
+          return;
+        }
+
+        const entry = index.get(identifier);
         if (entry === undefined) {
           return;
         }
-        LOCAL_SYMBOL_IDENTIFIER_INDEX.delete(identifier);
-        LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER.delete(entry.holder);
+
+        index.delete(identifier);
+        identifiersByHolder.delete(entry.holder);
         resetLocalSymbolHolder(entry.holder);
       })
     : undefined;


### PR DESCRIPTION
## Summary
- guard local symbol finalizer cleanup against missing registries when WeakRef or FinalizationRegistry are unavailable
- define local structural types for the CLI newline test to avoid relying on Node type packages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f9c2c7a3ec83219d3e9ae3338aab00