### PR TITLE
docs: clarify RangeError exit code

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -19,7 +19,7 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
 - 終了コード:
 - `0` … 成功
 - `1` … その他の例外
-- `2` … 循環/labels長不正/override不正など仕様違反
+- `2` … 循環/labels長不正/override不正など仕様違反。`RangeError`（未知フラグや許可外値など。例: `--json=invalid`）もこの終了コード。
 
 ## 出力例
 


### PR DESCRIPTION
## Summary
- document that RangeError cases exit with status code 2 and provide an example

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68fc3148805c8321947fa4e4536bf58a