### PR TITLE
Handle optional --json values as positional when unsupported

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -66,7 +66,11 @@ function parseArgs(argv) {
                     args[key] = spec.defaultValue;
                     continue;
                 }
-                assertAllowedFlagValue(key, next, spec.allowedValues);
+                if (spec.allowedValues !== undefined &&
+                    !spec.allowedValues.includes(next)) {
+                    args[key] = spec.defaultValue;
+                    continue;
+                }
                 args[key] = next;
                 i += 1;
             }

--- a/dist/src/cli.js
+++ b/dist/src/cli.js
@@ -66,7 +66,11 @@ function parseArgs(argv) {
                     args[key] = spec.defaultValue;
                     continue;
                 }
-                assertAllowedFlagValue(key, next, spec.allowedValues);
+                if (spec.allowedValues !== undefined &&
+                    !spec.allowedValues.includes(next)) {
+                    args[key] = spec.defaultValue;
+                    continue;
+                }
                 args[key] = next;
                 i += 1;
             }

--- a/dist/tests/categorizer.test.js
+++ b/dist/tests/categorizer.test.js
@@ -973,7 +973,7 @@ test("cat32 binary accepts flag values separated by whitespace", async () => {
     assert.equal(parsed.hash, expected.hash);
     assert.equal(parsed.key, expected.key);
 });
