### PR TITLE
Validate labels option inputs in Cat32

### DIFF
--- a/src/categorizer.ts
+++ b/src/categorizer.ts
@@ -31,9 +31,22 @@ export class Cat32 {
   private overrides: Map<string, number>;
 
   constructor(opts: CategorizerOptions = {}) {
-    this.labels = (opts.labels && opts.labels.length === 32) ? opts.labels.slice(0, 32) : DEFAULT_LABELS;
-    if (opts.labels && opts.labels.length !== 32) {
-      throw new RangeError("labels length must be 32");
+    const { labels } = opts;
+    if (labels !== undefined) {
+      if (!Array.isArray(labels)) {
+        throw new TypeError("labels must be an array of 32 strings");
+      }
+      if (labels.length !== 32) {
+        throw new RangeError("labels length must be 32");
+      }
+      for (const label of labels) {
+        if (typeof label !== "string") {
+          throw new TypeError("labels must be an array of 32 strings");
+        }
+      }
+      this.labels = labels.slice(0, 32);
+    } else {
+      this.labels = DEFAULT_LABELS;
     }
     this.salt = opts.salt ?? "";
     const namespaceValue = opts.namespace;

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -1950,6 +1950,27 @@ test("override accepts canonical key strings", () => {
   assert.equal(c.assign(true).index, 7);
 });
 
+test("labels option rejects non-array inputs", () => {
+  assert.throws(
+    () => new Cat32({ labels: 123 as unknown as string[] }),
+    (error) =>
+      error instanceof TypeError &&
+      error.message === "labels must be an array of 32 strings",
+  );
+});
+
+test("labels option rejects non-string entries", () => {
+  const invalidLabels = Array.from({ length: 32 }, (_, i) => `L${i}` as unknown);
+  invalidLabels[5] = 42;
+
+  assert.throws(
+    () => new Cat32({ labels: invalidLabels as string[] }),
+    (error) =>
+      error instanceof TypeError &&
+      error.message === "labels must be an array of 32 strings",
+  );
+});
+
 test("range 0..31 and various types", () => {
   const c = new Cat32();
   for (const k of ["a", "b", "c", "日本語", "ＡＢＣ", 123, true, null]) {


### PR DESCRIPTION
## Summary
- add coverage ensuring Cat32 rejects labels options that are not string arrays
- enforce array and element type validation in the Cat32 constructor

## Testing
- npm test *(fails: known CLI stdin newline handling, CLI normalization via stdin, release checklist, and stable stringify throughput assertions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa3ed76d448321831dfe36f00b259b