### PR TITLE
docs: clarify literal CLI argument handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ echo '{"id":1,"k":"v"}' | npx deterministic-32 --salt=proj
 # Output: one JSON per line (same shape as assign())
 ```
 - フラグ解析を止めたい場合は `--`（ダブルダッシュ）を挟む。例えば `cat32 -- --literal-key` は `--literal-key` をそのままキーとして処理する。
+  `--` より後ろのトークンは空白区切りのまま 1 つの入力として `parseArgs()` に渡され、フラグ再解釈は行われない。
+  詳細は [docs/CLI.md](./docs/CLI.md) を参照してください。
 - `echo` などからの標準入力は、実装上 `readStdin()` が末尾の `\r?\n` を既定で取り除くため、CLI 引数で渡した場合と同じ canonical key に揃います。
   現状 CLI からこの振る舞いを切り替える方法はなく、将来的に保持が必要になった場合は `readStdin` の `preserveTrailingNewline` オプションを公開するフラグ追加で対応予定です。
 - 利用可能なフラグ:


### PR DESCRIPTION
## Summary
- document how `--` stops flag parsing and forwards literals to `parseArgs`
- link the CLI manual for additional detail

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68fd3f1bf7a083219f6fb5a0ea36abe8