### PR TITLE
Fix TypeScript dist module ambient declarations

### DIFF
--- a/tests/dist-imports.d.ts
+++ b/tests/dist-imports.d.ts
@@ -1,7 +1,12 @@
 declare module "../dist/categorizer.js" {
-  export * from "../dist/categorizer";
+  export type {
+    NormalizeMode,
+    CategorizerOptions,
+    Assignment,
+  } from "../src/categorizer.js";
+  export { Cat32 } from "../src/categorizer.js";
 }
 
 declare module "../dist/hash.js" {
-  export * from "../dist/hash";
+  export { fnv1a32, toHex32 } from "../src/hash.js";
 }


### PR DESCRIPTION
## Summary
- adjust ambient dist module declarations used by tests to re-export types from the source modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f9c6268c988321b587cfa899db308b