### PR TITLE
Clone Cat32 default labels per instance

### DIFF
--- a/src/categorizer.ts
+++ b/src/categorizer.ts
@@ -46,7 +46,7 @@ export class Cat32 {
       }
       this.labels = providedLabels.slice(0, 32);
     } else {
-      this.labels = DEFAULT_LABELS;
+      this.labels = DEFAULT_LABELS.slice(0, 32);
     }
     this.salt = opts.salt ?? "";
     const namespaceValue = opts.namespace;

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -191,6 +191,20 @@ test("dist stableStringify matches JSON.stringify for string literals", async ()
   );
 });
 
+test("default Cat32 instances keep independent label arrays", () => {
+  const first = new Cat32();
+  const second = new Cat32();
+
+  const firstLabels = (first as unknown as { labels: string[] }).labels;
+  const secondLabels = (second as unknown as { labels: string[] }).labels;
+
+  assert.ok(firstLabels !== secondLabels);
+
+  firstLabels[0] = "Z";
+
+  assert.equal(secondLabels[0], "A");
+});
+
 test(
   "dist stableStringify preserves prefixed sentinel string literal content",
   async () => {


### PR DESCRIPTION
## Summary
- add a regression test that ensures default Cat32 instances do not share their label arrays
- clone the DEFAULT_LABELS array when Cat32 is constructed without custom labels

## Testing
- npm test *(fails: baseline CLI newline, CLI stdin normalization, checklist, JSON positional flag, and performance thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_68fa90399aac832184b3fcdda8c15e81