### PR TITLE
Fix execFile error condition in tsc regression test

### DIFF
--- a/tests/build/tsc-regression.test.ts
+++ b/tests/build/tsc-regression.test.ts
@@ -48,7 +48,7 @@ const runTsc = async (
       args,
       { cwd: repoRootPath, env },
       (error, stdout, stderr) => {
-        if (error) {
+        if (error !== null && error !== undefined) {
           reject(Object.assign(error ?? {}, { stdout, stderr }));
           return;
         }


### PR DESCRIPTION
## Summary
- ensure the tsc regression test only rejects when execFile returns a real error value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68feb647d4b08321817054544defa70e