### PR TITLE
Update CLI documentation for exit codes and NDJSON scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ echo '{"id":1,"k":"v"}' | npx deterministic-32 --salt=proj
   - `--pretty`: Shorthand for `--json pretty`.
   - `--help`: Show this help message and exit.
 - 出力は既定で 1 行 1 JSON の **NDJSON**（末尾改行あり）。
-  NDJSON を選べるのはデフォルト/compact モードのみです。
+  NDJSON はデフォルト/compact モードのみです。
   `--json` を付けない場合と `--json` / `--json=compact` を指定した場合はいずれもこの形式になります。
 - `--json=pretty` / `--pretty` / `--json --pretty` は複数行の整形 JSON（インデント 2）を返します。
   各レコードが複数行になるため NDJSON ではありません。

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -11,14 +11,14 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
   ```json
   {"index":7,"label":"H","hash":"1a2b3c4d","key":"...canonical..."}
   ```
-- `--json` を付けない場合と `--json` / `--json=compact` を指定した場合はいずれも compact JSON（1 行 1 JSON、末尾改行あり）の NDJSON を返す。
+- `--json` を付けない場合と `--json` / `--json=compact` を指定した場合はいずれも compact JSON（1 行 1 JSON、末尾改行あり）の NDJSON を返す。NDJSON (1 行 1 JSON オブジェクト) になるのは compact/既定モードのみ。
   - `--json=pretty` / `--pretty` / `--json --pretty` は 2 スペースで整形した複数行の JSON を返し、NDJSON ではない。
 - `--normalize` には Unicode 正規化モードとして `nfkc`（既定）、`nfkd`、`nfd`、`nfc`、`none` の 5 種類を指定できる。
 - `--help` を指定するとヘルプテキストを表示して終了する。
 - 終了コード:
 - `0` … 成功
 - `1` … その他の例外
-- `2` … 循環/labels長不正/override不正など仕様違反
+- `2` … 循環/labels長不正/override不正など仕様違反、および未知フラグや許可外値など CLI 引数エラー（例: `--json=invalid` で RangeError が発生した場合）
 
 ## 出力例
 


### PR DESCRIPTION
## Summary
- clarify that CLI exit code 2 also covers argument validation errors such as unsupported flag values
- document that NDJSON output applies only to default/compact modes in both README and CLI spec

## Testing
- `STABLE_STRINGIFY_SYMBOL_COLLISION_MAX_MS=600 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68fc1b775f6883218e22d88e3e9a2312