### PR TITLE
Handle clear issue report write failures

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -73,11 +73,14 @@ def _clear_issue_report(issue_path: pathlib.Path) -> None:
         issue_path.unlink()
     except FileNotFoundError:
         return
-    except OSError:
+    except OSError as unlink_error:
         try:
             issue_path.write_text("", encoding="utf-8")
-        except OSError:
-            pass
+        except OSError as write_error:
+            message = (
+                f"Failed to clear issue report at {issue_path}: {write_error}"
+            )
+            raise RuntimeError(message) from unlink_error
 
 def extract_duration(entry: dict[str, object]) -> int:
     duration = entry.get("duration_ms")

--- a/tests/test_analyze_clear_issue.py
+++ b/tests/test_analyze_clear_issue.py
@@ -1,0 +1,39 @@
+import importlib.util
+import pathlib
+from types import ModuleType
+from unittest import mock
+
+import pytest
+
+
+def _load_analyze_module() -> ModuleType:
+    module_path = pathlib.Path(__file__).resolve().parents[1] / "scripts" / "analyze.py"
+    spec = importlib.util.spec_from_file_location("scripts.analyze", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load scripts.analyze module for testing")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+analyze = _load_analyze_module()
+
+
+def test_clear_issue_report_raises_when_fallback_write_fails(tmp_path: pathlib.Path) -> None:
+    issue_path = tmp_path / "issue.md"
+
+    with (
+        mock.patch.object(pathlib.Path, "unlink", side_effect=OSError("unlink error")) as unlink_mock,
+        mock.patch.object(pathlib.Path, "write_text", side_effect=OSError("write error")) as write_mock,
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            analyze._clear_issue_report(issue_path)
+
+    unlink_mock.assert_called_once()
+    write_mock.assert_called_once()
+    args, kwargs = write_mock.call_args
+    assert args == ("",)
+    assert kwargs == {"encoding": "utf-8"}
+    message = str(exc_info.value)
+    assert "issue.md" in message
+    assert "write error" in message


### PR DESCRIPTION
## Summary
- raise a clear RuntimeError when clearing the issue report cannot remove or truncate the file
- add a regression test covering the failure path to ensure the fallback no longer silently passes

## Testing
- pytest tests/test_analyze_clear_issue.py

------
https://chatgpt.com/codex/tasks/task_e_68feb79e9f34832194981d7021923cd4