### PR TITLE
docs: document CLI help flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ npx deterministic-32 "user:123" --salt=proj --namespace=v1
 echo '{"id":1,"k":"v"}' | npx deterministic-32 --salt=proj
 # Output: one JSON per line (same shape as assign())
 ```
+- 利用可能なフラグ:
+  - `--salt <value>`: Salt to apply when assigning a category.
+  - `--namespace <value>`: Namespace that scopes generated categories.
+  - `--normalize <value>`: Unicode normalization form (`none`/`nfc`/`nfd`/`nfkc`/`nfkd`; default: `nfkc`).
+  - `--json [format]`: Output JSON format: `compact` or `pretty` (default: `compact`).
+  - `--pretty`: Shorthand for `--json pretty`.
+  - `--help`: Show this help message and exit.
 - 出力は既定で 1 行 1 JSON の **NDJSON**（末尾改行あり）。
   NDJSON を選べるのはデフォルト/compact モードのみです。
   `--json` を付けない場合と `--json` / `--json=compact` を指定した場合はいずれもこの形式になります。


### PR DESCRIPTION
## Summary
- document the CLI flags in README to match the current help output
- include the --help flag description alongside the other options

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68fc134c87248321827871118be6e6b5