### PR TITLE
Expose NormalizeMode from index exports

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,4 @@
 export { Cat32, type CategorizerOptions, type Assignment } from "./categorizer.js";
+export type { NormalizeMode } from "./categorizer.js";
 export { stableStringify } from "./serialize.js";
 export type StableStringify = typeof import("./serialize.js").stableStringify;

--- a/dist/src/index.d.ts
+++ b/dist/src/index.d.ts
@@ -1,3 +1,4 @@
 export { Cat32, type CategorizerOptions, type Assignment } from "./categorizer.js";
+export type { NormalizeMode } from "./categorizer.js";
 export { stableStringify } from "./serialize.js";
 export type StableStringify = typeof import("./serialize.js").stableStringify;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { Cat32, type CategorizerOptions, type Assignment } from "./categorizer.js";
+export type { NormalizeMode } from "./categorizer.js";
 export { stableStringify } from "./serialize.js";
 export type StableStringify = typeof import("./serialize.js").stableStringify;

--- a/tests/dist-imports.d.ts
+++ b/tests/dist-imports.d.ts
@@ -7,6 +7,10 @@ declare module "../dist/categorizer.js" {
   export { Cat32 } from "../src/categorizer.js";
 }
 
+declare module "../dist/index.js" {
+  export type { NormalizeMode } from "../src/categorizer.js";
+}
+
 declare module "../dist/hash.js" {
   export { fnv1a32, toHex32 } from "../src/hash.js";
 }


### PR DESCRIPTION
## Summary
- export the NormalizeMode type from the library entry point
- extend the dist import type test to cover NormalizeMode via the bundled index
- regenerate the emitted declaration files to include the new export

## Testing
- npm test *(fails: existing CLI newline, release checklist, and throughput assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68fa3ed742c0832199694c346854ed3c