### PR TITLE
Add regression test for dist CLI newline normalization

### DIFF
--- a/dist/tests/cli-stdin-newline.test.js
+++ b/dist/tests/cli-stdin-newline.test.js
@@ -56,6 +56,9 @@ test("dist/cli.js trims trailing newline when reading stdin", async () => {
     const [line] = stdout.split("\n");
     const record = JSON.parse(line);
     assert.equal(record.key, JSON.stringify("foo"));
+    if (isRunningFromDistTests) {
+        assert.equal(record.key.includes("\\\\r"), false);
+    }
 });
 test("dist/src/cli.js trims trailing newline when reading stdin", async () => {
     const { exitCode, stdout, stderr } = await runCat32WithInput("foo\n", {

--- a/tests/cli-stdin-newline.test.ts
+++ b/tests/cli-stdin-newline.test.ts
@@ -127,6 +127,9 @@ test("dist/cli.js trims trailing newline when reading stdin", async () => {
   const record = JSON.parse(line);
 
   assert.equal(record.key, JSON.stringify("foo"));
+  if (isRunningFromDistTests) {
+    assert.equal(record.key.includes("\\\\r"), false);
+  }
 });
 
 test("dist/src/cli.js trims trailing newline when reading stdin", async () => {


### PR DESCRIPTION
## Summary
- add a regression assertion in the CLI stdin newline test to ensure the dist build strips carriage returns when executed from the compiled suite
- regenerate the compiled CLI stdin newline test to carry the new assertion into dist output

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68faa0948b848321b28ff3e04109df72