### PR TITLE
docs: clarify cat32 alias availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ const assignment = cat.assign("hello");
 
 ## CLI
 
-`npx deterministic-32` の代わりに `npx cat32` も利用できます。ローカルインストール後は `node_modules/.bin/cat32`（例: `npx cat32` や npm-scripts から）を、`npm install -g deterministic-32` 後はグローバルに常駐した `cat32` コマンドをそのまま呼び出せます。
+`cat32` は `deterministic-32` パッケージに同梱された CLI バイナリアイアスで、`npx deterministic-32` と同等に利用できます。`npx cat32` で即時実行でき、ローカルインストール後は `node_modules/.bin/cat32`（例: npm-scripts からの呼び出し）を、`npm install -g deterministic-32` 後はグローバルに常駐した `cat32` コマンドをそのまま使えます。[^cat32-alias]
 
 ```bash
 npx deterministic-32 "user:123" --salt=proj --namespace=v1
 echo '{"id":1,"k":"v"}' | npx deterministic-32 --salt=proj
 # Output: one JSON per line (same shape as assign())
 ```
-- フラグ解析を止めたい場合は `--`（ダブルダッシュ）を挟む。例えば `cat32 -- --literal-key` は `--literal-key` をそのままキーとして処理する。
+- フラグ解析を止めたい場合は `--`（ダブルダッシュ）を挟む。例えば `cat32 -- --literal-key`[^cat32-alias] は `--literal-key` をそのままキーとして処理する。
   `--` より後ろのトークンは空白区切りのまま 1 つの入力として結合され、`parseArgs()` はそれ以上フラグとして解釈しない。
   詳細は [docs/CLI.md](./docs/CLI.md) を参照してください。
 - `echo` などからの標準入力は、実装上 `readStdin()` が末尾の `\r?\n` を既定で取り除くため、
@@ -90,13 +90,15 @@ echo '{"id":1,"k":"v"}' | npx deterministic-32 --salt=proj
 - `--json=pretty` / `--pretty` / `--json --pretty` は複数行の整形 JSON（インデント 2）を返します。
   各レコードが複数行になるため NDJSON ではありません。
 
-例（`cat32` は `npx cat32` で即時実行するか、ローカル/グローバルインストールで取得したバイナリを PATH に通して利用します）:
+例（`cat32`[^cat32-alias] は `npx cat32` で即時実行するか、ローカル/グローバルインストールで取得したバイナリを PATH に通して利用します）:
 
 ```bash
 cat32 --json foo
 # -> {"key":"\"foo\"",...} を含む NDJSON 1 レコードを出力し、成功終了します。
 #    スペース区切りで値を渡しているため `--json` は compact にフォールバックし、`foo` は次トークンとしてキーに扱われます。
 ```
+
+[^cat32-alias]: `cat32` は `deterministic-32` に同梱された CLI エイリアスです。`npx cat32`、ローカルインストール後の `node_modules/.bin/cat32`、`npm install -g deterministic-32` 後のグローバル `cat32` いずれからも起動できます。
 
 ## Determinism
 - Canonical key = **normalize(NFKC)** ∘ **stable stringify (key-sorted, cycle-check)**.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,11 +7,13 @@ $ npx deterministic-32 <key?> \
      --json[=compact|pretty] --pretty --help]
 ```
 
+以降の例で利用する `cat32` は `deterministic-32` パッケージに同梱された CLI バイナリアイアスで、`npx cat32`、ローカルインストール後の `node_modules/.bin/cat32`、`npm install -g deterministic-32` 後のグローバル `cat32` から呼び出せます。[^cat32-alias]
+
 - `<key>` が無い場合は **stdin** を読み取る。
   - 標準入力から取得した文字列の末尾にある `\r?\n` は既定で除去され、CLI 引数として同じ内容を渡した場合と同一のキーが得られる。
   - 末尾改行を保持したままキーを生成する設定は現状提供していない。改行の有無で差分を扱いたい場合は、入力段階で明示的にエスケープ文字やプレースホルダーを用いるなどして区別する運用を検討してほしい。
 - キーが `-` から始まるなど、フラグとして解釈されたくない引数を渡すときは `--`（ダブルダッシュ）を使って CLI のフラグ解析を終了させる。
-  例えば `cat32 -- --literal-key` は `--literal-key` をそのままキーとして扱う。
+  例えば `cat32 -- --literal-key`[^cat32-alias] は `--literal-key` をそのままキーとして扱う。
   `--` 以降のトークンは空白区切りのまま 1 つの文字列へ結合され、`parseArgs()` でフラグ再解釈されずにリテラル引数として処理される。
 - 出力は既定で **1行1JSON (NDJSON)**：
   ```json
@@ -68,3 +70,5 @@ $ cat32 --json --pretty foo
 $ cat32 -- --literal-key
 {"index":12,"label":"M","hash":"b9f6cbe3","key":"\"--literal-key\""}
 ```
+
+[^cat32-alias]: `cat32` は `deterministic-32` に同梱された CLI エイリアスです。`npx cat32`、ローカルインストール後の `node_modules/.bin/cat32`、`npm install -g deterministic-32` 後のグローバル `cat32` いずれからも起動できます。


### PR DESCRIPTION
## Summary
- explain that the cat32 binary ships with deterministic-32 and is usable via npx as well as local/global installs
- link CLI examples that use `cat32` back to the alias explanation in README and docs/CLI

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68fe31090f1c832192e199e25b0a9d01