### PR TITLE
Adjust CLI usage example formatting

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,7 +1,10 @@
 # CLI 仕様
 
 ```sh
-$ npx deterministic-32 <key?> [--salt=... --namespace=... --normalize=nfkc|nfkd|nfd|nfc|none --json[=compact|pretty] --pretty --help]
+$ npx deterministic-32 <key?> \
+    [--salt=... --namespace=... \
+     --normalize=nfkc|nfkd|nfd|nfc|none \
+     --json[=compact|pretty] --pretty --help]
 ```
 
 - `<key>` が無い場合は **stdin** を読み取る。


### PR DESCRIPTION
## Summary
- reformat the CLI usage example so the `--help` flag remains on the same line

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68fc3e840b048321b7108529feaa3349