### PR TITLE
docs: clarify CLI RangeError exit code

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -19,8 +19,7 @@ $ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|
 - 終了コード:
 - `0` … 成功
 - `1` … その他の例外
-- `2` … 仕様違反（循環/labels長不正/override不正など）および CLI 引数が `RangeError` を投げた場合（例: `--json=invalid`、存在しない正規化モード指定）。詳細は [DESIGN.md §6](./DESIGN.md#6-cli-cli-ts) を参照。
-- `3` … 循環/labels長不正/override不正など仕様違反。`RangeError`（未知フラグや許可外値など。例: `--json=invalid`）もこの終了コード。
+- `2` … 仕様違反（循環/labels長不正/override不正など）および CLI 引数が `RangeError` を投げた場合（例: 未知フラグ、許可外の `--json` 値、存在しない正規化モード指定）。詳細は [DESIGN.md §6](./DESIGN.md#6-cli-cli-ts) を参照。
 
 ## 出力例
 


### PR DESCRIPTION
## Summary
- clarify that CLI argument errors raising RangeError exit with code 2
- remove outdated exit-code description for RangeError in CLI docs

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68fc3deb818c832195b8c187160ebf47