### PR TITLE
docs: align CLI invocation formatting

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,6 +1,6 @@
 # CLI 仕様
 
-```
+```sh
 $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|nfd|nfc|none --json[=compact|pretty] --pretty --help]
 ```
 


### PR DESCRIPTION
## Summary
- adjust the CLI usage code block so the `--help` flag stays on the same line and mark the snippet as shell syntax

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68fc188148f88321a7fd6e23802b944d