-test("cat32 binary rejects unsupported --json positional value", async () => {
+test("cat32 binary treats unsupported --json positional value as input", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const child = spawn(process.argv[0], [CLI_BIN_PATH, "--json", "invalid"], {
         stdio: ["pipe", "pipe", "pipe"],
@@ -992,9 +992,12 @@ test("cat32 binary rejects unsupported --json positional value", async () => {
     const exitCode = await new Promise((resolve) => {
         child.on("close", (code) => resolve(code));
     });
-    assert.equal(stdout, "");
-    assert.equal(exitCode, 2);
-    assert.ok(stderr.includes('RangeError: unsupported --json value "invalid"'), `stderr did not include unsupported --json value message: ${stderr}`);
+    assert.equal(exitCode, 0, `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    assert.equal(stderr, "");
+    const parsed = JSON.parse(stdout);
+    const expected = new Cat32().assign("invalid");
+    assert.equal(parsed.hash, expected.hash);
+    assert.equal(parsed.key, expected.key);
 });
 test("cat32 binary exits with code 2 for unsupported --json= value", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
@@ -2067,7 +2070,7 @@ test("CLI outputs compact JSON by default", async () => {
     const expected = new Cat32().assign("default-json");
     assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
-test("cat32 command rejects unsupported --json positional value", async () => {
+test("cat32 command treats unsupported --json positional value as input", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const cat32CommandPath = import.meta.url.includes("/dist/tests/")
         ? new URL("../cli.js", import.meta.url).pathname
@@ -2099,9 +2102,12 @@ test("cat32 command rejects unsupported --json positional value", async () => {
     const exitCode = await new Promise((resolve) => {
         child.on("close", (code) => resolve(code));
     });
-    assert.equal(stdout, "");
-    assert.equal(exitCode, 2);
-    assert.ok(stderr.includes('RangeError: unsupported --json value "invalid"'), `stderr did not include unsupported --json value message: ${stderr}`);
+    assert.equal(exitCode, 0);
+    assert.equal(stderr, "");
+    const parsed = JSON.parse(stdout);
+    const expected = new Cat32().assign("invalid");
+    assert.equal(parsed.hash, expected.hash);
+    assert.equal(parsed.key, expected.key);
 });
 test("CLI outputs compact JSON when --json is provided without a value", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
@@ -2120,7 +2126,7 @@ test("CLI outputs compact JSON when --json is provided without a value", async (
     const expected = new Cat32().assign("json-flag");
     assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
-test("CLI rejects unsupported --json positional value", async () => {
+test("CLI treats unsupported --json positional value as input", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
     const child = spawn(process.argv[0], [CLI_PATH, "--json", "invalid"], {
         stdio: ["ignore", "pipe", "pipe"],
@@ -2138,9 +2144,12 @@ test("CLI rejects unsupported --json positional value", async () => {
     const exitCode = await new Promise((resolve) => {
         child.on("close", (code) => resolve(code));
     });
-    assert.equal(stdout, "");
-    assert.equal(exitCode, 2);
-    assert.ok(stderr.includes('RangeError: unsupported --json value "invalid"'), `stderr did not include unsupported --json value message: ${stderr}`);
+    assert.equal(exitCode, 0);
+    assert.equal(stderr, "");
+    const parsed = JSON.parse(stdout);
+    const expected = new Cat32().assign("invalid");
+    assert.equal(parsed.hash, expected.hash);
+    assert.equal(parsed.key, expected.key);
 });
 test("CLI exits with code 2 when --json= has an invalid value", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));

--- a/dist/tests/cli-help.test.js
+++ b/dist/tests/cli-help.test.js
@@ -4,9 +4,9 @@ const dynamicImport = new Function("specifier", "return import(specifier);");
 const CAT32_BIN = import.meta.url.includes("/dist/tests/")
     ? new URL("../cli.js", import.meta.url).pathname
     : new URL("../dist/cli.js", import.meta.url).pathname;
-test("cat32 --json invalid reports an error", async () => {
+test("cat32 --json=invalid reports an error", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
-    const child = spawn(process.argv[0], [CAT32_BIN, "--json", "invalid", "sample"], {
+    const child = spawn(process.argv[0], [CAT32_BIN, "--json=invalid", "sample"], {
         stdio: ["ignore", "pipe", "pipe"],
     });
     const stdoutChunks = [];

--- a/dist/tests/cli-json-flag.test.js
+++ b/dist/tests/cli-json-flag.test.js
@@ -4,9 +4,9 @@ const dynamicImport = new Function("specifier", "return import(specifier);");
 const CAT32_BIN = import.meta.url.includes("/dist/tests/")
     ? new URL("../cli.js", import.meta.url).pathname
     : new URL("../dist/cli.js", import.meta.url).pathname;
-test("cat32 --json invalid reports an error", async () => {
+test("cat32 --json=invalid reports an error", async () => {
     const { spawn } = (await dynamicImport("node:child_process"));
-    const child = spawn(process.argv[0], [CAT32_BIN, "--json", "invalid"], {
+    const child = spawn(process.argv[0], [CAT32_BIN, "--json=invalid"], {
         stdio: ["ignore", "pipe", "pipe"],
     });
     const stdoutChunks = [];
@@ -32,4 +32,56 @@ test("cat32 --json invalid reports an error", async () => {
     assert.equal(stdoutChunks.join(""), "");
     assert.equal(exitCode, 2);
     assert.ok(stderrChunks.join("").includes('RangeError: unsupported --json value "invalid"'), "stderr should report unsupported --json value");
+});
+test("cat32 --json foo falls back to default format and treats foo as input", async () => {
+    const { spawn } = (await dynamicImport("node:child_process"));
+    const { existsSync } = (await dynamicImport("node:fs"));
+    const distCliUrl = import.meta.url.includes("/dist/tests/")
+        ? new URL("../cli.js", import.meta.url)
+        : new URL("../dist/cli.js", import.meta.url);
+    const sourceCliUrl = import.meta.url.includes("/dist/tests/")
+        ? new URL("../src/cli.js", import.meta.url)
+        : new URL("../dist/src/cli.js", import.meta.url);
+    const cliScripts = [distCliUrl, sourceCliUrl]
+        .map((url) => url.pathname)
+        .filter((pathname, index, all) => all.indexOf(pathname) === index)
+        .filter((pathname) => existsSync(pathname));
+    assert.ok(cliScripts.length > 0, "expected at least one CLI script to test");
+    const run = (args) => {
+        const child = spawn(process.argv[0], args, {
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+        const stdoutChunks = [];
+        const stderrChunks = [];
+        child.stdout.setEncoding("utf8");
+        child.stdout.on("data", (chunk) => {
+            stdoutChunks.push(chunk);
+        });
+        child.stderr.setEncoding("utf8");
+        child.stderr.on("data", (chunk) => {
+            stderrChunks.push(chunk);
+        });
+        return new Promise((resolve, reject) => {
+            child.on("error", reject);
+            child.on("close", (code, signal) => {
+                if (signal !== null) {
+                    reject(new Error(`terminated by signal ${signal}`));
+                    return;
+                }
+                resolve({
+                    exitCode: code ?? -1,
+                    stdout: stdoutChunks.join(""),
+                    stderr: stderrChunks.join(""),
+                });
+            });
+        });
+    };
+    for (const scriptPath of cliScripts) {
+        const baseline = await run([scriptPath, "foo"]);
+        assert.equal(baseline.exitCode, 0, `expected baseline run for ${scriptPath} to exit successfully`);
+        const withJson = await run([scriptPath, "--json", "foo"]);
+        assert.equal(withJson.exitCode, 0, `expected --json foo run for ${scriptPath} to exit successfully`);
+        assert.equal(withJson.stderr, "", `expected --json foo run for ${scriptPath} to produce no stderr output`);
+        assert.equal(withJson.stdout, baseline.stdout, `expected --json foo run for ${scriptPath} to match baseline output`);
+    }
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,7 +93,14 @@ function parseArgs(argv: string[]): ParsedArgs {
           continue;
         }
 
-        assertAllowedFlagValue(key, next, spec.allowedValues);
+        if (
+          spec.allowedValues !== undefined &&
+          !spec.allowedValues.includes(next)
+        ) {
+          args[key] = spec.defaultValue;
+          continue;
+        }
+
         args[key] = next;
         i += 1;
       } else {

--- a/tests/categorizer.test.ts
+++ b/tests/categorizer.test.ts
@@ -1538,7 +1538,7 @@ test("cat32 binary accepts flag values separated by whitespace", async () => {
   assert.equal(parsed.key, expected.key);
 });
 
-test("cat32 binary rejects unsupported --json positional value", async () => {
+test("cat32 binary treats unsupported --json positional value as input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 
   const child = spawn(process.argv[0], [CLI_BIN_PATH, "--json", "invalid"], {
@@ -1563,12 +1563,17 @@ test("cat32 binary rejects unsupported --json positional value", async () => {
     child.on("close", (code: number | null) => resolve(code));
   });
 
-  assert.equal(stdout, "");
-  assert.equal(exitCode, 2);
-  assert.ok(
-    stderr.includes('RangeError: unsupported --json value "invalid"'),
-    `stderr did not include unsupported --json value message: ${stderr}`,
+  assert.equal(
+    exitCode,
+    0,
+    `cat32 failed: exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
   );
+  assert.equal(stderr, "");
+
+  const parsed = JSON.parse(stdout) as { hash: string; key: string };
+  const expected = new Cat32().assign("invalid");
+  assert.equal(parsed.hash, expected.hash);
+  assert.equal(parsed.key, expected.key);
 });
 
 test("cat32 binary exits with code 2 for unsupported --json= value", async () => {
@@ -3051,7 +3056,7 @@ test("CLI outputs compact JSON by default", async () => {
   assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
-test("cat32 command rejects unsupported --json positional value", async () => {
+test("cat32 command treats unsupported --json positional value as input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
 
   const cat32CommandPath = import.meta.url.includes("/dist/tests/")
@@ -3094,12 +3099,13 @@ test("cat32 command rejects unsupported --json positional value", async () => {
     child.on("close", (code: number | null) => resolve(code));
   });
 
-  assert.equal(stdout, "");
-  assert.equal(exitCode, 2);
-  assert.ok(
-    stderr.includes('RangeError: unsupported --json value "invalid"'),
-    `stderr did not include unsupported --json value message: ${stderr}`,
-  );
+  assert.equal(exitCode, 0);
+  assert.equal(stderr, "");
+
+  const parsed = JSON.parse(stdout) as { hash: string; key: string };
+  const expected = new Cat32().assign("invalid");
+  assert.equal(parsed.hash, expected.hash);
+  assert.equal(parsed.key, expected.key);
 });
 
 test("CLI outputs compact JSON when --json is provided without a value", async () => {
@@ -3123,7 +3129,7 @@ test("CLI outputs compact JSON when --json is provided without a value", async (
   assert.equal(stdout, JSON.stringify(expected) + "\n");
 });
 
-test("CLI rejects unsupported --json positional value", async () => {
+test("CLI treats unsupported --json positional value as input", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as { spawn: SpawnFunction };
   const child = spawn(process.argv[0], [CLI_PATH, "--json", "invalid"], {
     stdio: ["ignore", "pipe", "pipe"],
@@ -3145,12 +3151,13 @@ test("CLI rejects unsupported --json positional value", async () => {
     child.on("close", (code: number | null) => resolve(code));
   });
 
-  assert.equal(stdout, "");
-  assert.equal(exitCode, 2);
-  assert.ok(
-    stderr.includes('RangeError: unsupported --json value "invalid"'),
-    `stderr did not include unsupported --json value message: ${stderr}`,
-  );
+  assert.equal(exitCode, 0);
+  assert.equal(stderr, "");
+
+  const parsed = JSON.parse(stdout) as { hash: string; key: string };
+  const expected = new Cat32().assign("invalid");
+  assert.equal(parsed.hash, expected.hash);
+  assert.equal(parsed.key, expected.key);
 });
 
 test("CLI exits with code 2 when --json= has an invalid value", async () => {

--- a/tests/cli-help.test.ts
+++ b/tests/cli-help.test.ts
@@ -36,14 +36,14 @@ const CAT32_BIN = import.meta.url.includes("/dist/tests/")
   ? new URL("../cli.js", import.meta.url).pathname
   : new URL("../dist/cli.js", import.meta.url).pathname;
 
-test("cat32 --json invalid reports an error", async () => {
+test("cat32 --json=invalid reports an error", async () => {
   const { spawn } = (await dynamicImport("node:child_process")) as {
     spawn: SpawnFunction;
   };
 
   const child = spawn(
     process.argv[0],
-    [CAT32_BIN, "--json", "invalid", "sample"],
+    [CAT32_BIN, "--json=invalid", "sample"],
     {
       stdio: ["ignore", "pipe", "pipe"],
     },


### PR DESCRIPTION
## Summary
- update optional value parsing so unsupported `--json` arguments fall back to the default format without consuming the next positional token
- expand CLI tests to expect the fallback behaviour and verify both `dist/cli.js` and its source build accept `--json foo`
- rebuild the compiled CLI assets to reflect the updated argument parsing

## Testing
- `STABLE_STRINGIFY_SYMBOL_COLLISION_MAX_MS=700 npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68faa90812848321b564715c08f9b030