### PR TITLE
docs: clarify cat32 invocation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const assignment = cat.assign("hello");
 
 ## CLI
 
-`cat32` は `deterministic-32` パッケージに同梱された CLI バイナリアイアスで、`npx deterministic-32` と同等に利用できます。`npx cat32` で即時実行でき、ローカルインストール後は `node_modules/.bin/cat32`（例: npm-scripts からの呼び出し）を、`npm install -g deterministic-32` 後はグローバルに常駐した `cat32` コマンドをそのまま使えます。[^cat32-alias]
+`cat32` は `deterministic-32` パッケージに同梱された CLI バイナリアイアスで、ローカルインストール後は `node_modules/.bin/cat32`（例: npm-scripts からの呼び出し）を、`npm install -g deterministic-32` 後はグローバルに常駐した `cat32` コマンドをそのまま使えます。未導入環境で一時的に遠隔実行したい場合は `npx --package deterministic-32 cat32` のようにその場で取得して呼び出してください。詳しくは [CLI ドキュメント](docs/CLI.md) を参照してください。[^cat32-alias]
 
 ```bash
 npx deterministic-32 "user:123" --salt=proj --namespace=v1
@@ -99,7 +99,7 @@ cat32 --json foo
 #    一方 `--json=foo` のように `=` 付きで許可外の値を渡すと `RangeError` で終了します。
 ```
 
-[^cat32-alias]: `cat32` は `deterministic-32` に同梱された CLI エイリアスです。`npx cat32`、ローカルインストール後の `node_modules/.bin/cat32`、`npm install -g deterministic-32` 後のグローバル `cat32` いずれからも起動できます。
+[^cat32-alias]: `cat32` は `deterministic-32` に同梱された CLI エイリアスです。ローカルインストール後の `node_modules/.bin/cat32`、`npm install -g deterministic-32` 後のグローバル `cat32` に加えて、未導入環境では `npx --package deterministic-32 cat32` などの一時取得コマンドからも起動できます。
 
 ## Determinism
 - Canonical key = **normalize(NFKC)** ∘ **stable stringify (key-sorted, cycle-check)**.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,7 +7,7 @@ $ npx deterministic-32 <key?> \
      --json[=compact|pretty] --pretty --help]
 ```
 
-以降の例で利用する `cat32` は `deterministic-32` パッケージに同梱された CLI バイナリアイアスで、`npx cat32`、ローカルインストール後の `node_modules/.bin/cat32`、`npm install -g deterministic-32` 後のグローバル `cat32` から呼び出せます。[^cat32-alias]
+以降の例で利用する `cat32` は `deterministic-32` パッケージに同梱された CLI バイナリアイアスで、ローカルインストール後の `node_modules/.bin/cat32`、`npm install -g deterministic-32` 後のグローバル `cat32` に加えて、未導入環境では `npx --package deterministic-32 cat32` のように一時取得して呼び出せます。[^cat32-alias]
 
 - `<key>` が無い場合は **stdin** を読み取る。
   - 標準入力から取得した文字列の末尾にある `\r?\n` は既定で除去され、CLI 引数として同じ内容を渡した場合と同一のキーが得られる。
@@ -71,4 +71,4 @@ $ cat32 -- --literal-key
 {"index":12,"label":"M","hash":"b9f6cbe3","key":"\"--literal-key\""}
 ```
 
-[^cat32-alias]: `cat32` は `deterministic-32` に同梱された CLI エイリアスです。`npx cat32`、ローカルインストール後の `node_modules/.bin/cat32`、`npm install -g deterministic-32` 後のグローバル `cat32` いずれからも起動できます。
+[^cat32-alias]: `cat32` は `deterministic-32` に同梱された CLI エイリアスです。ローカルインストール後の `node_modules/.bin/cat32`、`npm install -g deterministic-32` 後のグローバル `cat32` に加え、未導入環境では `npx --package deterministic-32 cat32` のような一時取得コマンドからも起動できます。


### PR DESCRIPTION
## Summary
- document that the cat32 binary is available after local or global installation
- note the npx --package deterministic-32 cat32 workflow for environments without the package and link to the CLI guide

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68fe3ec56bcc8321ab526c0216952171