### PR TITLE
docs: clarify CLI exit codes for RangeError scenarios

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -47,7 +47,7 @@ tests/
 - 入力: 引数 `<key>` がなければ **stdin** を読む。
 - 出力: 既定/`compact` モードは **NDJSON**（1 行 1 JSON）で `Assignment` を出力。
 - 整形モード（`--json=pretty`/`--pretty`/`--json --pretty`）は複数行の整形 JSON を返し、NDJSON とは異なる。
-- 失敗コード: `2`（循環/ラベル不正など）、`1`（その他）。
+- 失敗コード: `2`（循環/ラベル不正、未知フラグ/不正値など `RangeError` を投げる CLI エラーを含む。例: `--json=invalid`、存在しない正規化モード指定など）、`1`（その他）。
 
 ## 7. 性能
 - 時間計算量: `O(len(utf8))`


### PR DESCRIPTION
## Summary
- clarify that CLI failures raising RangeError (unknown flags, invalid values) exit with code 2
- document representative examples such as `--json=invalid` to clarify error categorization boundaries

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68fc2b8afd44832199d67a372ed45cf3