### PR TITLE
docs: clarify NDJSON formatting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,11 @@ npx deterministic-32 "user:123" --salt=proj --namespace=v1
 echo '{"id":1,"k":"v"}' | npx deterministic-32 --salt=proj
 # Output: one JSON per line (same shape as assign())
 ```
-- 出力は既定で 1 行 1 JSON の **NDJSON**（末尾改行あり）。NDJSON はデフォルト/compact モードのみ利用でき、`--json` を付けない場合も、`--json` / `--json=compact` を指定した場合も同じ形式です。
-- `--json=pretty` / `--pretty` / `--json --pretty` は複数行の整形 JSON（インデント 2）を返し、各レコードが複数行になるため NDJSON ではありません。
+- 出力は既定で 1 行 1 JSON の **NDJSON**（末尾改行あり）。
+  NDJSON を選べるのはデフォルト/compact モードのみです。
+  `--json` を付けない場合と `--json` / `--json=compact` を指定した場合はいずれもこの形式になります。
+- `--json=pretty` / `--pretty` / `--json --pretty` は複数行の整形 JSON（インデント 2）を返します。
+  各レコードが複数行になるため NDJSON ではありません。
 
 ## Determinism
 - Canonical key = **normalize(NFKC)** ∘ **stable stringify (key-sorted, cycle-check)**.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -9,8 +9,11 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
   ```json
   {"index":7,"label":"H","hash":"1a2b3c4d","key":"...canonical..."}
   ```
-- `--json` を付けない場合、`--json` または `--json=compact` を指定した場合はいずれも compact JSON（1 行 1 JSON、末尾改行あり）の NDJSON を返す。NDJSON を選べるのはこの既定/compact モードのみ。NDJSON (1 行 1 JSON オブジェクト) になるのは compact/既定モードのときだけ。
-  - `--json=pretty` / `--pretty` / `--json --pretty` は 2 スペースで整形した複数行の JSON を返し、各レコードが複数行になるため NDJSON ではない。
+- `--json` を付けない場合と `--json` / `--json=compact` を指定した場合はいずれも compact JSON（1 行 1 JSON、末尾改行あり）の出力を返す。
+  形式は NDJSON で、利用できるのは既定/compact モードのみです。
+  NDJSON (1 行 1 JSON オブジェクト) になるのは compact/既定モードのときだけです。
+  - `--json=pretty` / `--pretty` / `--json --pretty` は 2 スペースで整形した複数行の JSON を返す。
+    各レコードが複数行になるため NDJSON ではない。
 - `--normalize` には Unicode 正規化モードとして `nfkc`（既定）、`nfkd`、`nfd`、`nfc`、`none` の 5 種類を指定できる。
 - 終了コード:
 - `0` … 成功


### PR DESCRIPTION
## Summary
- reflow NDJSON output description in README to avoid awkward word breaks
- rewrite CLI documentation NDJSON bullet to keep terminology unsplit and clarify mode availability

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68fbfa3b67bc8321ba831f7f75739a3f