### PR TITLE
Add module declarations for dist imports used in tests

### DIFF
--- a/tests/dist-imports.d.ts
+++ b/tests/dist-imports.d.ts
@@ -1,0 +1,7 @@
+declare module "../dist/categorizer.js" {
+  export * from "../dist/categorizer";
+}
+
+declare module "../dist/hash.js" {
+  export * from "../dist/hash";
+}


### PR DESCRIPTION
## Summary
- add explicit module declarations so TypeScript can resolve dist imports in tests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f9c4faaa0c83219b2919c7fabbb35b