### PR TITLE
Add NormalizeMode type coverage to dist import test

### DIFF
--- a/tests/dist-imports.d.ts
+++ b/tests/dist-imports.d.ts
@@ -11,6 +11,16 @@ declare module "../dist/index.js" {
   export type { NormalizeMode } from "../src/categorizer.js";
 }
 
+type DistNormalizeMode = import("../dist/index.js").NormalizeMode;
+type SrcNormalizeMode = import("../src/index.js").NormalizeMode;
+
+type _AssertDistNormalizeMode = DistNormalizeMode extends import("../src/categorizer.js").NormalizeMode
+  ? true
+  : never;
+type _AssertSrcNormalizeMode = SrcNormalizeMode extends import("../src/categorizer.js").NormalizeMode
+  ? true
+  : never;
+
 declare module "../dist/hash.js" {
   export { fnv1a32, toHex32 } from "../src/hash.js";
 }


### PR DESCRIPTION
## Summary
- extend the dist import type declarations to assert that NormalizeMode is available from both dist and source entrypoints

## Testing
- npm test *(fails: CLI newline assertions, release checklist expectation, and throughput threshold in stable-stringify string-collision suite)*

------
https://chatgpt.com/codex/tasks/task_e_68fa7cd651e08321bf13d5c1d4dc34b1