### PR TITLE
Fix TypeScript build errors for local symbol registry and CLI test import

### DIFF
--- a/tests/cli/stdio-newline.test.ts
+++ b/tests/cli/stdio-newline.test.ts
@@ -37,12 +37,14 @@ const dynamicImport = new Function(
   "return import(specifier);",
 ) as (specifier: string) => Promise<SpawnModule>;
 
+const CHILD_PROCESS_MODULE_SPECIFIER: string = "node:child_process";
+
 const CAT32_MODULE_SPECIFIER = import.meta.url.includes("/dist/tests/")
   ? new URL("../../cli.js", import.meta.url).href
   : new URL("../../dist/cli.js", import.meta.url).href;
 
 async function runCat32(stderrIsTTY: boolean): Promise<RunResult> {
-  const { spawn } = (await dynamicImport("node:child_process")) as SpawnModule;
+  const { spawn } = (await dynamicImport(CHILD_PROCESS_MODULE_SPECIFIER)) as SpawnModule;
   const inlineScript = `process.stderr.isTTY = ${stderrIsTTY ? "true" : "false"};\nawait import(${JSON.stringify(
     CAT32_MODULE_SPECIFIER,
   )});`;


### PR DESCRIPTION
## Summary
- tighten the guard logic around the local symbol finalizer to satisfy strict undefined checks
- avoid literal module specifiers in the CLI newline test to keep TypeScript from requiring Node typings

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f9c57774948321849c8d788a2a1390