### PR TITLE
Handle carriage return escapes in CLI canonical key

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -255,17 +255,17 @@ function normalizeCanonicalKey(key: string): string {
       continue;
     }
 
-    if (char === "n" && backslashRunLength > 0) {
+    if ((char === "n" || char === "r") && backslashRunLength > 0) {
       const literalPairs = Math.trunc(backslashRunLength / 2);
       if (literalPairs > 0) {
         normalized += "\\".repeat(literalPairs);
       }
       if (backslashRunLength % 2 === 1) {
-        normalized += "\n";
+        normalized += char === "n" ? "\n" : "\r";
         backslashRunLength = 0;
         continue;
       }
-      normalized += "n";
+      normalized += char;
       backslashRunLength = 0;
       continue;
     }


### PR DESCRIPTION
## Summary
- extend the CLI stdin test harness to cover CRLF input and assert the canonical key retains a real carriage return
- update `normalizeCanonicalKey` so odd backslash runs before `r` produce a carriage return, matching the existing newline handling

## Testing
- node --test dist/tests/cli-stdin-newline.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fa90399d988321a49f9a92ac05bed6