### PR TITLE
Fix CLI exit code list indentation

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -14,8 +14,8 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
 - `--normalize` には Unicode 正規化モードとして `nfkc`（既定）、`nfkd`、`nfd`、`nfc`、`none` の 5 種類を指定できる。
 - 終了コード:
 - `0` … 成功
+- `1` … その他の例外
 - `2` … 循環/labels長不正/override不正など仕様違反
-  - `1` … その他の例外
 
 ## 出力例
 


### PR DESCRIPTION
## Summary
- adjust the CLI documentation exit code list so that the return codes share the same list level

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbfa3b611c832194199abe6d94dd0d