### PR TITLE
Update CLI newline tests to expect trimmed output

### DIFF
--- a/dist/tests/cli/stdio-newline.test.js
+++ b/dist/tests/cli/stdio-newline.test.js
@@ -49,20 +49,20 @@ function waitForExit(child) {
         });
     });
 }
-function assertKeyWithTrailingNewline(output) {
+function assertKeyWithoutTrailingNewline(output) {
     const [line] = output.split("\n");
     const record = JSON.parse(line);
-    assert.equal(record.key, "\"foo\n\"");
+    assert.equal(record.key, JSON.stringify("foo"));
 }
 test("cat32 preserves newline when stderr is a TTY", async () => {
     const result = await runCat32(true);
     assert.equal(result.exitCode, 0);
     assert.equal(result.stderr, "");
-    assertKeyWithTrailingNewline(result.stdout);
+    assertKeyWithoutTrailingNewline(result.stdout);
 });
 test("cat32 preserves newline when stderr is not a TTY", async () => {
     const result = await runCat32(false);
     assert.equal(result.exitCode, 0);
     assert.equal(result.stderr, "");
-    assertKeyWithTrailingNewline(result.stdout);
+    assertKeyWithoutTrailingNewline(result.stdout);
 });

--- a/tests/cli/stdio-newline.test.ts
+++ b/tests/cli/stdio-newline.test.ts
@@ -95,22 +95,22 @@ function waitForExit(child: ChildProcessWithoutNullStreams): Promise<number> {
   });
 }
 
-function assertKeyWithTrailingNewline(output: string) {
+function assertKeyWithoutTrailingNewline(output: string) {
   const [line] = output.split("\n");
   const record = JSON.parse(line);
-  assert.equal(record.key, "\"foo\n\"");
+  assert.equal(record.key, JSON.stringify("foo"));
 }
 
 test("cat32 preserves newline when stderr is a TTY", async () => {
   const result = await runCat32(true);
   assert.equal(result.exitCode, 0);
   assert.equal(result.stderr, "");
-  assertKeyWithTrailingNewline(result.stdout);
+  assertKeyWithoutTrailingNewline(result.stdout);
 });
 
 test("cat32 preserves newline when stderr is not a TTY", async () => {
   const result = await runCat32(false);
   assert.equal(result.exitCode, 0);
   assert.equal(result.stderr, "");
-  assertKeyWithTrailingNewline(result.stdout);
+  assertKeyWithoutTrailingNewline(result.stdout);
 });


### PR DESCRIPTION
## Summary
- update the stdio newline CLI test helper to compare against JSON.stringify("foo")
- regenerate the distributed test file to mirror the updated expectation

## Testing
- npm test *(fails: existing suite failures in dist/tests/categorizer.test.js, dist/tests/checklists-release.test.js, and dist/tests/stable-stringify-string-collisions.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68fa9946209c8321959065cbba1f1307