### PR TITLE
docs: add stableStringify export documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ echo '{"id":1,"k":"v"}' | npx deterministic-32 --salt=proj
   - `--pretty`: Shorthand for `--json pretty`.
   - `--help`: Show this help message and exit.
 - 出力は既定で 1 行 1 JSON の **NDJSON**（末尾改行あり）。
-  NDJSON を選べるのはデフォルト/compact モードのみです。
+  NDJSON はデフォルト/compact モードのみで利用できます。
   `--json` を付けない場合と `--json` / `--json=compact` を指定した場合はいずれもこの形式になります。
 - `--json=pretty` / `--pretty` / `--json --pretty` は複数行の整形 JSON（インデント 2）を返します。
   各レコードが複数行になるため NDJSON ではありません。

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,6 +27,9 @@ export class Cat32 {
   index(input: unknown): number;
   labelOf(input: unknown): string;
 }
+
+export function stableStringify(value: unknown): string;
+export type StableStringify = typeof stableStringify;
 ```
 
 `normalize` には Unicode 正規化モードとして `"none" | "nfc" | "nfd" | "nfkc" | "nfkd"` の 5 種類を指定できます（CLI の `--normalize` も同じ値を受け付けます）。既定値は `"nfkc"` です。
@@ -40,6 +43,11 @@ const a = cat.assign({ id: 1, tags: ["a", "b"] });
 // a = { index, label, hash, key }
 ```
 
+### stableStringify で canonical key を取得する
+
+`stableStringify(value)` は `Cat32.assign(value).key` と同じ canonical key を生成し、構造化データを事前に文字列化する用途に利用できます
+。`normalize` オプションはコンストラクター側で再適用されるため、`stableStringify` 単体で事前計算しても整合性が保たれます。
+
 ### overrides の canonical key 取得
 
-`overrides` のキーには `stableStringify(value)` で得た canonical key を渡してください。`Cat32.assign(value).key` でも同じ結果を得られますが、`overrides` 用に事前計算する場合は `stableStringify` のみで十分です（constructor 側で `normalize` が再適用されます）。
+`overrides` のキーには上記 `stableStringify(value)` で得た canonical key を渡してください。`Cat32.assign(value).key` でも同じ結果を得られます。

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -12,6 +12,7 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
   {"index":7,"label":"H","hash":"1a2b3c4d","key":"...canonical..."}
   ```
 - `--json` を付けない場合と `--json` / `--json=compact` を指定した場合はいずれも compact JSON（1 行 1 JSON、末尾改行あり）の NDJSON を返す。
+  NDJSON (1 行 1 JSON オブジェクト) になるのは compact/既定モードのみです。
   - `--json=pretty` / `--pretty` / `--json --pretty` は 2 スペースで整形した複数行の JSON を返し、NDJSON ではない。
 - `--normalize` には Unicode 正規化モードとして `nfkc`（既定）、`nfkd`、`nfd`、`nfc`、`none` の 5 種類を指定できる。
 - `--help` を指定するとヘルプテキストを表示して終了する。


### PR DESCRIPTION
## Summary
- document the stableStringify function and type exports in the API reference with usage guidance
- clarify README and CLI specification that NDJSON output is limited to default/compact modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68fc1b7865508321a2f56b369aae77ce