### PR TITLE
Fix error handling fallback in build artifact test

### DIFF
--- a/tests/build-artifacts.test.ts
+++ b/tests/build-artifacts.test.ts
@@ -46,8 +46,10 @@ const runBuild = async (
       ["run", "build", ...args],
       { cwd: repoRootPath, env },
       (error, stdout, stderr) => {
-        if (error) {
-          reject(Object.assign(error ?? {}, { stdout, stderr }));
+        if (error != null) {
+          const rejectionError =
+            typeof error === "object" && error !== null ? error : { error };
+          reject(Object.assign(rejectionError as Record<string, unknown>, { stdout, stderr }));
           return;
         }
         resolve();


### PR DESCRIPTION
## Summary
- ensure the build artifact test wraps exec errors in an object before rejecting

## Testing
- npm test -- tests/build-artifacts.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68feb7990da48321b1f8fba1aafe1d77