### PR TITLE
docs: adjust --normalize flag paragraph

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -32,7 +32,7 @@ export function stableStringify(value: unknown): string;
 export type StableStringify = typeof stableStringify;
 ```
 
-`normalize` には Unicode 正規化モードとして `"none" | "nfc" | "nfd" | "nfkc" | "nfkd"` の 5 種類を指定できます（CLI の `--normalize` も同じ値を受け付けます）。既定値は `"nfkc"` です。
+`normalize` には Unicode 正規化モードとして `"none" | "nfc" | "nfd" | "nfkc" | "nfkd"` の 5 種類を指定できます。CLI の `--normalize` も同じ値を受け付け、既定値は `"nfkc"` です。
 
 ### 例
 ```ts


### PR DESCRIPTION
## Summary
- CLI フラグ `--normalize` が Markdown 上で分割されないよう、該当段落の文をリフローしました

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68fce551b4ec8321a84b9d3d3e0b7100