### PR TITLE
docs: clarify NDJSON description in CLI guide

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -11,11 +11,8 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
   ```json
   {"index":7,"label":"H","hash":"1a2b3c4d","key":"...canonical..."}
   ```
-- `--json` を付けない場合と `--json` / `--json=compact` を指定した場合はいずれも compact JSON（1 行 1 JSON、末尾改行あり）の出力を返す。
-  形式は NDJSON で、利用できるのは既定/compact モードのみです。
-  NDJSON (1 行 1 JSON オブジェクト) になるのは compact/既定モードのときだけです。
-  - `--json=pretty` / `--pretty` / `--json --pretty` は 2 スペースで整形した複数行の JSON を返す。
-    各レコードが複数行になるため NDJSON ではない。
+- `--json` を付けない場合と `--json` / `--json=compact` を指定した場合はいずれも compact JSON（1 行 1 JSON、末尾改行あり）の NDJSON を返す。
+  - `--json=pretty` / `--pretty` / `--json --pretty` は 2 スペースで整形した複数行の JSON を返し、NDJSON ではない。
 - `--normalize` には Unicode 正規化モードとして `nfkc`（既定）、`nfkd`、`nfd`、`nfc`、`none` の 5 種類を指定できる。
 - `--help` を指定するとヘルプテキストを表示して終了する。
 - 終了コード:


### PR DESCRIPTION
## Summary
- consolidate the NDJSON explanation in the CLI documentation to avoid redundant wording
- clarify that only default and compact JSON outputs are NDJSON while pretty modes are multi-line JSON

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68fc1880a3fc8321a6c883591c1afd01