### PR TITLE
Fix CLI --json positional parsing and add doc sync test

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,34 +21,34 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
 
 ```sh
 $ cat32 foo
-{"index":7,"label":"H","hash":"1a2b3c4d","key":"\"foo\""}
+{"index":15,"label":"P","hash":"c6aac00f","key":"\"foo\""}
 
 $ cat32 --json foo
-{"index":7,"label":"H","hash":"1a2b3c4d","key":"\"foo\""}
+{"index":15,"label":"P","hash":"c6aac00f","key":"\"foo\""}
 
 $ cat32 --json=pretty foo
 ※ 以下の整形モード例は 1 件のレコードが複数行に展開される。
 整形モードでは 1 レコードが複数行の JSON になるため、ストリーム処理では compact/既定モードを利用する。
 {
-  "index": 7,
-  "label": "H",
-  "hash": "1a2b3c4d",
+  "index": 15,
+  "label": "P",
+  "hash": "c6aac00f",
   "key": "\"foo\""
 }
 
 $ cat32 --pretty foo
 {
-  "index": 7,
-  "label": "H",
-  "hash": "1a2b3c4d",
+  "index": 15,
+  "label": "P",
+  "hash": "c6aac00f",
   "key": "\"foo\""
 }
 
 $ cat32 --json --pretty foo
 {
-  "index": 7,
-  "label": "H",
-  "hash": "1a2b3c4d",
+  "index": 15,
+  "label": "P",
+  "hash": "c6aac00f",
   "key": "\"foo\""
 }
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,9 +93,13 @@ function parseArgs(argv: string[]): ParsedArgs {
           continue;
         }
 
-        assertAllowedFlagValue(key, next, spec.allowedValues);
-        args[key] = next;
-        i += 1;
+        if (spec.allowedValues === undefined || spec.allowedValues.includes(next)) {
+          args[key] = next;
+          i += 1;
+          continue;
+        }
+
+        args[key] = spec.defaultValue;
       } else {
         let value: string | undefined;
         if (eq >= 0) {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -1538,7 +1538,7 @@ test("cat32 binary accepts flag values separated by whitespace", async () => {
   assert.equal(parsed.key, expected.key);
 });
 
-test("cat32 binary rejects unsupported --json positional value", async () => {
+test("cat32 binary treats --json positional value as compact input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 
   const child = spawn(process.argv[0], [CLI_BIN_PATH, "--json", "invalid"], {
@@ -1563,12 +1563,11 @@ test("cat32 binary rejects unsupported --json positional value", async () => {
     child.on("close", (code: number | null) => resolve(code));
   });
 
-  assert.equal(stdout, "");
-  assert.equal(exitCode, 2);
-  assert.ok(
-    stderr.includes('RangeError: unsupported --json value "invalid"'),
-    `stderr did not include unsupported --json value message: ${stderr}`,
-  );
+  assert.equal(exitCode, 0);
+  assert.equal(stderr, "");
+
+  const parsed = JSON.parse(stdout.trim()) as { key: string };
+  assert.equal(parsed.key, JSON.stringify("invalid"));
 });
 
 test("cat32 binary exits with code 2 for unsupported --json= value", async () => {
@@ -3051,7 +3050,7 @@ test("CLI outputs compact JSON by default", async () => {
   assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
-test("cat32 command rejects unsupported --json positional value", async () => {
+test("cat32 command treats --json positional value as compact input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 
   const cat32CommandPath = import.meta.url.includes("/dist/tests/")
@@ -3094,12 +3093,11 @@ test("cat32 command rejects unsupported --json positional value", async () => {
     child.on("close", (code: number | null) => resolve(code));
   });
 
-  assert.equal(stdout, "");
-  assert.equal(exitCode, 2);
-  assert.ok(
-    stderr.includes('RangeError: unsupported --json value "invalid"'),
-    `stderr did not include unsupported --json value message: ${stderr}`,
-  );
+  assert.equal(exitCode, 0);
+  assert.equal(stderr, "");
+
+  const parsed = JSON.parse(stdout.trim()) as { key: string };
+  assert.equal(parsed.key, JSON.stringify("invalid"));
 });
 
 test("CLI outputs compact JSON when --json is provided without a value", async () => {
@@ -3123,7 +3121,7 @@ test("CLI outputs compact JSON when --json is provided without a value", async (
   assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
-test("CLI rejects unsupported --json positional value", async () => {
+test("CLI treats --json positional value as compact input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
   const child = spawn(process.argv[0], [CLI_PATH, "--json", "invalid"], {
     stdio: ["ignore", "pipe", "pipe"],
@@ -3145,12 +3143,11 @@ test("CLI rejects unsupported --json positional value", async () => {
     child.on("close", (code: number | null) => resolve(code));
   });
 
-  assert.equal(stdout, "");
-  assert.equal(exitCode, 2);
-  assert.ok(
-    stderr.includes('RangeError: unsupported --json value "invalid"'),
-    `stderr did not include unsupported --json value message: ${stderr}`,
-  );
+  assert.equal(exitCode, 0);
+  assert.equal(stderr, "");
+
+  const parsed = JSON.parse(stdout.trim()) as { key: string };
+  assert.equal(parsed.key, JSON.stringify("invalid"));
 });
 
 test("CLI exits with code 2 when --json= has an invalid value", async () => {

--- a/tests/cli-doc-examples.test.ts
+++ b/tests/cli-doc-examples.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+type SpawnOptions = { stdio?: ("pipe" | "inherit" | "ignore")[] };
+type SpawnedProcess = {
+  stdout: { setEncoding(encoding: "utf8"): void; on(event: "data", listener: (chunk: string) => void): void } | null;
+  stderr: { setEncoding(encoding: "utf8"): void; on(event: "data", listener: (chunk: string) => void): void } | null;
+  on(event: "close", listener: (code: number | null, signal: string | null) => void): void;
+  on(event: "error", listener: (error: unknown) => void): void;
+};
+type SpawnFunction = (command: string, args: string[], options?: SpawnOptions) => SpawnedProcess;
+type FsPromisesModule = { readFile(path: string, encoding: "utf8"): Promise<string> };
+type CliCase = { name: string; args: string[]; docCommand: string; docOutput: string };
+
+const dynamicImport = new Function("specifier", "return import(specifier);") as (specifier: string) => Promise<unknown>;
+const isDist = import.meta.url.includes("/dist/tests/");
+const distUrl = new URL(isDist ? "../" : "../dist/", import.meta.url);
+const projectUrl = new URL("../", distUrl);
+const cliDocPath = new URL("./docs/CLI.md", projectUrl).pathname;
+
+const compact = '{"index":15,"label":"P","hash":"c6aac00f","key":"\\"foo\\""}';
+const pretty = '{\n  "index": 15,\n  "label": "P",\n  "hash": "c6aac00f",\n  "key": "\\"foo\\""\n}';
+
+const cases: CliCase[] = [
+  { name: "cat32 foo", args: ["foo"], docCommand: "$ cat32 foo", docOutput: compact },
+  { name: "cat32 --json foo", args: ["--json", "foo"], docCommand: "$ cat32 --json foo", docOutput: compact },
+  { name: "cat32 --json=pretty foo", args: ["--json=pretty", "foo"], docCommand: "$ cat32 --json=pretty foo", docOutput: pretty },
+  { name: "cat32 --pretty foo", args: ["--pretty", "foo"], docCommand: "$ cat32 --pretty foo", docOutput: pretty },
+  { name: "cat32 --json --pretty foo", args: ["--json", "--pretty", "foo"], docCommand: "$ cat32 --json --pretty foo", docOutput: pretty },
+];
+
+const bins = [
+  { label: "dist/cli.js", path: new URL("./cli.js", distUrl).pathname },
+  { label: "dist/src/cli.js", path: new URL("./src/cli.js", distUrl).pathname },
+];
+
+async function runCat32(binPath: string, args: string[]) {
+  const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
+  const child = spawn(process.argv[0], [binPath, ...args], { stdio: ["ignore", "pipe", "pipe"] });
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  child.stdout?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk) => {
+    stdoutChunks.push(chunk);
+  });
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk) => {
+    stderrChunks.push(chunk);
+  });
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (signal !== null) {
+        reject(new Error(`terminated by signal ${signal}`));
+        return;
+      }
+      resolve(code ?? -1);
+    });
+  });
+  return { exitCode, stdout: stdoutChunks.join(""), stderr: stderrChunks.join("") };
+}
+
+test("CLI examples in docs stay in sync", async () => {
+  const { readFile } = (await dynamicImport("node:fs/promises")) as FsPromisesModule;
+  const doc = await readFile(cliDocPath, "utf8");
+  for (const cliCase of cases) {
+    assert.ok(doc.includes(cliCase.docCommand), `docs should contain command: ${cliCase.docCommand}`);
+    assert.ok(doc.includes(cliCase.docOutput), `docs should contain output for ${cliCase.name}`);
+    for (const bin of bins) {
+      const { exitCode, stdout, stderr } = await runCat32(bin.path, cliCase.args);
+      assert.equal(exitCode, 0);
+      assert.equal(stderr, "");
+      assert.equal(stdout, `${cliCase.docOutput}\n`);
+    }
+  }
+});

--- a/tests/cli-help.test.ts
+++ b/tests/cli-help.test.ts
@@ -36,14 +36,14 @@ const CAT32_BIN = import.meta.url.includes("/dist/tests/")
   ? new URL("../cli.js", import.meta.url).pathname
   : new URL("../dist/cli.js", import.meta.url).pathname;
 
-test("cat32 --json invalid reports an error", async () => {
+test("cat32 --json=invalid reports an error", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as {
     spawn: SpawnFunction;
   };
 
   const child = spawn(
     process.argv[0],
-    [CAT32_BIN, "--json", "invalid", "sample"],
+    [CAT32_BIN, "--json=invalid", "sample"],
     {
       stdio: ["ignore", "pipe", "pipe"],
     },

--- a/tests/cli-json-flag.test.ts
+++ b/tests/cli-json-flag.test.ts
@@ -36,14 +36,14 @@ const CAT32_BIN = import.meta.url.includes("/dist/tests/")
   ? new URL("../cli.js", import.meta.url).pathname
   : new URL("../dist/cli.js", import.meta.url).pathname;
 
-test("cat32 --json invalid reports an error", async () => {
+test("cat32 --json=invalid reports an error", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as {
     spawn: SpawnFunction;
   };
 
   const child = spawn(
     process.argv[0],
-    [CAT32_BIN, "--json", "invalid"],
+    [CAT32_BIN, "--json=invalid"],
     {
       stdio: ["ignore", "pipe", "pipe"],
     },


### PR DESCRIPTION
## Summary
- add an integration test that exercises the documented CLI examples against both dist/cli.js and dist/src/cli.js
- update the CLI documentation samples to match the actual Cat32 output
- adjust optional flag parsing so `--json foo` keeps `foo` as the positional key and update existing tests accordingly

## Testing
- node --test dist/tests/cli-doc-examples.test.js
- npm test *(fails: stable stringify duplicate-symbol throughput assertion exceeds 0ms threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68faa908c5488321b77da5949abbe7de