### PR TITLE
Add ambient type declarations for dist module imports

### DIFF
--- a/types/dist-modules.d.ts
+++ b/types/dist-modules.d.ts
@@ -1,8 +1,0 @@
-declare module "../dist/categorizer.js" {
-  export type { NormalizeMode, CategorizerOptions, Assignment } from "../src/categorizer";
-  export { Cat32 } from "../src/categorizer";
-}
-
-declare module "../dist/hash.js" {
-  export { fnv1a32, toHex32 } from "../src/hash";
-}

--- a/types/dist-modules/index.d.ts
+++ b/types/dist-modules/index.d.ts
@@ -1,0 +1,12 @@
+declare module "../dist/categorizer.js" {
+  export type {
+    NormalizeMode,
+    CategorizerOptions,
+    Assignment,
+  } from "../src/categorizer.js";
+  export { Cat32 } from "../src/categorizer.js";
+}
+
+declare module "../dist/hash.js" {
+  export { fnv1a32, toHex32 } from "../src/hash.js";
+}


### PR DESCRIPTION
## Summary
- add ambient module declarations that map the dist categorizer and hash bundles to their source types so TypeScript can resolve the dynamic imports used in tests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f9c81fd1048321b4283002c8c960f5