### PR TITLE
Handle weak local symbol registry entries

### DIFF
--- a/tests/build/tsc-regression.test.ts
+++ b/tests/build/tsc-regression.test.ts
@@ -70,6 +70,9 @@ const assertNoLocalSymbolRegistryErrors = (stderr: string): void => {
     "LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER",
     "getOrCreateSymbolObject",
     "peekLocalSymbolSentinelRecordFromObject",
+    "createLocalSymbolRegistryEntry",
+    "storeLocalSymbolHolderEntry",
+    "reviveLocalSymbolHolderFromEntry",
   ] as const) {
     assert.ok(
       !stderr.includes(`TS2304: Cannot find name '${identifier}'`),
@@ -86,6 +89,7 @@ const assertNoLocalSymbolRegistryErrors = (stderr: string): void => {
     "TS2552: Cannot find name 'LOCAL_SYMBOL_IDENTIFIER_INDEX'",
     "TS2552: Cannot find name 'LOCAL_SYMBOL_IDENTIFIER_BY_HOLDER'",
     "TS2304: Cannot find name 'isWeakRegistryEntry'",
+    "TS2304: Cannot find name 'LocalSymbolRegistryEntry'",
   ]) {
     assert.ok(
       !stderr.includes(diagnostic),


### PR DESCRIPTION
## Summary
- store local symbol holders as weak registry entries when WeakRef is available and refresh entries when revived
- update local symbol sentinel registration to keep registry entries in sync with finalizer tokens
- extend the tsc regression guard to cover the new helper utilities and types

## Testing
- npm run build
- npm run test *(fails: existing CLI newline, release checklist, and throughput assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68f9c604d14083218d1d6f77fd81507f