### PR TITLE
Fix TypeScript build by declaring dist categorizer module

### DIFF
--- a/tests/dist-categorizer.d.ts
+++ b/tests/dist-categorizer.d.ts
@@ -1,0 +1,3 @@
+declare module "../dist/categorizer.js" {
+  export * from "../src/categorizer.js";
+}


### PR DESCRIPTION
## Summary
- add an ambient module declaration so TypeScript can resolve the built categorizer bundle during tests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa84f996e083218e590fb8ae5794e8