### PR TITLE
Trim trailing newline in CLI stdin input

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -187,7 +187,7 @@ type ReadStdinOptions = {
 
 function readStdin(options: ReadStdinOptions = {}): Promise<string> {
   const { preserveTrailingNewline } = options;
-  const shouldPreserveTrailingNewline = preserveTrailingNewline ?? true;
+  const shouldPreserveTrailingNewline = preserveTrailingNewline ?? false;
   return new Promise((resolve, reject) => {
     const stdin = process.stdin as ReadableStdin;
     let data = "";

--- a/tests/cli-stdin-newline.test.ts
+++ b/tests/cli-stdin-newline.test.ts
@@ -37,7 +37,7 @@ const CAT32_BIN = import.meta.url.includes("/dist/tests/")
   ? new URL("../cli.js", import.meta.url).pathname
   : new URL("../dist/cli.js", import.meta.url).pathname;
 
-test("cat32 preserves canonical key newline when reading stdin", async () => {
+test("cat32 trims trailing newline when reading stdin", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as {
     spawn: SpawnFunction;
   };
@@ -79,5 +79,5 @@ test("cat32 preserves canonical key newline when reading stdin", async () => {
   const [line] = output.split("\n");
   const record = JSON.parse(line);
 
-  assert.equal(record.key, "\"foo\n\"");
+  assert.equal(record.key, JSON.stringify("foo"));
 });


### PR DESCRIPTION
## Summary
- default stdin reader to drop trailing newlines before categorizing
- update CLI stdin test to assert trimmed behaviour

## Testing
- node scripts/run-tests.js --test tests/cli-stdin-newline.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fa80b564148321926bacf097b80ec9