### PR TITLE
Add guard for CLI --json fallback documentation

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -15,6 +15,10 @@ $ npx deterministic-32 <key?> \
   {"index":7,"label":"H","hash":"1a2b3c4d","key":"...canonical..."}
   ```
 - `--json` を付けない場合と `--json` / `--json=compact` を指定した場合はいずれも compact JSON（1 行 1 JSON、末尾改行あり）の NDJSON を返す。NDJSON (1 行 1 JSON オブジェクト) になるのは compact/既定モードのみです。
+  - CLI の `--json` オプションは以下の順序で値を解決する。
+    1. `--json=pretty` のように `=` で指定された値を採用し、`compact` / `pretty` 以外なら `RangeError` を発生させる。
+    2. スペース区切りの次トークンが `compact` または `pretty` の場合はそれを値として消費し、`--json pretty` のように扱う。
+    3. 上記のどちらにも該当しなければ既定の `compact` へフォールバックし、そのトークンは位置引数として扱う。`cat32 --json foo` では `foo` が許可外のトークンなので、出力は compact のまま `foo` がキーとして受理される。
   - `--json=pretty` / `--pretty` / `--json --pretty` は 2 スペースで整形した複数行の JSON を返し、NDJSON ではない。
 - `--normalize` には Unicode 正規化モードとして `nfkc`（既定）、`nfkd`、`nfd`、`nfc`、`none` の 5 種類を指定できる。
 - `--help` を指定するとヘルプテキストを表示して終了する。

--- a/tests/cli-docs-consistency.test.ts
+++ b/tests/cli-docs-consistency.test.ts
@@ -58,3 +58,18 @@ test("CLI documented exit codes match implementation", async () => {
     "docs must not advertise an exit code 3 for RangeError or other cases",
   );
 });
+
+test("CLI docs describe --json fallback for disallowed next token", async () => {
+  const { readFile } = (await dynamicImport("node:fs/promises")) as FsPromisesModule;
+  const doc = await readFile(cliDocPath, "utf8");
+
+  assert.ok(
+    /--json[\s\S]{0,160}フォールバック[\s\S]{0,160}位置引数/u.test(doc),
+    "docs should explain that --json falls back to the default format and treats the token as a positional argument when the next token is not allowed",
+  );
+
+  assert.ok(
+    /cat32 --json foo[\s\S]{0,200}foo[\s\S]{0,120}キー/u.test(doc),
+    "docs should explain why cat32 --json foo accepts foo as the key",
+  );
+});


### PR DESCRIPTION
## Summary
- add a docs guard test that checks the CLI guide explains the --json fallback and positional handling
- document the --json option resolution order and why `cat32 --json foo` treats `foo` as the key

## Testing
- STABLE_STRINGIFY_SYMBOL_COLLISION_MAX_MS=600 npm test

------
https://chatgpt.com/codex/tasks/task_e_68fcec7134c083219df30aa77cf029ac